### PR TITLE
Know a simulation by its room name, not by dispatch metadata

### DIFF
--- a/apps/cli/skills/integrate-egma/references/integrate-egma-sdk.md
+++ b/apps/cli/skills/integrate-egma/references/integrate-egma-sdk.md
@@ -12,8 +12,10 @@ every requested entry is present and preserve every existing Egma entry. An
 integration task adds capabilities; it removes one only when the developer asks
 for that removal explicitly.
 
-The Python package is named `egma`. Require `egma>=0.1.1` and add it through the
-dependency file the repository already uses. The Egma SDK does not yet support
+The Python package is named `egma`. Require `egma>=0.2.0` and add it through the
+dependency file the repository already uses. `0.2.0` is the first release in
+which both entries read the job's room name, which is the only signal that
+reaches the worker on all four LiveKit dispatch paths. The Egma SDK does not yet support
 a worker built with `@livekit/agents`; report that boundary and leave a Node
 worker unchanged.
 

--- a/apps/cli/skills/integrate-egma/references/run-livekit-agent-locally.md
+++ b/apps/cli/skills/integrate-egma/references/run-livekit-agent-locally.md
@@ -18,7 +18,7 @@ The process requires `LIVEKIT_URL`, `LIVEKIT_API_KEY`, and
 arguments and output.
 
 Before the worker starts, the helper checks the same Python environment that
-LiveKit will use for Egma SDK 0.1.1 or newer. When it is missing, the helper
+LiveKit will use for Egma SDK 0.2.0 or newer. When it is missing, the helper
 installs the dependency through the verified project manifest without changing
 the manifest or its lock file, then checks the import again. The helper runs
 from that manifest's project directory, which must also contain the worker.

--- a/apps/cli/skills/integrate-egma/scripts/livekit-local.mjs
+++ b/apps/cli/skills/integrate-egma/scripts/livekit-local.mjs
@@ -7,7 +7,13 @@ import path from "node:path";
 import process from "node:process";
 
 const MINIMUM_VERSION = [2, 18, 2];
-const MINIMUM_EGMA_VERSION = [0, 1, 1];
+// 0.2.0 is the first Egma SDK release whose two entries decide from the job's
+// room name. Below it they read dispatch metadata, which reaches the worker on
+// one of the four LiveKit dispatch paths, so a lower version is inert on the
+// other three without saying so. A local worker that reports ready on such an
+// environment sends the developer into a run whose mock tools never answer.
+const MINIMUM_EGMA_VERSION = [0, 2, 0];
+const MINIMUM_EGMA_SHOWN = MINIMUM_EGMA_VERSION.join(".");
 const LIVEKIT_INSTALLER = "https://get.livekit.io/cli";
 const REQUIRED_ENV = ["LIVEKIT_URL", "LIVEKIT_API_KEY", "LIVEKIT_API_SECRET"];
 const WORKER_ONLY_ENV_PREFIX = "EGMA_";
@@ -417,7 +423,9 @@ async function prepareEgmaDependency(worker) {
   const runtime = await pythonEnvironment(worker);
   const probe = ["-c", egmaVersionProbe()];
   if (pythonSucceeds(runtime, probe)) {
-    process.stderr.write("livekit-local: Egma Python SDK 0.1.1 or newer is ready.\n");
+    process.stderr.write(
+      `livekit-local: Egma Python SDK ${MINIMUM_EGMA_SHOWN} or newer is ready.\n`,
+    );
     return;
   }
 
@@ -430,7 +438,7 @@ async function prepareEgmaDependency(worker) {
   });
   if (!pythonSucceeds(runtime, probe)) {
     throw new Error(
-      "the worker environment still cannot import Egma Python SDK 0.1.1 or newer after dependency installation",
+      `the worker environment still cannot import Egma Python SDK ${MINIMUM_EGMA_SHOWN} or newer after dependency installation`,
     );
   }
 }

--- a/apps/cli/src/livekit/connect.ts
+++ b/apps/cli/src/livekit/connect.ts
@@ -35,7 +35,10 @@ export type LiveKitKeyPairRegistration = CommonRegistration & {
   readonly variant: typeof LIVEKIT_KEY_PAIR_VARIANT;
   /** Omit for automatic dispatch. */
   readonly agentName?: string | undefined;
-  /** JSON object text handed to the worker as room metadata. */
+  /**
+   * JSON object text handed to the worker on the room's metadata, and on the
+   * dispatch's too wherever `agentName` above names one to dispatch.
+   */
   readonly metadata?: string | undefined;
   readonly credentials: ConnectionCredentials;
 };

--- a/apps/cli/src/wizard/worker-integration-step.ts
+++ b/apps/cli/src/wizard/worker-integration-step.ts
@@ -122,7 +122,7 @@ function workerIntegrationTask(
     "",
     "## Report the dependency manifest",
     "",
-    "After you have confirmed that the registry dependency `egma>=0.1.1` is declared,",
+    "After you have confirmed that the registry dependency `egma>=0.2.0` is declared,",
     "report the existing manifest you verified on one line:",
     "",
     "```text",
@@ -175,7 +175,7 @@ export function workerEntryInstructions(
     "Egma could not verify the requested entries in your LiveKit worker.",
     "Add the following to the worker before starting a run:",
     "",
-    '  1. Add the registry dependency "egma>=0.1.1" to your Python dependencies.',
+    '  1. Add the registry dependency "egma>=0.2.0" to your Python dependencies.',
     ...(monitoring
       ? [
           "  2. Make monitor_livekit(ctx) the first statement of the job entrypoint.",

--- a/apps/cli/src/wizard/worker-integration-verifier.ts
+++ b/apps/cli/src/wizard/worker-integration-verifier.ts
@@ -1191,6 +1191,24 @@ function requirementsEgmaDeclarations(source: string): readonly string[] {
     .filter((line) => namesEgma(line));
 }
 
+/**
+ * Whether one declaration pins the SDK at or above the floor Egma needs.
+ *
+ * The floor is `0.2.0` because that is the first release in which `mockable`
+ * and `monitor_livekit` decide from the job's room name. A `livekit_room`
+ * connection can put a worker in an Egma room by four dispatch paths, and a
+ * release below the floor reads dispatch metadata instead, which reaches the
+ * worker on one of those four. Below the floor, therefore, mock tools are
+ * inert on the other three and a simulation's spans leave through the
+ * production door. Neither failure says anything from inside the worker: the
+ * run completes, the real tools answer a synthetic caller, and the coverage
+ * stamp is three empty lists. That silence is why the pin is proved from the
+ * manifest here rather than left for the import to complain about.
+ *
+ * A direct reference — a URL, a path, a VCS checkout, anything carrying `@` —
+ * names no version to compare against the floor, so it is refused rather than
+ * guessed at.
+ */
 function registryEgmaAtLeastMinimum(requirement: string): boolean {
   if (requirement.includes("@")) return false;
   const match = /^\s*egma(?:\s*\[[^\]]+\])?\s*(>=|>|==|~=|\^)\s*(\d+)(?:\.(\d+))?(?:\.(\d+))?/iu.exec(
@@ -1198,7 +1216,7 @@ function registryEgmaAtLeastMinimum(requirement: string): boolean {
   );
   if (match === null) return false;
   const version = [Number(match[2]), Number(match[3] ?? 0), Number(match[4] ?? 0)];
-  const minimum = [0, 1, 1];
+  const minimum = [0, 2, 0];
   for (let at = 0; at < minimum.length; at += 1) {
     if ((version[at] ?? 0) === (minimum[at] ?? 0)) continue;
     return (version[at] ?? 0) > (minimum[at] ?? 0);
@@ -1281,7 +1299,7 @@ function manifestPreservationReason(
     declarations.length !== 1 ||
     !registryEgmaAtLeastMinimum(declarations[0] ?? "")
   ) {
-    return `Egma read ${after.shown}, but expected one registry egma>=0.1.1 dependency.`;
+    return `Egma read ${after.shown}, but expected one registry egma>=0.2.0 dependency.`;
   }
   return manifestWithoutEgma(before) === manifestWithoutEgma(after)
     ? null

--- a/apps/cli/test/livekit-local-helper.test.ts
+++ b/apps/cli/test/livekit-local-helper.test.ts
@@ -55,7 +55,7 @@ if (process.env.OBSERVED_PYTHON_FILE) {
 }
 if (args[0] === "-c") process.exit(existsSync(process.env.FIXTURE_INSTALLED_MARKER) ? 0 : 1);
 if (args[0] === "-m" && args[1] === "pip" && args[2] === "install" && args[3] === "-r") {
-  writeFileSync(process.env.FIXTURE_INSTALLED_MARKER, "0.1.1\\n");
+  writeFileSync(process.env.FIXTURE_INSTALLED_MARKER, "0.2.0\\n");
   process.exit(0);
 }
 process.exit(2);
@@ -143,7 +143,7 @@ writeFileSync(process.env.OBSERVED_UV_FILE, JSON.stringify({
   key: process.env.LIVEKIT_API_KEY ?? null,
   secret: process.env.LIVEKIT_API_SECRET ?? null,
 }));
-writeFileSync(process.env.FIXTURE_INSTALLED_MARKER, "0.1.1\\n");
+writeFileSync(process.env.FIXTURE_INSTALLED_MARKER, "0.2.0\\n");
 `;
 
 afterEach(async () => {
@@ -263,7 +263,7 @@ describe.skipIf(process.platform === "win32")("the local LiveKit skill helper", 
     ]);
     await Promise.all([
       writeFile(path.join(repository, "src", "agent.py"), "# fixture\n", "utf8"),
-      writeFile(requirements, "livekit-agents>=1.6.7\negma>=0.1.1\n", "utf8"),
+      writeFile(requirements, "livekit-agents>=1.6.7\negma>=0.2.0\n", "utf8"),
       writeExecutable(fakePython, FAKE_PYTHON),
       writeExecutable(path.join(bin, "lk"), FAKE_LIVEKIT),
     ]);
@@ -353,10 +353,14 @@ describe.skipIf(process.platform === "win32")("the local LiveKit skill helper", 
     };
     expect(await probeVersion("0.1.0.dev1")).toBe(1);
     expect(await probeVersion("0.1.0")).toBe(1);
-    expect(await probeVersion("0.1.1.dev1")).toBe(1);
-    expect(await probeVersion("0.1.1")).toBe(0);
-    expect(await probeVersion("0.1.1.post1")).toBe(0);
-    expect(await probeVersion("0.1.1+local.1")).toBe(0);
+    expect(await probeVersion("0.1.1")).toBe(1);
+    expect(await probeVersion("0.1.9")).toBe(1);
+    expect(await probeVersion("0.2.0.dev1")).toBe(1);
+    expect(await probeVersion("0.2.0")).toBe(0);
+    expect(await probeVersion("0.2.0.post1")).toBe(0);
+    expect(await probeVersion("0.2.0+local.1")).toBe(0);
+    expect(await probeVersion("0.2.1")).toBe(0);
+    expect(await probeVersion("1.0.0")).toBe(0);
 
     const mismatch = await runHelper({
       bin,
@@ -404,7 +408,7 @@ describe.skipIf(process.platform === "win32")("the local LiveKit skill helper", 
       writeFile(path.join(project, "src", "agent.py"), "# fixture\n", "utf8"),
       writeFile(
         path.join(project, "pyproject.toml"),
-        '[project]\nname = "fixture-agent"\nversion = "0.0.0"\ndependencies = ["livekit-agents>=1.6.7", "egma>=0.1.1"]\n' +
+        '[project]\nname = "fixture-agent"\nversion = "0.0.0"\ndependencies = ["livekit-agents>=1.6.7", "egma>=0.2.0"]\n' +
           (hasLock ? "" : "\n[tool.uv]\n"),
         "utf8",
       ),

--- a/apps/cli/test/livekit-wizard.test.ts
+++ b/apps/cli/test/livekit-wizard.test.ts
@@ -139,7 +139,7 @@ const WORKER_INTEGRATION_TASK = "Reconcile this LiveKit worker with Egma";
 /** The one fragment that names the mock-authoring task and nothing else. */
 const MOCK_AUTHORING_TASK = "Write the mocked world for";
 const REQUIREMENTS_BEFORE = "livekit-agents\n";
-const REQUIREMENTS_WITH_EGMA = `${REQUIREMENTS_BEFORE}egma>=0.1.1\n`;
+const REQUIREMENTS_WITH_EGMA = `${REQUIREMENTS_BEFORE}egma>=0.2.0\n`;
 
 /** What the scripted agent does when it cannot identify one job entrypoint. */
 function cannotFindTheWorker(): FakeStep[] {
@@ -247,7 +247,7 @@ function catalog(): Record<string, unknown> {
         fields: [
           { key: "url", label: "LiveKit server URL", kind: "url", required: true, help: "The server.", afterCredentials: false },
           { key: "agentName", label: "Agent name", kind: "text", required: false, help: "Optional dispatch name.", afterCredentials: false },
-          { key: "metadata", label: "Room metadata", kind: "json", required: false, help: "Optional JSON metadata.", afterCredentials: true },
+          { key: "metadata", label: "Agent metadata", kind: "json", required: false, help: "Optional JSON metadata.", afterCredentials: true },
         ],
         credentialRule: "required",
         credentialHelp: "Egma stores this pair sealed.",

--- a/apps/cli/test/skills.test.ts
+++ b/apps/cli/test/skills.test.ts
@@ -298,10 +298,11 @@ describe("Egma's instruction content", () => {
     expect(sdk.replace(/\s+/gu, " ")).toContain("Do not guess a worker file");
   });
 
-  it("requires the first Python SDK release that follows LiveKit handoffs", () => {
+  it("requires the first Python SDK release that reads the room name", () => {
     const sdk = integrateEgmaReference("integrate-egma-sdk");
 
-    expect(sdk).toContain("`egma>=0.1.1`");
+    expect(sdk).toContain("`egma>=0.2.0`");
+    expect(sdk).not.toContain("0.1.1");
   });
 
   /** The mock-world task owns no worker file or SDK instructions. */

--- a/apps/cli/test/support/fixture-platform/agents.ts
+++ b/apps/cli/test/support/fixture-platform/agents.ts
@@ -263,6 +263,15 @@ function authHeadersJson(what: string, field: string, value: unknown): string {
   return candidate;
 }
 
+/**
+ * What LiveKit accepts in one metadata field, less the room egma keeps back
+ * for the context block it merges into the dispatch beside the customer's
+ * keys. Mirrored from the access layer so the fixture refuses the oversize
+ * value the real platform refuses: a fixture that admits what production
+ * rejects lets a CLI test register a connection nobody could really have.
+ */
+const METADATA_BYTES = 512 * 1024 - 8 * 1024;
+
 /** A JSON object carried as the text it was written as, checked at create. */
 function jsonObjectText(key: string, value: unknown): string {
   const candidate = typeof value === "string" ? value.trim() : "";
@@ -275,6 +284,12 @@ function jsonObjectText(key: string, value: unknown): string {
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
     throw new Refusal(
       `the config's ${key} must be a JSON object written in a string, which looks like {"tenant":"acme"}`,
+    );
+  }
+  const bytes = Buffer.byteLength(candidate, "utf8");
+  if (bytes > METADATA_BYTES) {
+    throw new Refusal(
+      `the config's ${key} is ${bytes} bytes and egma admits at most ${METADATA_BYTES} on the room and the dispatch`,
     );
   }
   return candidate;
@@ -348,9 +363,12 @@ const REGISTRY: Readonly<Record<string, Descriptor>> = {
     /**
      * Two access variants answer one question: who mints the
      * token that opens the room. Nothing carries over between them — a
-     * connection that names an endpoint holds no key pair, so it cannot
-     * dispatch a worker or carry room metadata, and both keys are refused on
-     * it by name rather than silently ignored.
+     * connection that names an endpoint holds no key pair, so it can neither
+     * create the room that carries metadata nor dispatch the worker that is
+     * handed it, which is one power covering both of the channels a metadata
+     * value rides. `agentName` and `metadata` are therefore not among that
+     * variant's keys, and both are refused on it by name rather than silently
+     * ignored.
      */
     accessVariants: [
       {
@@ -360,7 +378,10 @@ const REGISTRY: Readonly<Record<string, Descriptor>> = {
           url: livekitServerUrl,
           // Left out means automatic dispatch: whichever worker is listening.
           agentName: optional(nonEmptyString),
-          // Handed to the agent as the room's metadata, exactly as written.
+          // Handed to the agent exactly as written, on both of the channels
+          // LiveKit gives an agent to read its per-session context from: the
+          // room's metadata always, and the dispatch's metadata as well
+          // wherever `agentName` above names a worker to dispatch.
           metadata: optional(jsonObjectText),
         },
         credentials: {

--- a/apps/cli/test/wizard-monitoring.test.ts
+++ b/apps/cli/test/wizard-monitoring.test.ts
@@ -71,7 +71,7 @@ const WORKER_INTEGRATION_TASK = "Reconcile this LiveKit worker with Egma";
 const MOCK_AUTHORING_TASK = "Write the mocked world for";
 const GENERATE_TASK = "## The words the agent is running on";
 const REQUIREMENTS_BEFORE = "livekit-agents\n";
-const REQUIREMENTS_WITH_EGMA = `${REQUIREMENTS_BEFORE}egma>=0.1.1\n`;
+const REQUIREMENTS_WITH_EGMA = `${REQUIREMENTS_BEFORE}egma>=0.2.0\n`;
 
 /**
  * The Retell account behind the wizard's own discovery, for the both lane.

--- a/apps/cli/test/worker-integration-verifier.test.ts
+++ b/apps/cli/test/worker-integration-verifier.test.ts
@@ -331,14 +331,37 @@ describe("the LiveKit worker integration verifier", () => {
     expectVerified(await claim(after, manifest, dependency, before));
   });
 
-  it("rejects an Egma SDK version without AgentTask handoff support", async () => {
+  it.each([
+    {
+      name: "an Egma SDK pin two releases under the floor",
+      dependency: "livekit-agents>=1.6.7\negma>=0.1.0\n",
+    },
+    {
+      name: "the last Egma SDK pin that reads dispatch metadata",
+      dependency: "livekit-agents>=1.6.7\negma>=0.1.1\n",
+    },
+    {
+      name: "an Egma SDK pin that excludes the floor itself",
+      dependency: "livekit-agents>=1.6.7\negma>0.2.0\n",
+    },
+  ])("rejects $name", async ({ dependency }) => {
     const result = await claim(
       WORKER_WITH_DIRECT_MOCKABLE,
       "requirements.txt",
-      "livekit-agents>=1.6.7\negma>=0.1.0\n",
+      dependency,
     );
 
-    expectUnverified(result, "egma>=0.1.1");
+    expectUnverified(result, "egma>=0.2.0");
+  });
+
+  it("accepts an Egma SDK pin at the floor exactly", async () => {
+    expectVerified(
+      await claim(
+        WORKER_WITH_DIRECT_MOCKABLE,
+        "requirements.txt",
+        "livekit-agents>=1.6.7\negma>=0.2.0\n",
+      ),
+    );
   });
 
   it.each([
@@ -844,7 +867,7 @@ describe("the LiveKit worker integration verifier", () => {
     await writeFile(serviceWorker, WORKER_WITH_DIRECT_MOCKABLE, "utf8");
     await writeFile(
       path.join(made.dir, dependencyFile),
-      "livekit-agents>=1.2\negma>=0.1.1\n",
+      "livekit-agents>=1.2\negma>=0.2.0\n",
       "utf8",
     );
 

--- a/apps/simulator/src/egma_simulator/media/livekit_room.py
+++ b/apps/simulator/src/egma_simulator/media/livekit_room.py
@@ -327,14 +327,21 @@ def dispatch_metadata(
         "egmaIdentity": egma_identity,
         "protocolVersion": PROTOCOL_VERSION,
     }
-    # ``ensure_ascii=False`` on both writes below, because the room and the
-    # dispatch are promised to carry the same bytes and the room copy is the
-    # configured string untouched. Escaping here would hand ``{"tenant":
-    # "café"}`` to the dispatch as ``caf\u00e9``, so an agent
-    # reading its own key would get a different value out of the two channels
-    # it is told are the same one. LiveKit carries UTF-8 on both.
+    # ``ensure_ascii=True`` on both writes below, and it is a correctness
+    # rule rather than a style one. A configured value may hold a lone
+    # surrogate: ``{"label":"\ud800"}`` is legal JSON, the control plane
+    # admits it, and the room's copy carries it as the six ASCII characters
+    # the customer wrote. Parsed, it is a character with no UTF-8 form at
+    # all, so writing it out raw would put a string on this request that
+    # cannot be encoded onto the wire, and the simulation would die at
+    # dispatch over a value the room carried without complaint.
+    #
+    # What escaping costs is bytes, and only on egma's copy: an agent
+    # reading its own key parses it back to the same value either way.
+    # That is why the room is what promises the string byte for byte, and
+    # the dispatch promises the keys.
     if not written:
-        return json.dumps(context, separators=(",", ":"), ensure_ascii=False)
+        return json.dumps(context, separators=(",", ":"), ensure_ascii=True)
 
     try:
         held = json.loads(written)
@@ -355,7 +362,7 @@ def dispatch_metadata(
             collided,
         )
         return written
-    return json.dumps({**held, **context}, separators=(",", ":"), ensure_ascii=False)
+    return json.dumps({**held, **context}, separators=(",", ":"), ensure_ascii=True)
 
 
 def platform_refusal(what_failed: str, code: str, told: str) -> MediaBackendError:

--- a/apps/simulator/src/egma_simulator/media/livekit_room.py
+++ b/apps/simulator/src/egma_simulator/media/livekit_room.py
@@ -55,20 +55,36 @@ Two deliberate differences from the driver that places a phone call:
 - **"Dial" means dispatch, not SIP.** Nothing is called; a worker is
   asked for.
 
-## The two metadata channels
+## The two metadata channels are the customer's
 
-Platform integrations have taught agents to expect two, and they carry
-different things:
+Platform integrations have taught agents to expect two, and both of them
+belong to the customer:
 
 - **Room metadata** is the connection's own configured JSON, verbatim.
-  It is the customer's to write and egma's to pass through untouched —
-  the place an agent reads whatever its own deployment needs.
-- **Dispatch metadata** is egma's context and only egma's: which
-  simulation this room is conducting, the modality it is in, who egma is
-  in the room, and which version of the mock-tool exchange that
-  participant speaks. It carries **nothing of the test's content** — no
-  scenario text, no persona, no expected behavior, and no mock answer —
-  because an agent that reads its script stops being under test.
+- **Dispatch metadata** is the same configured JSON. It is the channel
+  LiveKit's own documentation teaches agents to read for per-session
+  context, so an agent that reads it finds its own object there and not
+  somebody else's — which is what an agent doing
+  ``json.loads(ctx.job.metadata)["their_key"]`` needs in order to survive
+  being put under test.
+
+Neither carries **anything of the test's content** — no scenario text, no
+persona, no expected behavior, and no mock answer — because an agent that
+reads its script stops being under test.
+
+**Where egma's own signal lives instead.** Not in either of these. An
+agent learns it is in a simulation from the room's name, which begins
+``egma-sim-`` on every way into a room, and it addresses egma by the
+persona's participant identity — see :mod:`egma_simulator.media.room`,
+where both are declared as the published contracts they are. Dispatch
+metadata cannot carry that signal: it reaches the agent only where egma
+dispatches by name, which is one of the four ways in. On the other three
+there is no dispatch at all, and an agent reading that channel for egma's
+context would find nothing and conclude it was in production while a
+simulation ran around it.
+
+One transitional exception is described at :func:`dispatch_metadata`, and
+it names the condition on which it goes.
 
 ## Answering for the agent's tools
 
@@ -144,12 +160,18 @@ KNOWN_CREDENTIAL_KEYS = frozenset({"apiKey", "apiSecret"})
 URL_SCHEMES = ("ws://", "wss://", "http://", "https://")
 
 ENDPOINT_CONFIG_KEYS = frozenset({"url", "tokenEndpoint"})
-"""What the second shape's config holds — and what it does not.
+"""What the token-endpoint access variant's config holds — and what it
+does not.
 
-No agent name and no room metadata, because both are powers a key pair
-buys: nothing here can dispatch a worker or create the room that would
-carry the metadata. A key the driver would read and quietly do nothing
-with is worse than one it refuses by name.
+No agent name and no metadata, because both are powers a key pair buys.
+Metadata rides two channels and this access variant reaches neither:
+creating the room that carries the room copy and dispatching the worker
+that is handed the dispatch copy are the same one power, held by whoever
+holds the key pair. A key the driver would read and quietly do nothing
+with is worse than one it refuses by name. Where a customer on this
+access variant wants their agent to read something, their own endpoint is
+the side minting the token and dispatching the worker, so their own
+endpoint is what puts it there.
 """
 
 ENDPOINT_CREDENTIAL_KEYS = frozenset({"headers"})
@@ -256,36 +278,84 @@ async def _token_body(answer: Any) -> bytes:
     return bytes(held)
 
 
-def dispatch_metadata(simulation_id: str, *, egma_identity: str) -> str:
-    """egma's context for one dispatched worker, and nothing else's.
+def dispatch_metadata(
+    configured: str | None, simulation_id: str, *, egma_identity: str
+) -> str:
+    """What a dispatched worker is handed: the customer's own JSON.
 
-    Four facts, and every one of them is about *where egma is*, never
-    about what the test asks:
+    The connection's configured metadata is the whole of this message's
+    purpose. It rides here for the same reason it rides on the room:
+    dispatch metadata is where LiveKit teaches an agent to read its
+    per-session context, so an agent that reads it must find its own
+    object and not egma's. **Nothing of the test's content is ever added**
+    — no scenario, no persona, no expected behavior, and no mock answer —
+    because an agent that could read its script would stop being under
+    test.
 
-    - ``simulationId`` — which simulation this room is conducting, so an
-      agent can line its own telemetry up with egma's record.
-    - ``modality`` — that it is a voice one.
-    - ``egmaIdentity`` — who egma is in this room. It is the address the
-      agent's side sends a mock-tool call to, and it is the whole of the
-      authorisation: a room with no such participant has nobody to ask,
-      which is every production room.
-    - ``protocolVersion`` — which version of that exchange egma speaks,
-      so the other side knows before it says anything.
+    ## The retiring context block
 
-    **Nothing of the test's content, ever.** No scenario, no persona, no
-    expected behavior, and no mock answer — an answer reaches the agent
-    only at the moment it calls the tool, because an agent that could read
-    its script would stop being under test.
+    Underneath the customer's keys, and only where none of them collide,
+    four facts about *where egma is* are added: ``simulationId``,
+    ``modality``, ``egmaIdentity`` and ``protocolVersion``. They are not
+    how an agent finds egma — the room name and the persona identity are,
+    on all four ways into a room — and they are here for one reason only:
+    an SDK older than room-name detection reads this block and nothing
+    else. Take it away today and every worker running such an SDK stops
+    serving mock tools inside a live simulation without saying so, runs
+    the customer's real tools instead, and exports the simulation's own
+    spans through its production door as a conversation that never
+    happened.
+
+    So it stays until it is provably unread, and the condition is
+    recorded rather than remembered: delete this block, its keys, and its
+    collision check once egma's own telemetry reports no hello from an SDK
+    below the room-name minimum for a full release cycle.
+
+    A customer's own key always wins. Where their configured JSON already
+    uses one of these four names, or is not a JSON object at all, their
+    string rides alone byte for byte and the block is dropped. Corrupting
+    a value an agent reads is a worse failure than an old SDK losing its
+    one way into a simulation: the agent's own deployment breaks on a key
+    it was promised, in production shape, inside a run that was meant to
+    test it — while the old SDK's loss is a mock-tool exchange nobody
+    offered, which is where every simulation stood before mock tools.
     """
-    return json.dumps(
-        {
-            "simulationId": simulation_id,
-            "modality": "voice",
-            "egmaIdentity": egma_identity,
-            "protocolVersion": PROTOCOL_VERSION,
-        },
-        separators=(",", ":"),
-    )
+    written = configured or ""
+    context = {
+        "simulationId": simulation_id,
+        "modality": "voice",
+        "egmaIdentity": egma_identity,
+        "protocolVersion": PROTOCOL_VERSION,
+    }
+    # ``ensure_ascii=False`` on both writes below, because the room and the
+    # dispatch are promised to carry the same bytes and the room copy is the
+    # configured string untouched. Escaping here would hand ``{"tenant":
+    # "café"}`` to the dispatch as ``caf\u00e9``, so an agent
+    # reading its own key would get a different value out of the two channels
+    # it is told are the same one. LiveKit carries UTF-8 on both.
+    if not written:
+        return json.dumps(context, separators=(",", ":"), ensure_ascii=False)
+
+    try:
+        held = json.loads(written)
+    except ValueError:
+        held = None
+    if not isinstance(held, dict):
+        return written
+
+    # Read off the block itself rather than from a second list of its
+    # names, so what is checked for and what would be written cannot
+    # drift apart.
+    collided = sorted(set(held) & set(context))
+    if collided:
+        logger.warning(
+            "the configured metadata for this connection already uses %s, so "
+            "the dispatch carries the configured JSON alone; an Egma SDK "
+            "older than room-name detection will not find a simulation here",
+            collided,
+        )
+        return written
+    return json.dumps({**held, **context}, separators=(",", ":"), ensure_ascii=False)
 
 
 def platform_refusal(what_failed: str, code: str, told: str) -> MediaBackendError:
@@ -331,8 +401,15 @@ class RoomSettings:
     """Which agent to dispatch. Empty means automatic dispatch."""
 
     metadata: str | None = None
-    """The connection's configured JSON, as the room's metadata carries
-    it. ``None`` where the connection configured none."""
+    """The connection's configured JSON, as both metadata channels carry
+    it.
+
+    One field for two channels, because the customer configured one
+    value: :meth:`_create_room` sets it as the room's metadata byte for
+    byte, and :meth:`_dispatch` passes this same string through
+    :func:`dispatch_metadata` for the dispatch's. ``None`` where the
+    connection configured none.
+    """
 
     token_endpoint: str = ""
     """Where egma asks for a token, once per simulation. Empty on the
@@ -632,6 +709,7 @@ class LiveKitRoomBackend:
         self._participant_name = persona_name_for(simulation_id)
         self._room: JoinedRoom | None = None
         self._asked_for_a_room = False
+        self._offered = False
 
     @property
     def room_name(self) -> str:
@@ -644,15 +722,32 @@ class LiveKitRoomBackend:
         """Get a way into the room and build its Pipecat transport."""
         way_in = await self._way_in()
         self._room = self._joined_room(way_in)
+        self._room.answer_when_joined(self._answer_for_mocked_tools)
         return self._room.create_transport()
 
     def _answer_for_mocked_tools(self) -> None:
         """Stand ready to answer for the agent's tools, in the room.
 
-        Done the moment the room is joined and before the worker is asked
-        for, because the agent's side says hello as its session starts —
-        a handler registered afterwards would be a race with the first
-        thing the agent does.
+        Done at the join itself, which is the earliest moment it can be
+        done and the only one that is early enough. The agent's side says
+        hello as its session starts, and on three of the four ways into a
+        room nothing egma does decides when that session starts: the
+        worker can already be in the room, mid-hello, while egma is still
+        connecting. A method registered a step later than the connect is a
+        race with the first thing the agent says, and losing it reads on
+        the far side as "no egma here" — every real tool then runs inside
+        a live simulation, and the record says nothing about it.
+
+        Asked for twice, deliberately: once by the room the instant it is
+        entered, and once from :meth:`dial` for a room that offers no such
+        moment. Whichever call gets both methods on is the one that
+        offers the exchange, and the other returns having done nothing.
+        The flag that decides which is which is set only after both
+        registrations return, so the second ask stays a real second
+        chance: a room that refused at the join is a room the fallback
+        can still offer in, and a flag raised before the work would spend
+        that chance on nothing and leave every mocked tool running its
+        own implementation for the whole simulation.
 
         Both methods go on whether or not this simulation mocks anything.
         A room where egma answers for no tools still answers the hello
@@ -671,7 +766,7 @@ class LiveKitRoomBackend:
         offered — and the record then claims nothing about tools, which is
         the truth, because egma never stood in their path.
         """
-        if self._mock_tools is None or self._room is None:
+        if self._mock_tools is None or self._room is None or self._offered:
             return
         try:
             self._room.register_rpc(HELLO_METHOD, self._mock_tools.hello)
@@ -684,6 +779,7 @@ class LiveKitRoomBackend:
                 self._quotable(repr(unoffered)),
             )
             return
+        self._offered = True
         self._mock_tools.standing_ready()
 
     async def _way_in(self) -> WayIn:
@@ -721,11 +817,16 @@ class LiveKitRoomBackend:
         here at all. Dispatching takes the key pair egma deliberately was
         not given, so putting a worker in the room is the endpoint's job
         and egma's part is to be in the room when it arrives.
+
+        On three of the four ways in the agent may have arrived already,
+        so the room is asked who is in it before anybody starts waiting
+        for somebody to come.
         """
         if self._room is None:
             raise MediaBackendError("an agent was requested before a room transport")
         await self._room.wait_connected()
         self._answer_for_mocked_tools()
+        self._room.note_anybody_already_here()
         if not self._settings.mints_its_own:
             return
         if not self._settings.agent_name:
@@ -807,20 +908,23 @@ class LiveKitRoomBackend:
         await self._asked(request, "the room could not be created")
 
     async def _dispatch(self) -> None:
-        """One `CreateAgentDispatch`, carrying egma's context and no more."""
+        """One `CreateAgentDispatch`, carrying the connection's own JSON."""
         from livekit import api
 
         request = api.CreateAgentDispatchRequest(
             room=self._room_name,
             agent_name=self._settings.agent_name,
-            # The identity the token grants, not a name invented here: the
-            # agent's side addresses its mock-tool calls to exactly this
-            # participant, so a metadata block naming anybody else would
-            # send them to nobody. Dispatching happens only on the shape
-            # that mints its own token, which is the shape that signs this
-            # identity — see `room_token`.
+            # The identity the token grants, not a name invented here: an
+            # SDK old enough to still read the retiring block addresses
+            # its mock-tool calls to exactly this participant, so a name
+            # invented for the message would send them to nobody.
+            # Dispatching happens only on the access variant that mints its
+            # own token, which is the one that signs this identity — see
+            # `room_token`.
             metadata=dispatch_metadata(
-                self._simulation_id, egma_identity=PERSONA_IDENTITY
+                self._settings.metadata,
+                self._simulation_id,
+                egma_identity=PERSONA_IDENTITY,
             ),
         )
         await self._asked(

--- a/apps/simulator/src/egma_simulator/media/room.py
+++ b/apps/simulator/src/egma_simulator/media/room.py
@@ -19,7 +19,50 @@ logger = logging.getLogger(__name__)
 RpcMethod = Callable[[str], Awaitable[str]]
 
 ROOM_PREFIX = "egma-sim"
+"""The stem of the name every room egma conducts a simulation in.
+
+**The published contract is the hyphenated ``egma-sim-``** — this stem
+and the separator that :func:`fresh_room_name` and :func:`room_name_for`
+below put after it. That hyphenated form is what a customer's own token
+endpoint allowlists, what the hardening recipe names its empty timeout
+against, and what the egma SDK inside the customer's worker reads to
+answer "am I in a simulation?"
+before it connects to anything — the one question that decides whether
+mock tools are served and whether the agent's spans go out the
+production door. Every room name built below begins with it on all four
+ways into a room, which is what makes that answer the same answer
+everywhere.
+
+Move the value and every installed SDK goes inert inside a real
+simulation: real tools run, and the simulation's spans arrive in
+Monitoring as a production conversation. One test in this package holds
+the line — ``apps/simulator/tests/test_plug_phone.py`` asserts a
+conducted room name begins ``egma-sim-``, written out by hand rather than
+built from this constant, so a rename here goes red rather than quiet.
+Read that red as the contract refusing to move, not as a fixture to
+update.
+
+Nothing links this constant to the far side of the contract, and nothing
+can: the SDK holds its own copy in
+``sdks/python/src/egma/mockable.py``, pinned again by
+``sdks/python/tests/room_stub.py`` and
+``fixtures/livekit-dumb-agent/tests/conftest.py``, and a customer runs
+whichever release of it they installed. A version already deployed cannot
+be edited to follow a rename. That is what makes the value frozen rather
+than merely stable.
+"""
+
 PERSONA_IDENTITY = "egma-persona"
+"""Who egma is in the room, as the far side addresses it.
+
+Published with the prefix above and frozen for the same reason: it is the
+destination the agent's side sends a mock-tool call to, and room
+membership under this identity is the whole of the authorisation. It
+appears in two forms — exactly this string where egma mints its own
+token, and :func:`persona_name_for` where a customer's endpoint mints
+one — so both begin here.
+"""
+
 CONNECT_SECONDS = 30.0
 AUDIO_STREAM_CLOSE_SECONDS = 2.0
 PIPECAT_VERSION = "1.7.0"
@@ -327,10 +370,26 @@ class JoinedRoom:
         self.ended = asyncio.Event()
         self.failed = asyncio.Event()
         self._leaving = False
+        self._offer: Callable[[], None] | None = None
 
     @property
     def joined(self) -> bool:
         return self._transport is not None
+
+    def answer_when_joined(self, offer: Callable[[], None]) -> None:
+        """Run ``offer`` the instant this room is entered, before anything
+        else learns the room is up.
+
+        The agent can already be in the room when egma arrives — on three
+        of the four ways in nothing egma does puts it there, so it joins
+        whenever its own dispatcher says. Whatever offers to answer for
+        the agent's tools therefore has to be live at the earliest moment
+        it *can* be live, which is the connect itself: a method registered
+        one step later is a race against the first thing the agent's
+        session says, and losing that race reads on the far side as "no
+        egma here" and runs every real tool inside a live simulation.
+        """
+        self._offer = offer
 
     def create_transport(self) -> VoiceMedia:
         """Create stock LiveKit input and output processors without rates."""
@@ -355,6 +414,9 @@ class JoinedRoom:
 
         @transport.event_handler("on_connected")
         async def _connected(_transport: object) -> None:
+            offer = self._offer
+            if offer is not None:
+                offer()
             self._connected.set()
 
         @transport.event_handler("on_before_disconnect")
@@ -372,6 +434,22 @@ class JoinedRoom:
 
         @transport.event_handler("on_participant_connected")
         async def _arrived(_transport: object, _participant: str) -> None:
+            self.arrivals.set()
+
+        @transport.event_handler("on_first_participant_joined")
+        async def _already_here(_transport: object, _participant: str) -> None:
+            # The other half of "somebody is in the room". The transport
+            # raises this for the first participant it ever sees, by
+            # either of the two routes it can see one: a participant that
+            # connects while egma is watching raises the arrival above
+            # *and* this one, while a participant already in the room when
+            # egma walked in raises only this one. So the two handlers
+            # overlap rather than divide, and the overlap is free — both
+            # set the same event, which is set once and read as a state.
+            # This handler earns its place on the second route alone: an
+            # agent that got into the room first would otherwise be waited
+            # out and reported as a worker that never came, while it sat
+            # there publishing audio.
             self.arrivals.set()
 
         @transport.event_handler("on_participant_disconnected")
@@ -421,6 +499,34 @@ class JoinedRoom:
                 "simulator was joining",
                 ending=ERROR,
             )
+
+    def note_anybody_already_here(self) -> None:
+        """Count whoever was in the room before egma got into it.
+
+        The events above are the room telling egma who arrives. This is
+        egma asking, once, immediately after the join — because the two
+        can disagree by exactly one participant: the transport announces
+        an already-present participant as the first joiner while the
+        connect is still returning, and nothing guarantees that handler
+        has run by the time the join is awaited here. Asking costs one
+        local read and closes that gap, so an agent that was quicker into
+        the room than egma is somebody who came rather than nobody.
+
+        The read is of the room's *remote* participants, so egma cannot
+        count itself and turn an empty room into somebody who came.
+
+        It never raises. A transport that stops offering this read leaves
+        the wait exactly where the events put it, which is the behaviour
+        without it, rather than failing a simulation over a check.
+        """
+        if self.arrivals.is_set() or self._transport is None:
+            return
+        try:
+            present = self._transport.get_participants()
+        except Exception:
+            return
+        if present:
+            self.arrivals.set()
 
     def register_rpc(self, method: str, handler: RpcMethod) -> None:
         if self._transport is None:

--- a/apps/simulator/src/egma_simulator/mock_tools.py
+++ b/apps/simulator/src/egma_simulator/mock_tools.py
@@ -86,10 +86,31 @@ logger = logging.getLogger(__name__)
 PROTOCOL_VERSION = 1
 """Which version of this exchange egma's participant speaks.
 
-It rides the dispatch metadata so the other side knows before it says
-anything, and it rides every hello in both directions so a mismatch is
-refused at the first message rather than discovered halfway through a
-simulation.
+It rides every hello in both directions, so a mismatch is refused at the
+first message rather than discovered halfway through a simulation. It
+also rides the retiring context block on a named dispatch — see
+:func:`egma_simulator.media.livekit_room.dispatch_metadata` — which is
+the one channel an SDK older than room-name detection reads.
+
+**Which channel announces this number is not part of it.** The version
+names the shape of a hello and of its reply, and nothing about where the
+other side first read it. An SDK speaking 1 and a simulator speaking 1
+therefore understand each other whichever way round they were upgraded,
+and a bump made over a channel would refuse both of those pairings with
+904 and buy nothing — the SDK that would need warning off is the one that
+sends no hello at all, so it would never see the number.
+
+Two facts constrain a future bump, and both are load-bearing. This file
+and the SDK's own copy are deliberately duplicated and must stay equal,
+and
+``packages/simulation-contract/fixtures/seam/mock-tool-exchange.v1.json``
+pins the number into the canonical bytes both suites read. So a real
+shape change ships in this order: the simulator first accepts both
+versions in :func:`_speaks_this_version`, a second fixture is added
+beside the first rather than edited into it, and only once that release
+has drained may the SDK start sending the new number. Self-hosting makes
+"old simulator, new SDK" a lasting pairing rather than a rollout window,
+which is why the order is that way round.
 """
 
 HELLO_METHOD = "egma.hello"

--- a/apps/simulator/src/egma_simulator/plugs/livekit.py
+++ b/apps/simulator/src/egma_simulator/plugs/livekit.py
@@ -31,8 +31,12 @@ creates the room, dispatches the worker and deletes the room at the end:
 - ``agentName`` (string, optional) — which agent to dispatch. Absent or
   blank: automatic dispatch, which is what a worker registered without a
   name already gets.
-- ``metadata`` (a JSON object in a string, optional) — carried on the
-  room, verbatim, for the agent to read.
+- ``metadata`` (a JSON object in a string, optional) — the customer's
+  own, for the agent to read. It is carried on the room verbatim, and
+  where this connection names an agent it is carried on that agent's
+  dispatch too, which is where LiveKit's own documentation teaches an
+  agent to look for its per-session context. Automatic dispatch has no
+  dispatch of egma's to put it on, so there it rides the room alone.
 
 Its credentials are the customer's LiveKit ``apiKey`` and ``apiSecret``.
 Unlike a phone connection, a room connection carries its own: the room is
@@ -63,11 +67,16 @@ conversion, and pacing. Egma does not select or expose a processing rate.
 
 A room is the one connection where egma can stand in the agent's tool
 path, because it is the one where egma is already in the room with it. The
-mock-tool exchange is offered on egma's own participant and the agent's
-side is told where to find it in the dispatch metadata; what answers it is
-:mod:`egma_simulator.mock_tools`, handed to this plug already holding the
-answers the run resolved. Nothing about it is this file's: the plug passes
-it to the driver that joins the room, and the driver offers it there.
+mock-tool exchange is offered on egma's own participant, and how the
+agent's side finds it is the room itself: the name every simulation room
+carries says a simulation is running, and the persona's participant
+identity is the address — both published, both the same on all four ways
+into a room, and neither of them a metadata channel the customer writes.
+What answers it is :mod:`egma_simulator.mock_tools`, handed to this plug
+already holding the answers the run resolved. Nothing about it is this
+file's: the plug passes it to the driver that joins the room, and the
+driver offers it there, at the join, before an agent that was quicker
+into the room can ask.
 
 ## Where a turn begins and ends
 

--- a/apps/simulator/tests/room_stub.py
+++ b/apps/simulator/tests/room_stub.py
@@ -13,9 +13,9 @@ for its token really asks, over a socket, of the endpoint in
 
 Everything else is the real driver's own code, and deliberately so. The
 requests recorded below are the very protobuf messages that would have
-gone on the wire, built by the driver: the room's name and the metadata
-the connection configured, the agent's name and the context egma
-dispatches with. So are the waits, the endings, the sentences a person
+gone on the wire, built by the driver: the room's name, the agent's name,
+and the metadata the connection configured on both channels that carry
+it. So are the waits, the endings, the sentences a person
 reads and the scrubbing of the key pair. What this suite proves about a
 refusal or an ending is therefore proved about the code a customer's
 server will run.
@@ -46,6 +46,10 @@ The script it is built with:
   exchange looks like from the plug's seat.
 - ``agent_joins`` — false for the worker that never comes: the room
   opens, the dispatch goes out, and nobody arrives.
+- ``agent_was_already_in_the_room`` — true for the worker that got there
+  first, which is what the three ways in that egma does not dispatch on
+  look like. It is in the room and publishing, and no arrival is ever
+  announced for it.
 - ``agent_publishes_audio`` — false for the worker that joins and
   publishes nothing, which is a worker that crashed rather than an agent
   under test.
@@ -53,6 +57,9 @@ The script it is built with:
   it will not make the room, or will not dispatch into it.
 - ``refuses_rpc`` — a participant that will not take the mock-tool methods
   at all, which must cost the exchange and never the conversation.
+- ``refuses_the_offer_at_the_join`` — a participant that will not take them
+  at the join and will take them after it, which is the room the driver's
+  second offer exists for.
 """
 
 from __future__ import annotations
@@ -131,10 +138,28 @@ class StubRoom:
         self._activation: asyncio.Task[None] | None = None
         self._joined = False
         self._methods: dict[str, object] = {}
+        self._offer: object = None
+        self._offering_at_the_join = False
         self.arrivals = asyncio.Event()
         self.carrying_audio = asyncio.Event()
         self.ended = asyncio.Event()
         self.who_arrived: list[str] = []
+
+    def answer_when_joined(self, offer: object) -> None:
+        """Take the driver's offer to answer for the agent's tools."""
+        self._offer = offer
+
+    def note_anybody_already_here(self) -> None:
+        """Answer the driver's one question: is somebody in here already?
+
+        The real room asks its transport; this one knows. Both answer the
+        same question for the same reason — a participant that was in the
+        room before egma got into it is never announced as an arrival, so
+        an agent that was quicker would otherwise be waited out and
+        reported as a worker that never came.
+        """
+        if self.who_arrived:
+            self.arrivals.set()
 
     @property
     def transport(self) -> ScriptedTransport | None:
@@ -155,6 +180,17 @@ class StubRoom:
             ends_after_replies=stub.hangs_up_after_replies,
         )
         stub.transports.append(self._transport)
+        # Entering the room is the moment the driver offers to answer for
+        # the agent's tools, and it is offered here rather than later for
+        # one reason: the agent can already be in the room. Modelled in
+        # that order so nothing below can pass against an ordering the
+        # real room does not have.
+        self._offering_at_the_join = True
+        try:
+            if self._offer is not None:
+                self._offer()
+        finally:
+            self._offering_at_the_join = False
         # Where egma minted its own token, the worker is on its way because
         # egma asked for it. Where it did not, nobody asked and nobody
         # could: the endpoint that minted the token is what dispatches, so
@@ -162,7 +198,7 @@ class StubRoom:
         if self._backend.endpoint_dispatches:
             self._backend.agent_is_coming = stub.agent_joins
         if self._backend.agent_is_coming:
-            self.agent_arrives()
+            self.agent_arrives(announced=not stub.agent_was_already_in_the_room)
         return self._transport.media
 
     async def wait_connected(self) -> None:
@@ -192,6 +228,8 @@ class StubRoom:
         it.
         """
         refusal = self._backend.stub.refuses_rpc
+        if refusal is None and self._offering_at_the_join:
+            refusal = self._backend.stub.refuses_the_offer_at_the_join
         if refusal is not None:
             raise RuntimeError(refusal)
         self._methods[method] = answering(handler)
@@ -222,12 +260,22 @@ class StubRoom:
             )
         return answered
 
-    def agent_arrives(self) -> None:
-        """The worker turns up, and — unless it is broken — is heard."""
+    def agent_arrives(self, *, announced: bool = True) -> None:
+        """The worker turns up, and — unless it is broken — is heard.
+
+        ``announced`` is false for the worker that was in the room before
+        egma was. A room announces an arrival to whoever is already
+        watching; somebody who was there first is not an arrival to
+        anyone, and the transport says so once, in its other event. So
+        the participant is in the room and its audio is on the wire with
+        no arrival to wait for — which is exactly the case the driver has
+        to find by asking.
+        """
         if AGENT_IDENTITY in self.who_arrived:
             return
         self.who_arrived.append(AGENT_IDENTITY)
-        self.arrivals.set()
+        if announced:
+            self.arrivals.set()
         transport = self._transport
         stub = self._backend.stub
         if transport is None or not stub.agent_publishes_audio:
@@ -359,11 +407,29 @@ class RoomStub:
     hangs_up_after_replies: bool = False
     agent_joins: bool = True
     agent_publishes_audio: bool = True
+    agent_was_already_in_the_room: bool = False
+    """True for the worker that got in before egma did.
+
+    The ordinary case wherever egma is not the one dispatching: nothing
+    egma does decides when that worker is given the room, so it can be
+    sitting in it, publishing, before egma's transport connects. The room
+    then announces nobody — being there first is not an arrival — and a
+    driver that only waits for arrivals waits the whole budget out and
+    calls a present agent a worker that never came."""
     refuses_room: str | None = None
     refuses_dispatch: str | None = None
     refuses_rpc: str | None = None
     """A participant that will not take the mock-tool methods at all — the
     one refusal that must cost the exchange and nothing else."""
+
+    refuses_the_offer_at_the_join: str | None = None
+    """A participant that will not take them at the join, and will after.
+
+    The driver offers at the join because the agent may already be in the
+    room, and again from ``dial`` for a room that has no such moment. This
+    is the room where the first of those two does not take: the second is
+    the only offer left, so what it costs to spend it on nothing is every
+    mocked tool in the simulation running its own implementation."""
 
     rooms: list[CreatedRoom] = field(default_factory=list)
     """Every room this LiveKit was asked to make, in order."""
@@ -393,9 +459,12 @@ class RoomStub:
     standing_ready: asyncio.Event = field(default_factory=asyncio.Event)
     """Set once egma has offered the exchange in the room.
 
-    What a session waits for before it says hello — the same thing that
-    really decides it on a live room, where an agent's side finds egma by
-    the identity in its dispatch metadata or finds nobody at all."""
+    What a session waits for before it says hello. On a live room the
+    agent's side has no such event: it finds egma by the persona identity
+    in a room whose name says a simulation is running, and a room with no
+    such participant answers nothing. Which is why the driver offers the
+    methods at the join and not a step later — the far side may already
+    be knocking."""
 
     def driver(self, **built: object) -> RoomStubBackend:
         """The factory a plug is handed, in place of the real driver."""

--- a/apps/simulator/tests/test_plug_livekit.py
+++ b/apps/simulator/tests/test_plug_livekit.py
@@ -61,7 +61,7 @@ from egma_simulator.media.room import (
     room_token,
 )
 from egma_simulator.media.scripted_transport import FRAME_SECONDS
-from egma_simulator.mock_tools import PROTOCOL_VERSION
+from egma_simulator.mock_tools import PROTOCOL_VERSION, MockToolSeam
 from egma_simulator.model import GOODBYE, ScriptedModel
 from egma_simulator.persona import Persona
 from egma_simulator.pipeline import assemble
@@ -70,7 +70,7 @@ from egma_simulator.plugs import livekit as livekit_plug
 from egma_simulator.plugs.livekit import LiveKitRoom
 from egma_simulator.recording import channels_of
 from egma_simulator.redaction import REDACTED
-from egma_simulator.spec import SimulationSpec
+from egma_simulator.spec import MockTool, SimulationSpec
 from egma_simulator.speech import SCRIPTED_PAIR
 from egma_simulator.walk import Conducted, WalkControls
 
@@ -940,13 +940,152 @@ async def test_an_unnamed_agent_takes_the_automatic_path(
     assert len(stub.rooms) == 1
 
 
-async def test_the_dispatch_carries_egmas_context_and_none_of_the_test(
+async def test_an_agent_that_got_into_the_room_first_is_still_somebody_who_came():
+    """A worker already in the room is not a worker that never came.
+
+    On three of the four ways into a room, nothing egma does decides when
+    the worker is given the room: automatic dispatch hands it over the
+    moment the room exists, and a customer's own dispatcher hands it over
+    whenever it likes. So the ordinary case is an agent sitting in the
+    room, publishing, before egma's transport connects — and a room
+    announces an arrival only to somebody who was already watching.
+    Waiting for an event that will never fire would end a live simulation
+    as ``agent_never_joined`` while the agent was in the room the whole
+    time, and blame the customer's worker for it.
+    """
+    stub = RoomStub(
+        greeting="Front desk.",
+        replies=["Noted."],
+        agent_was_already_in_the_room=True,
+    )
+    plug = room(stub)
+
+    await plug.prepare()
+    assert not stub.room.arrivals.is_set(), (
+        "the room announced an arrival for somebody who was there first, "
+        "which is not what a room does"
+    )
+    await plug.open()
+    try:
+        assert stub.room.arrivals.is_set()
+        assert stub.room.who_arrived == [AGENT_IDENTITY]
+    finally:
+        await plug.close()
+
+
+async def test_the_mock_tool_methods_are_offered_at_the_join():
+    """Live before anybody can ask, because somebody may already be asking.
+
+    The agent's side says hello as its session starts, and where egma is
+    not the one dispatching that session can be under way while egma is
+    still connecting. A method registered a step after the join is a race
+    with the first thing the agent says; losing it reads on the far side
+    as "no egma here", and every tool the simulation meant to answer for
+    runs its own implementation instead — inside a live simulation, with
+    nothing on the record to say so.
+    """
+    stub = RoomStub(greeting="Front desk.", replies=["Noted."])
+    plug = LiveKitRoom(
+        modality="voice",
+        access_variant="livekit_room.project_credentials",
+        config={"url": A_URL},
+        credentials={"apiKey": A_KEY, "apiSecret": A_SECRET},
+        simulation_id=A_SIMULATION,
+        mock_tools=MockToolSeam((MockTool("check_calendar", {"answer": {}}, 0),)),
+        driver=stub.driver,
+    )
+
+    await plug.prepare()
+    try:
+        assert stub.standing_ready.is_set(), (
+            "the exchange was not offered until after the join, which is a "
+            "race with the first thing the agent's session says"
+        )
+        assert await stub.says_hello("check_calendar") == {
+            "protocol_version": PROTOCOL_VERSION,
+            "mocked_tools": ["check_calendar"],
+        }
+    finally:
+        await plug.close()
+
+
+async def test_a_refusal_at_the_join_leaves_the_second_offer_its_chance():
+    """The fallback offer is spent on the room that needs it, not on air.
+
+    The driver offers twice: at the join, which is the only moment early
+    enough for an agent that was already in the room, and again from
+    ``dial`` for a room that had no such moment. A room can refuse the
+    first and take the second, and then the second is the only offer the
+    simulation has left. Counting the exchange as offered before the
+    participant has taken the methods throws that one away, and every
+    mocked tool in the run then reaches its own implementation while the
+    record says nothing about it.
+    """
+    stub = RoomStub(
+        greeting="Front desk.",
+        replies=["Noted."],
+        refuses_the_offer_at_the_join="the participant is not ready yet",
+    )
+    plug = LiveKitRoom(
+        modality="voice",
+        access_variant="livekit_room.project_credentials",
+        config={"url": A_URL},
+        credentials={"apiKey": A_KEY, "apiSecret": A_SECRET},
+        simulation_id=A_SIMULATION,
+        mock_tools=MockToolSeam((MockTool("check_calendar", {"answer": {}}, 0),)),
+        driver=stub.driver,
+    )
+
+    await plug.prepare()
+    try:
+        assert not stub.standing_ready.is_set(), (
+            "the room took the methods at the join, so this is not the room "
+            "the second offer exists for"
+        )
+        await plug.open()
+        assert stub.standing_ready.is_set(), (
+            "the join was refused and the second offer was skipped, so every "
+            "mocked tool in this simulation runs for real"
+        )
+        assert await stub.says_hello("check_calendar") == {
+            "protocol_version": PROTOCOL_VERSION,
+            "mocked_tools": ["check_calendar"],
+        }
+    finally:
+        await plug.close()
+
+
+async def test_the_dispatch_carries_the_customers_own_keys_untouched(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """What an agent is told when it is asked for: which simulation this
-    is and that it is a voice one — and nothing whatever about what it is
-    going to be asked, because an agent that reads its script stops being
-    under test."""
+    """The whole point of the channel: an agent reading its per-session
+    context out of the dispatch finds its own object there.
+
+    LiveKit's own documentation sends agents to this channel for exactly
+    that, so an agent doing ``json.loads(ctx.job.metadata)["clinic"]``
+    reads what its own deployment configured rather than breaking the
+    moment somebody puts it under test.
+    """
+    stub = RoomStub(greeting="Front desk.", replies=["Noted."])
+    await room_walk(
+        tmp_path,
+        stub,
+        monkeypatch,
+        agent_name="front-desk",
+        metadata='{"clinic":"lakeside","locale":"en-GB"}',
+        scenario="One point.",
+    )
+
+    carried = json.loads(stub.dispatches[0].metadata)
+    assert carried["clinic"] == "lakeside"
+    assert carried["locale"] == "en-GB"
+
+
+async def test_the_dispatch_carries_none_of_the_test(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Nothing whatever about what the agent is going to be asked,
+    because an agent that reads its script stops being under test."""
     scenario = "Ask to move the Tuesday cleaning to Thursday. Say you are Margaret."
     stub = RoomStub(greeting="Front desk.", replies=["Noted."])
     await room_walk(
@@ -954,23 +1093,32 @@ async def test_the_dispatch_carries_egmas_context_and_none_of_the_test(
         stub,
         monkeypatch,
         agent_name="front-desk",
+        metadata='{"clinic":"lakeside"}',
         scenario=scenario,
     )
 
-    carried = json.loads(stub.dispatches[0].metadata)
-    assert carried == {
-        "simulationId": A_SIMULATION,
-        "modality": "voice",
-        "egmaIdentity": PERSONA_IDENTITY,
-        "protocolVersion": PROTOCOL_VERSION,
-    }
     for word in ("Tuesday", "Thursday", "Margaret", "cleaning", A_PERSONALITY):
         assert word not in stub.dispatches[0].metadata
 
 
-def test_egmas_context_is_the_same_string_wherever_it_is_built():
-    """Written out once, so the sentence a worker parses cannot drift."""
-    assert json.loads(dispatch_metadata("sim_01ABC", egma_identity="egma-persona")) == {
+def test_the_retiring_context_rides_under_the_customers_json():
+    """Both, where they fit: the customer's object with egma's four facts
+    added beneath it.
+
+    egma's own signal is the room's name and the persona's identity, on
+    all four ways into a room. These four keys are here for one reason —
+    an SDK older than room-name detection reads them and nothing else —
+    and the customer's keys are what the message is actually for, so they
+    arrive with their values intact.
+    """
+    carried = json.loads(
+        dispatch_metadata(
+            '{"clinic":"lakeside"}', "sim_01ABC", egma_identity="egma-persona"
+        )
+    )
+
+    assert carried == {
+        "clinic": "lakeside",
         "simulationId": "sim_01ABC",
         "modality": "voice",
         "egmaIdentity": "egma-persona",
@@ -978,15 +1126,88 @@ def test_egmas_context_is_the_same_string_wherever_it_is_built():
     }
 
 
+def test_a_connection_that_configured_nothing_carries_the_retiring_context_alone():
+    """Nothing of the customer's to carry, so nothing of theirs is at
+    risk — which is the one case where egma's own block is the whole
+    message rather than a few keys under somebody else's."""
+    assert json.loads(
+        dispatch_metadata(None, "sim_01ABC", egma_identity="egma-persona")
+    ) == {
+        "simulationId": "sim_01ABC",
+        "modality": "voice",
+        "egmaIdentity": "egma-persona",
+        "protocolVersion": PROTOCOL_VERSION,
+    }
+
+
+@pytest.mark.parametrize(
+    "configured",
+    [
+        '{"egmaIdentity":"theirs"}',
+        '{"clinic":"lakeside","protocolVersion":9}',
+        '{"modality":"chat"}',
+        '{"simulationId":"their-own-id"}',
+    ],
+)
+def test_a_customers_own_key_wins_over_the_retiring_context(configured: str):
+    """Their value, byte for byte, and egma's block dropped whole.
+
+    Overwriting a key an agent reads breaks the agent's own deployment
+    inside the run that was meant to test it, so it is not traded for
+    anything — not even for an older SDK's one way of finding a
+    simulation, which the room's own name gives it back.
+    """
+    assert (
+        dispatch_metadata(configured, "sim_01ABC", egma_identity="egma-persona")
+        == configured
+    )
+
+
+def test_the_two_channels_carry_the_same_characters():
+    """One value, two channels, and the same text out of both.
+
+    The room carries the configured string untouched, so the dispatch has
+    to say the same thing rather than an escaped spelling of it: an agent
+    reading ``ctx.room.metadata`` and one reading ``ctx.job.metadata`` are
+    promised the same value, and a customer comparing the two, or hashing
+    one, must not find them different. LiveKit carries UTF-8 on both.
+    """
+    configured = '{"tenant":"café","city":"東京"}'
+    carried = dispatch_metadata(configured, "sim_01ABC", egma_identity="egma-persona")
+
+    assert "café" in carried
+    assert "東京" in carried
+    assert "\\u" not in carried
+    assert json.loads(carried)["tenant"] == "café"
+    assert json.loads(carried)["city"] == "東京"
+
+
+def test_metadata_that_is_not_an_object_rides_exactly_as_configured():
+    """Nowhere to add anything, so nothing is added and nothing is lost.
+
+    The door stores this as a JSON object in a string and the driver
+    refuses anything else on the way in, so this is unreachable through
+    the product. It is pinned anyway, because the alternative to passing
+    an unparsable string through is corrupting it.
+    """
+    assert (
+        dispatch_metadata("not json at all", "sim_01ABC", egma_identity="p")
+        == "not json at all"
+    )
+
+
 async def test_the_dispatch_names_the_participant_the_token_really_opens(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """The identity in the metadata is the address a mock-tool call goes to.
+    """The retiring block's identity is the one the token really grants.
 
-    An agent's side sends its calls to whoever the metadata names, so a
-    name invented for the message rather than taken from the token would
-    address a participant that is not in the room — and every mocked tool
-    would quietly run for real.
+    An SDK older than room-name detection sends its mock-tool calls to
+    whoever that block names, so a name invented for the message rather
+    than taken from the token would address a participant that is not in
+    the room — and every mocked tool would quietly run for real, in a
+    live simulation, with nothing on the record to say so. Newer SDKs
+    read the persona identity off the room instead; this is what holds
+    the older ones up until the block goes.
     """
     stub = RoomStub(greeting="Front desk.", replies=["Noted."])
     await room_walk(
@@ -1002,8 +1223,8 @@ def jwt_identity(token: str) -> str:
     """Whose token this is, read out of the token itself.
 
     Decoded rather than asserted against a constant, because the question
-    is whether the two really agree — the metadata is only right if it
-    names the identity the signed token actually grants.
+    is whether the two really agree — the block is only right if it names
+    the identity the signed token actually grants.
     """
     import base64
 

--- a/apps/simulator/tests/test_plug_livekit.py
+++ b/apps/simulator/tests/test_plug_livekit.py
@@ -1081,6 +1081,37 @@ async def test_the_dispatch_carries_the_customers_own_keys_untouched(
     assert carried["locale"] == "en-GB"
 
 
+async def test_the_dispatch_survives_a_value_with_no_utf_8_form(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A lone surrogate is legal JSON, so the door admits it and the room
+    carries it. The dispatch has to survive it too.
+
+    ``{"label":"\\ud800"}`` is a valid JSON object whose parsed value is a
+    character that has no UTF-8 encoding at all. The room's copy never meets
+    that problem, because it rides as the ASCII the customer wrote. egma's
+    copy is written out again, and written out raw it would be a string that
+    cannot go on the wire — a simulation dead at dispatch over a value the
+    other channel carried without complaint.
+    """
+    stub = RoomStub(greeting="Front desk.", replies=["Noted."])
+    await room_walk(
+        tmp_path,
+        stub,
+        monkeypatch,
+        agent_name="front-desk",
+        metadata='{"label":"\\ud800"}',
+        scenario="One point.",
+    )
+
+    carried = stub.dispatches[0].metadata
+    # The whole of the claim: it goes on the wire, and it still reads back
+    # as the value the customer configured.
+    carried.encode("utf-8")
+    assert json.loads(carried)["label"] == "\ud800"
+    assert json.loads(carried)["simulationId"]
+
+
 async def test_the_dispatch_carries_none_of_the_test(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
@@ -1163,23 +1194,28 @@ def test_a_customers_own_key_wins_over_the_retiring_context(configured: str):
     )
 
 
-def test_the_two_channels_carry_the_same_characters():
-    """One value, two channels, and the same text out of both.
+def test_the_two_channels_carry_the_same_value():
+    """One value, two channels, and the same thing read out of both.
 
-    The room carries the configured string untouched, so the dispatch has
-    to say the same thing rather than an escaped spelling of it: an agent
-    reading ``ctx.room.metadata`` and one reading ``ctx.job.metadata`` are
-    promised the same value, and a customer comparing the two, or hashing
-    one, must not find them different. LiveKit carries UTF-8 on both.
+    The room carries the configured string untouched and the dispatch
+    carries egma's own writing of it, so the promise the two share is the
+    value rather than the bytes: an agent reading ``ctx.room.metadata`` and
+    one reading ``ctx.job.metadata`` parse their way to the same object.
+
+    egma's copy is escaped on the way out, and it has to be. A configured
+    value may hold a character with no UTF-8 form, and the room never meets
+    that because it rides as the ASCII the customer wrote; written out raw,
+    egma's copy would be a string that cannot go on the wire at all. So the
+    spelling may differ and the value may not, and what is pinned here is
+    the second of those.
     """
-    configured = '{"tenant":"café","city":"東京"}'
+    configured = '{"tenant":"caf\u00e9","city":"\u6771\u4eac"}'
     carried = dispatch_metadata(configured, "sim_01ABC", egma_identity="egma-persona")
 
-    assert "café" in carried
-    assert "東京" in carried
-    assert "\\u" not in carried
-    assert json.loads(carried)["tenant"] == "café"
-    assert json.loads(carried)["city"] == "東京"
+    assert json.loads(carried)["tenant"] == json.loads(configured)["tenant"]
+    assert json.loads(carried)["city"] == json.loads(configured)["city"]
+    # The property the spelling buys, and the reason it is not the room's.
+    carried.encode("utf-8")
 
 
 def test_metadata_that_is_not_an_object_rides_exactly_as_configured():

--- a/apps/web/app/projects/[projectId]/agents/livekit-monitoring-instructions.tsx
+++ b/apps/web/app/projects/[projectId]/agents/livekit-monitoring-instructions.tsx
@@ -5,7 +5,13 @@ import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 
-const INSTALL = "pip install egma";
+// Pinned, because the floor is what makes the guard hold. `monitor_livekit`
+// reads the job's room name to tell a simulation from a production call, and
+// 0.2.0 is the first release that does. An unpinned install can resolve to a
+// release that reads dispatch metadata instead, which reaches the worker on
+// one of the four LiveKit dispatch paths — so on the other three a
+// simulation's spans arrive here as a production conversation.
+const INSTALL = "pip install 'egma>=0.2.0'";
 const HOOK = `from egma import monitor_livekit
 
 async def entrypoint(ctx):

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -303,7 +303,7 @@ const TYPES = {
         },
         {
           key: "metadata",
-          label: "Room metadata",
+          label: "Agent metadata",
           kind: "json",
           required: false,
           help: "JSON handed to the agent.",

--- a/apps/web/test/livekit-monitoring-instructions.test.tsx
+++ b/apps/web/test/livekit-monitoring-instructions.test.tsx
@@ -25,7 +25,7 @@ describe("LiveKit monitoring instructions", () => {
     expect(screen.getAllByRole("button", { name: "Copy" })).toHaveLength(3);
 
     const copy = container.textContent ?? "";
-    expect(copy).toContain("pip install egma");
+    expect(copy).toContain("pip install 'egma>=0.2.0'");
     expect(copy).toContain("from egma import monitor_livekit");
     expect(copy.indexOf("monitor_livekit(ctx)")).toBeLessThan(
       copy.indexOf("await session.start(...)"),

--- a/docs/concepts/agents-and-connections.mdx
+++ b/docs/concepts/agents-and-connections.mdx
@@ -92,6 +92,44 @@ voice-only and has two access variants:
 These variants control the same connection type. They are not different agent
 platforms.
 
+#### What your agent reads
+
+A `livekit_room.project_credentials` connection takes an optional `metadata`
+key: a JSON object written inside a string. Egma hands it to your agent on both
+of the channels LiveKit gives an agent for its per-session context.
+
+| Channel | Where your agent reads it | When |
+|---|---|---|
+| Room metadata | `ctx.room.metadata` | Always |
+| Dispatch metadata | `ctx.job.metadata` | When the connection names an agent |
+
+Naming an agent is what creates a dispatch for the value to ride on. A blank
+agent name is automatic dispatch, where LiveKit hands the room to whichever
+worker is listening and there is no dispatch to carry anything, so the room is
+the only channel there.
+
+The room carries your string byte for byte. The dispatch carries your keys
+unchanged and, underneath them, four names that say where Egma is:
+`simulationId`, `modality`, `egmaIdentity` and `protocolVersion`. Your own keys
+always win. If your configured JSON already uses one of those four names, or is
+not a JSON object at all, Egma drops the block and the dispatch carries your
+string alone. That block is read only by Egma Python SDK releases below `0.2.0`.
+It is not how the SDK finds a simulation, and it goes when those releases are
+gone.
+
+Egma writes nothing of the test into either channel. No scenario, no persona, no
+expected behavior, and no mock tool answer: an agent that could read its script
+would stop being under test. What tells Egma's SDK it is in a simulation is the
+room's name, not anything placed in your metadata — see
+[the Python SDK](/integrations/python-sdk#how-the-sdk-knows-it-is-in-a-simulation).
+
+The `livekit_room.customer_token_endpoint` variant takes no `metadata` and no
+agent name. Creating the room and dispatching the worker are both powers the
+project key pair buys, and that variant deliberately gives Egma neither, so both
+keys are refused when the connection is created rather than accepted and
+ignored. On that variant your own endpoint is the side that puts a worker in the
+room, so it is also the side that gives the worker anything to read.
+
 ## Create a connection through the API
 
 Create an agent with an inline Retell chat connection:

--- a/docs/concepts/telemetry.mdx
+++ b/docs/concepts/telemetry.mdx
@@ -71,8 +71,13 @@ OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer%20egma_your_project_key
 Install the Egma Python SDK:
 
 ```bash
-pip install egma
+pip install 'egma>=0.2.0'
 ```
+
+The helper reads the job's room name and keeps a simulation's spans out of
+Monitoring, so a test does not arrive here a second time as a production
+conversation. The `0.2.0` floor is what makes that hold on every LiveKit
+dispatch path. See [the Python SDK](/integrations/python-sdk#how-the-sdk-knows-it-is-in-a-simulation).
 
 Set the Egma API origin and an existing project API key:
 

--- a/docs/integrations/python-sdk.mdx
+++ b/docs/integrations/python-sdk.mdx
@@ -9,23 +9,31 @@ The `egma` Python package has two separate jobs:
 - `monitor_livekit(ctx)` sends production LiveKit spans to Egma Monitoring.
 - `await mockable(agent, ctx, session)` lets Egma answer selected tools during a simulation.
 
-Calling one function never enables or changes the other. `mockable` remains inert in production. `monitor_livekit` remains inert in a job that Egma dispatched for a simulation, so that simulation does not also appear as a production conversation.
+Calling one function never enables or changes the other. `mockable` remains inert in production. `monitor_livekit` remains inert in a job whose room Egma named for a simulation, so that simulation does not also appear as a production conversation.
+
+Both decide that from the same fact: [the room's name](#how-the-sdk-knows-it-is-in-a-simulation).
 
 This solves a real problem: a simulation that reaches your real tools has real side effects. It books the appointment, sends the message, charges the card. And a real backend only ever shows you the branch its data happens to be on — "the calendar is full", "the lookup fails", "the booking API errors" are where voice agents die in production, but none of them can be ordered up on demand from a real backend.
 
 ## Install
 
 ```bash
-pip install egma
+pip install 'egma>=0.2.0'
 ```
 
 Or with uv:
 
 ```bash
-uv add egma
+uv add 'egma>=0.2.0'
 ```
 
 Requires Python 3.11 or newer and `livekit-agents>=1.6.7,<1.7`.
+
+The floor is `0.2.0` because that is the first release in which both functions
+read the room's name. A LiveKit connection puts your worker in an Egma room along
+four dispatch paths; releases below the floor read dispatch metadata instead,
+which arrives on one of the four, so `0.2.0` is what makes mock tools and the
+monitoring guard hold on all of them.
 
 <Note>
   The `livekit-agents` version is pinned to one minor version intentionally. Mock tools use LiveKit's testing API. Monitoring must also read LiveKit's current tracer provider because its public telemetry API has a setter but no getter. The fixture and live tests verify both seams before the supported range changes. See [Version pinning](#version-pinning) below.
@@ -93,6 +101,23 @@ The helper stops with a direct, safe setup error when required settings are miss
 
 Monitoring stays empty until a trace reaches Egma, then lists each production conversation as it arrives. OTLP is one-way in this release, so Egma cannot see a DNS, firewall, or network failure inside the worker. If nothing appears, check the worker's OpenTelemetry logs and confirm that it can reach `EGMA_URL`.
 
+## How the SDK knows it is in a simulation
+
+Both functions ask one question, and they read the answer off the same place: **the name of the room the job was given.**
+
+Every room Egma holds a simulation in is named with the prefix `egma-sim-`. That prefix is a fixed, published contract. It does not change between releases, and it is the same on a self-hosted Egma as on the hosted one. Egma names the room before anything is dispatched into it, so the prefix is there on every one of the four dispatch paths that can put your worker in that room — Egma dispatching it by name, LiveKit's automatic dispatch handing it over, or your own token endpoint dispatching it.
+
+Egma joins that room as a participant named `egma-persona`, or `egma-persona-<simulation id>` where your own endpoint minted the token. That identity is the address `mockable` sends mock-tool calls to. It is published for the same reason and is fixed in the same way.
+
+Two things follow, and both are deliberate.
+
+- **Your dispatch metadata stays yours.** LiveKit teaches it as the channel for a caller's own context, so whatever you configure on the connection arrives there, and on the room's metadata, unchanged. Egma reads its own answer from the room's name instead of writing anything you would have to work around. On the one dispatch path where Egma dispatches your worker by name, a small block saying where Egma is — `simulationId`, `modality`, `egmaIdentity` and `protocolVersion` — rides *underneath* your own keys. Your keys always win: if your configured JSON already uses one of those four names, or is not a JSON object, Egma drops the block and sends your string alone. Nothing in this SDK reads it; only releases below `0.2.0` do, and it goes when they are gone. See [Agents and connections](/concepts/agents-and-connections).
+- **A room name is chosen by whoever mints the join token.** Where Egma holds your project key pair that is Egma; where you run a token endpoint that is your endpoint. So if you write your own guard on this prefix, refuse `egma-sim-` room names in your own production token minting, exactly as you would allowlist the prefix on the endpoint that serves Egma.
+
+<Note>
+  An Egma SDK below `0.2.0` reads `egmaIdentity` out of `ctx.job.metadata` instead, and so do some hand-written guards. Read the room name. `egmaIdentity` reaches your worker on one of the four dispatch paths, and even there Egma drops the block whenever your own configured metadata collides with it, so a guard on that key is silently false inside a real simulation. See [the interim recipe](#before-you-install-anything-the-interim-recipe).
+</Note>
+
 ## Use mock tools in simulations
 
 Import `mockable` and call it once in your agent's entrypoint, after the agent object exists and before `session.start`:
@@ -137,7 +162,7 @@ That is the whole integration.
 
 ## What `mockable` does
 
-`mockable` reads the dispatch metadata on `ctx.job` once. In any room without an Egma participant in it — which is every production room — it returns immediately having touched nothing. Your tools are the same objects, called the same way, with no wrapper between them and the model. This is enforced by a test in the package (`tests/test_inert.py`), not just described in documentation.
+`mockable` reads the room's name off `ctx.job` once, and reads nothing else. In a room Egma did not name — which is every production room — it returns immediately having touched nothing: no connect, no message, no wrapper between your tools and the model. This is enforced by a test in the package (`tests/test_inert.py`), not just described in documentation.
 
 In a simulation, `mockable`:
 
@@ -159,17 +184,25 @@ The SDK follows later `Agent` and `AgentTask` handoffs. Do not add another `mock
 
 The inert path is not a best-effort claim — it is a construction property with a test behind it.
 
-- **No Egma participant in the room** → `mockable` returns immediately. Zero added latency, no side effects, no wrapped tools.
+- **A room Egma did not name** → `mockable` returns immediately. Zero added latency, no side effects, no wrapped tools, and no connect it forced. This is every production room.
 - **Egma present but unreachable mid-simulation** → the real tool runs. A room that lost its Egma participant behaves as a room that never had one.
 - **Egma explicitly refuses a call** (unknown tool, malformed payload) → `ToolError` is raised so the model hears a tool that failed and can respond accordingly. Falling open on a refusal would mean a simulation has real side effects on Egma's behalf, which is never the right outcome.
 
 | Situation | Behavior |
 |---|---|
-| Production room (no Egma) | Returns immediately, nothing wrapped |
+| Production room | Returns immediately, nothing wrapped |
 | Simulation — tool has a mock | Egma answers; result returned to model |
 | Simulation — tool has no mock | Real tool runs |
 | Egma not reachable (fail-open) | Real tool runs |
 | Egma explicitly refuses (fail-closed) | `ToolError` raised to model |
+
+### What a simulation room costs before the greeting
+
+Inside an `egma-sim-` room, and only there, `mockable` connects the job to the room if your entrypoint has not already done so, and then waits for Egma's participant to appear and answer. Your agent's session starts after that.
+
+The wait is bounded at **45 seconds**: the 30 Egma allows itself to reach the room, plus a 15-second margin the SDK chooses for the two parts of Egma's journey that the 30 does not cover: on a connection where Egma asks your own token endpoint for a token, the time spent waiting on that endpoint before Egma starts connecting at all; and, at the far end, the sliver between Egma's participant becoming visible in the room and its two methods answering. It is normally over in well under a second, and it is long because the alternative is worse: a simulation that gave up early is a simulation where every mocked tool ran its real implementation — a real appointment booked, a real card charged. If the wait runs out, nothing is wrapped, the reason is logged at `ERROR`, and monitoring stays suppressed, because the room's name already said this was a simulation.
+
+None of this happens in a production room. It is the reason the room-name check comes first and costs nothing.
 
 ## How tool matching works
 
@@ -205,15 +238,11 @@ If `mock_tools` ever moves in a future version, the documented fallback is `Agen
 If you need tool isolation today without the Egma SDK, you can use LiveKit's own `mock_tools` with a guard you write yourself:
 
 ```python
-import json
 from livekit.agents import mock_tools
 
 
 def in_a_simulation(ctx: agents.JobContext) -> bool:
-    try:
-        return bool(json.loads(ctx.job.metadata or "{}").get("egmaIdentity"))
-    except ValueError:
-        return False
+    return ctx.job.room.name.startswith("egma-sim-")
 
 
 async def entrypoint(ctx: agents.JobContext) -> None:
@@ -231,11 +260,16 @@ async def entrypoint(ctx: agents.JobContext) -> None:
     await session.start(agent=agent, room=ctx.room)
 ```
 
-This is production-safe by the same logic — no Egma in the room means the guard is false and nothing is wrapped. But it has real limitations:
+This is production-safe by the same logic — a room Egma did not name means the guard is false and nothing is wrapped. But it has real limitations:
 
 - One canned answer per tool for every simulation. You cannot author different answers for different tests without editing your agent's source code.
 - Nothing about those tool calls reaches Egma's record: no arguments, no answers, no timings, no coverage stamp. Graders that read tool facts have nothing to read.
 - No declared delay, so latency numbers from a mocked run will flatter you.
-- The guard couples your agent to the exact shape of Egma's dispatch metadata today. If that shape changes, your agent breaks in a way your own tests would not catch. `mockable` exists to own that coupling so your side stays one line.
+- The guard is true in *any* room whose name starts with `egma-sim-`, including one Egma is not in. `mockable` waits for Egma's participant and gives up out loud; this guard has nobody to wait for and simply mocks.
+- It fires on the room name alone, so a production room named to look like a simulation runs your canned answers. Refuse the `egma-sim-` prefix wherever your own side mints production tokens.
+
+<Warning>
+  Write this guard on the room name, and not on `egmaIdentity` in `ctx.job.metadata`. Egma writes that block on one of the four dispatch paths — the one that dispatches your worker by name — and drops it even there when your own configured metadata already uses one of its four key names or is not a JSON object. A guard on it is therefore false inside real simulations, and it goes on being false without complaining: reading a missing key raises nothing, so whatever you gated behind it runs its real implementation against a live caller.
+</Warning>
 
 Use this as a bridge while migrating, not as a permanent solution.

--- a/docs/self-hosting.mdx
+++ b/docs/self-hosting.mdx
@@ -199,6 +199,38 @@ The API applies database migrations during boot. Internal credentials and
 Docker volumes are preserved for normal upgrades from this baseline forward.
 Deployment credentials continue to come from the current `.env` file.
 
+### The SDK and this checkout move together
+
+Your simulator is built from this repository. The Egma Python SDK that runs
+inside a customer's LiveKit worker comes from PyPI and upgrades on its own
+schedule, so the two can drift apart in either direction.
+
+Mock tools on every dispatch path need `egma>=0.2.0` in the worker **and** a
+simulator from this baseline or newer.
+
+A worker on an SDK below `0.2.0` reads a small context block out of its dispatch
+metadata, and the simulator still writes that block — but only on a connection
+that dispatches the worker by name, and only where the connection's own
+`metadata` leaves room for it. It is dropped where that configured JSON already
+uses `simulationId`, `modality`, `egmaIdentity` or `protocolVersion`: the
+customer's string rides alone, and the simulator logs a warning naming the keys
+that collided. That warning is where an old worker's lost mock tools are
+explained, so it is the line to search for when one comes up empty.
+
+So an older worker is inert inside a real simulation on the other three dispatch
+paths, and on the named-dispatch path too whenever the block is dropped: its
+real tools run against a live caller, and the simulation's coverage stamp is
+three empty lists. Raising the worker's pin to `0.2.0` is the one fix that holds
+on every dispatch path, and it is the half you do not control.
+
+Upgrading the worker first loses nothing. The `egma-sim-` room-name prefix and
+the `egma-persona` participant identity are frozen contracts, so a `0.2.0`
+worker reads the same two strings whichever simulator it meets.
+
+An out-of-date worker does not fail loudly. The coverage stamp on the run is
+where it shows, so pull this repository on your own schedule rather than waiting
+for a run to complain.
+
 <Warning>
   There is no in-place self-host upgrade from a build before the current
   database baseline, and Egma has no supported data-preserving upgrade for that

--- a/fixtures/livekit-dumb-agent/README.md
+++ b/fixtures/livekit-dumb-agent/README.md
@@ -58,11 +58,13 @@ await mockable(agent, ctx, session)
 ```
 
 It sits in `entrypoint`, after the agent and the session exist and before
-`session.start`. In a room Egma dispatched, it reports both tools by name
-and stands Egma in front of whichever ones the simulation has answers for.
-**In every other room it does nothing at all** — that is the SDK's whole
-safety story, and `tests/test_outside_egma.py` holds this agent to it
-rather than taking the SDK's word for it.
+`session.start`. In a room Egma named for a simulation — every one of them
+begins `egma-sim-` — it reports both tools by name and stands Egma in
+front of whichever ones the simulation has answers for. That holds on both
+dispatch styles, including the unnamed one where this worker is in the
+room before Egma is. **In every other room it does nothing at all** — that
+is the SDK's whole safety story, and `tests/test_outside_egma.py` holds
+this agent to it rather than taking the SDK's word for it.
 
 The `egma` dependency here is the copy in `sdks/python`, not the published
 package, so this fixture always exercises the seam as it stands on this

--- a/fixtures/livekit-dumb-agent/agent.py
+++ b/fixtures/livekit-dumb-agent/agent.py
@@ -33,12 +33,16 @@ a clock, a network or a disk.
 ## The one line that lets egma answer
 
 ``await mockable(agent, ctx, session)`` goes after the agent and the
-session exist and before the session starts. In a room egma dispatched, it
-reports these two tools by name and stands egma in front of whichever ones
-this simulation has answers for. **In every other room it does nothing at
-all** — no wrapper, no message, the same two callables — so this file
-behaves identically whether or not egma is anywhere near it, which is the
-property `tests/test_outside_egma.py` holds it to.
+session exist and before the session starts. In a room egma named for a
+simulation, it reports these two tools by name and stands egma in front of
+whichever ones this simulation has answers for. It does that on both
+dispatch styles below, including the unnamed one where this worker is in
+the room before egma is: the SDK reads the room's name, which arrives with
+the job either way, and waits for egma's own participant. **In every other
+room it does nothing at all** — no wrapper, no message, no connect, the
+same two callables — so this file behaves identically whether or not egma
+is anywhere near it, which is the property `tests/test_outside_egma.py`
+holds it to.
 
 ## The export that makes this agent visible in Egma
 

--- a/fixtures/livekit-dumb-agent/tests/conftest.py
+++ b/fixtures/livekit-dumb-agent/tests/conftest.py
@@ -28,10 +28,25 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 
 @dataclass
-class StubJob:
-    """A job, down to the one field the SDK reads of one."""
+class StubJobRoom:
+    """The room as the server described it to the worker."""
 
+    name: str
+
+
+@dataclass
+class StubJob:
+    """A job, down to the two fields the SDK reads of one."""
+
+    room: StubJobRoom
     metadata: str
+
+
+@dataclass
+class StubEgmaParticipant:
+    """Somebody in the room by egma's own name, who nothing should ask."""
+
+    identity: str = "egma-persona"
 
 
 @dataclass
@@ -45,13 +60,45 @@ class StubRoom:
     twice and hides which claim broke. Answering means an SDK that spoke
     in a production room goes on to succeed, quietly, and is caught by
     the one thing that would then be untrue — ``asked`` not being empty.
+
+    egma is in the participant list for the same reason. The SDK finds
+    egma by name among the people in the room, so a room with nobody in it
+    would make this suite pass by absence rather than by the room's name
+    being the customer's own.
     """
 
     asked: list[str] = field(default_factory=list)
+    connect_calls: int = 0
+    present: tuple[str, ...] = ("egma-persona",)
+
+    def __post_init__(self) -> None:
+        self.remote_participants = {
+            identity: StubEgmaParticipant(identity) for identity in self.present
+        }
+        self._listeners: list[Any] = []
 
     @property
     def local_participant(self) -> StubRoom:
         return self
+
+    def isconnected(self) -> bool:
+        return True
+
+    def on(self, event: str, callback: Any) -> Any:
+        if event == "participant_connected":
+            self._listeners.append(callback)
+        return callback
+
+    def off(self, event: str, callback: Any) -> None:
+        if callback in self._listeners:
+            self._listeners.remove(callback)
+
+    def arrive(self, identity: str) -> None:
+        """Put somebody in the room the way LiveKit announces one."""
+        participant = StubEgmaParticipant(identity)
+        self.remote_participants[identity] = participant
+        for callback in list(self._listeners):
+            callback(participant)
 
     async def perform_rpc(self, *, method: str, **_rest: Any) -> str:
         self.asked.append(method)
@@ -67,10 +114,32 @@ class StubContext:
     room: StubRoom
     job: StubJob
 
+    async def connect(self) -> None:
+        self.room.connect_calls += 1
 
-def outside_egma(metadata: str = "") -> StubContext:
-    """A job dispatched by anybody but egma, which is every production one."""
-    return StubContext(room=StubRoom(), job=StubJob(metadata=metadata))
+
+def outside_egma(
+    room_name: str = "maple-street-front-desk", metadata: str = ""
+) -> StubContext:
+    """A job in anybody's room but egma's, which is every production one."""
+    return StubContext(
+        room=StubRoom(),
+        job=StubJob(room=StubJobRoom(name=room_name), metadata=metadata),
+    )
+
+
+def inside_egma(room_name: str = "egma-sim-fixture-0001") -> StubContext:
+    """A job in a room egma named, with nobody in it yet.
+
+    Empty on purpose. Nothing dispatches this worker on egma's behalf
+    unless the practice configured a named agent, so the ordinary order is
+    that this agent is in the room first and egma walks in afterwards —
+    which is what ``StubRoom.arrive`` is for.
+    """
+    return StubContext(
+        room=StubRoom(present=()),
+        job=StubJob(room=StubJobRoom(name=room_name), metadata=""),
+    )
 
 
 @pytest.fixture

--- a/fixtures/livekit-dumb-agent/tests/test_census.py
+++ b/fixtures/livekit-dumb-agent/tests/test_census.py
@@ -15,10 +15,11 @@ so the count is asserted here rather than trusted to survive a tidy-up.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 
-from conftest import tools_on
-from egma import monitoring
+from conftest import inside_egma, tools_on
+from egma import mockable, monitoring
 
 from agent import FrontDesk
 
@@ -31,6 +32,30 @@ UNMOCKED_TOOL = "opening_hours"
 
 def test_the_agent_carries_both_tools_before_anything_is_wrapped():
     assert set(tools_on(FrontDesk())) == {MOCKABLE_TOOL, UNMOCKED_TOOL}
+
+
+async def test_this_agent_reports_its_tools_when_egma_walks_in_second(session):
+    """The dispatch path this fixture is silent on unless the SDK waits.
+
+    This worker registers unnamed by default, so nothing dispatches it on
+    egma's behalf: LiveKit walks it into the room as soon as the room
+    exists, which is before egma's own participant is in it. The room's
+    name is what says this is a simulation, and it says so from the first
+    line of the entrypoint — so the census still goes, and it goes to the
+    participant that arrives afterwards.
+    """
+    agent = FrontDesk()
+    context = inside_egma()
+
+    async def egma_walks_in() -> None:
+        await asyncio.sleep(0.05)
+        context.room.arrive("egma-persona")
+
+    joining = asyncio.create_task(egma_walks_in())
+    await mockable(agent, context, session)
+    await joining
+
+    assert context.room.asked == ["egma.hello"]
 
 
 def test_the_booking_shaped_tool_takes_the_day_it_is_asked_about():

--- a/fixtures/livekit-dumb-agent/tests/test_outside_egma.py
+++ b/fixtures/livekit-dumb-agent/tests/test_outside_egma.py
@@ -7,8 +7,8 @@ that is a different claim: a wiring mistake here would leave the SDK's own
 suite green and this fixture changed.
 
 Nothing here needs a room, a model or a key. A production room is a room
-with no egma named in its dispatch metadata, and that is a string, so the
-whole property is testable on a laptop with the network unplugged.
+egma did not name, and a room's name is a string, so the whole property is
+testable on a laptop with the network unplugged.
 """
 
 from __future__ import annotations
@@ -19,21 +19,35 @@ from egma import mockable
 
 from agent import AFTERNOON_SLOT, MORNING_SLOT, FrontDesk
 
-NO_EGMA = [
+NOT_AN_EGMA_ROOM = [
+    pytest.param("maple-street-front-desk", id="the practice's own room"),
+    pytest.param("", id="no room name at all"),
+    pytest.param("egma-simulator-demo", id="a name that merely starts alike"),
+    pytest.param("call-egma-sim-0001", id="the prefix in the middle"),
+]
+
+THE_PRACTICE_S_OWN_METADATA = [
     pytest.param("", id="no metadata at all"),
     pytest.param("   ", id="metadata of blanks"),
     pytest.param(
         '{"tenant":"maple-street","shift":"mornings"}', id="the practice's own"
     ),
     pytest.param("not json at all", id="metadata that is not json"),
+    pytest.param(
+        '{"egmaIdentity":"egma-persona"}',
+        id="the practice's own use of egma's key name",
+    ),
 ]
 
 
-@pytest.mark.parametrize("metadata", NO_EGMA)
-async def test_a_room_with_no_egma_in_it_leaves_this_agent_alone(metadata, session):
+@pytest.mark.parametrize("metadata", THE_PRACTICE_S_OWN_METADATA)
+@pytest.mark.parametrize("room_name", NOT_AN_EGMA_ROOM)
+async def test_a_room_egma_did_not_name_leaves_this_agent_alone(
+    room_name, metadata, session
+):
     agent = FrontDesk()
     before = agent.tools
-    context = outside_egma(metadata)
+    context = outside_egma(room_name, metadata)
 
     await mockable(agent, context, session)
 
@@ -49,9 +63,13 @@ async def test_a_room_with_no_egma_in_it_leaves_this_agent_alone(metadata, sessi
     # every production session a round trip before it could greet
     # anybody — and the substitution it installs afterwards is written
     # into a side table rather than onto the agent, so the objects above
-    # would still be the same ones. The room in this test would answer
-    # such a call happily. This empty list is what says none was made.
+    # would still be the same ones. The room in this test has egma in it
+    # and would answer such a call happily. This empty list is what says
+    # none was made.
     assert context.room.asked == []
+    # Nor was the room connected on egma's account. Where this agent
+    # connects, it connects for its own reasons.
+    assert context.room.connect_calls == 0
 
 
 async def test_the_tools_still_answer_out_of_this_file(session):

--- a/fixtures/livekit-dumb-agent/uv.lock
+++ b/fixtures/livekit-dumb-agent/uv.lock
@@ -444,7 +444,7 @@ wheels = [
 
 [[package]]
 name = "egma"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "../../sdks/python" }
 dependencies = [
     { name = "livekit-agents" },

--- a/packages/db/src/access/connection-registry.ts
+++ b/packages/db/src/access/connection-registry.ts
@@ -77,7 +77,8 @@ export type ConfigFieldMetadata = {
   /**
    * Keep a supporting config field after the credential fields when that is
    * the order a person needs to fill the form in. Most config comes first;
-   * this is only for a field such as room metadata that completes the setup.
+   * this is only for a field such as the agent metadata that completes the
+   * setup.
    */
   readonly afterCredentials?: true;
 };
@@ -672,14 +673,48 @@ function livekitServerUrl(key: string, value: unknown): string {
 }
 
 /**
+ * What LiveKit accepts in any one metadata field.
+ *
+ * The same 512 KiB ceiling covers room metadata, participant metadata and the
+ * metadata a job is dispatched with, so a value written once and carried on
+ * two of those channels is measured against one number.
+ */
+const LIVEKIT_METADATA_BYTES = 512 * 1024;
+
+/**
+ * What egma accepts, which is the ceiling less room to add to the value.
+ *
+ * The stored string is not the whole of what a dispatch carries: a small block
+ * of egma's own context is merged in beside the customer's keys for as long as
+ * SDKs that read it are still running. A value sized to the ceiling exactly
+ * would therefore pass here and be refused by LiveKit mid-simulation, which is
+ * the one outcome this gate exists to prevent. Eight kibibytes is far more
+ * than that block will ever be and costs nothing real: a metadata value is a
+ * tenant and a locale, and anything approaching either number is a payload
+ * that LiveKit's own guidance says to pass by id instead.
+ */
+const METADATA_BYTES = LIVEKIT_METADATA_BYTES - 8 * 1024;
+
+/**
  * A JSON object, carried as the text it was written as.
  *
- * Text rather than a parsed object because it travels verbatim — it is handed
- * to the agent as the room's metadata exactly as it arrives, and re-serialising
- * it here would hand over something the customer never wrote. Checked all the
- * same, and checked at create: a stray comma refused here is a person looking
- * at their own mistake, while the same comma refused at dispatch is a run that
- * has already started and an agent left to make sense of it.
+ * Text rather than a parsed object because one of the two channels it rides
+ * carries it verbatim: the room's metadata is this string exactly as it
+ * arrives, and re-serialising it here would hand the agent something the
+ * customer never wrote. The dispatch's copy is the customer's keys written out
+ * again beside a small block of egma's own, so the room's byte-for-byte
+ * promise is only keepable while the text itself is what gets stored. Checked
+ * all the same, and checked at create: a stray comma refused here is a person
+ * looking at their own mistake, while the same comma refused at dispatch is a
+ * run that has already started and an agent left to make sense of it.
+ *
+ * Size is checked here for that same reason, and it is measured against the
+ * copy that runs out of room first — the dispatch's, which is this string plus
+ * that block. A string LiveKit will not carry
+ * is a connection that opens a room, bills for it, and then fails every
+ * simulation on it at the dispatch — a refusal nobody can act on from the
+ * record it leaves. Measured in UTF-8 bytes, because that is what goes on the
+ * wire and not what a character count would suggest.
  */
 function jsonObjectText(key: string, value: unknown): string {
   const candidate = typeof value === "string" ? value.trim() : "";
@@ -695,6 +730,18 @@ function jsonObjectText(key: string, value: unknown): string {
       "not_admitted",
       `the config's ${key} must be a JSON object written in a string, which ` +
         `looks like {"tenant":"acme"}`,
+    );
+  }
+
+  const bytes = Buffer.byteLength(candidate, "utf8");
+  if (bytes > METADATA_BYTES) {
+    throw new AgentWriteRefusedError(
+      "not_admitted",
+      `the config's ${key} is ${bytes} bytes and egma admits at most ` +
+        `${METADATA_BYTES} on the room and the dispatch — livekit's own ` +
+        `ceiling is ${LIVEKIT_METADATA_BYTES} bytes, and egma holds the ` +
+        `difference back as room for the block it merges into the dispatch; ` +
+        `hold a large value in your own store and put its id here instead`,
     );
   }
   return candidate;
@@ -926,7 +973,14 @@ export const CONNECTION_REGISTRY: Readonly<
      * holds no key pair, so it cannot create a room, cannot dispatch a worker
      * and cannot delete anything — which is why `agentName` and `metadata` are
      * not among its keys. Both are powers a key pair buys, and a config key
-     * egma would silently ignore is worse than one it refuses by name.
+     * egma would silently ignore is worse than one it refuses by name. That
+     * holds for `metadata` on both of the channels it rides: creating the
+     * room that carries it and dispatching the worker that is handed it are
+     * the same one power, and the token-endpoint access variant has
+     * neither. Where a customer on that variant wants their agent to read
+     * something, their own
+     * endpoint is what puts it there — it is the side minting the token and
+     * dispatching the worker.
      */
     accessVariants: [
       {
@@ -942,7 +996,16 @@ export const CONNECTION_REGISTRY: Readonly<
           // listening takes the room, and that is the state every quickstart
           // agent runs in.
           agentName: optional(nonEmptyString),
-          // Handed to the agent as the room's metadata, exactly as written.
+          // Handed to the agent on both of the channels LiveKit gives it to
+          // read its per-session context from, and each channel carries the
+          // value to a different precision. The room's metadata is this
+          // string byte for byte, always. The dispatch's metadata is these
+          // keys and values written out again, beside a small block of egma's
+          // own, wherever `agentName` above names a worker to dispatch:
+          // whitespace the customer wrote is not preserved there, and no key
+          // of theirs is touched. Automatic dispatch creates no dispatch for
+          // it to ride on, so there the room is the only channel and this key
+          // reaches the agent at `ctx.room.metadata` alone.
           metadata: optional(jsonObjectText),
         },
         fields: [
@@ -960,9 +1023,9 @@ export const CONNECTION_REGISTRY: Readonly<
           },
           {
             key: "metadata",
-            label: "Room metadata",
+            label: "Agent metadata",
             kind: "json",
-            help: 'A JSON object handed to the agent as the room metadata, exactly as written, like {"tenant":"acme"}.',
+            help: 'A JSON object handed to your agent, like {"tenant":"acme"}. The room metadata at ctx.room.metadata carries your string byte for byte. When this connection names an agent above, the dispatch metadata at ctx.job.metadata carries your keys unchanged as well. Egma writes nothing of its own over your keys.',
             afterCredentials: true,
           },
         ],

--- a/packages/db/src/access/connection-registry.ts
+++ b/packages/db/src/access/connection-registry.ts
@@ -1002,8 +1002,10 @@ export const CONNECTION_REGISTRY: Readonly<
           // string byte for byte, always. The dispatch's metadata is these
           // keys and values written out again, beside a small block of egma's
           // own, wherever `agentName` above names a worker to dispatch:
-          // whitespace the customer wrote is not preserved there, and no key
-          // of theirs is touched. Automatic dispatch creates no dispatch for
+          // whitespace the customer wrote is not preserved there, anything
+          // outside ASCII is escaped so that a value with no UTF-8 form of
+          // its own can still go on the wire, and no key of theirs is
+          // touched. Automatic dispatch creates no dispatch for
           // it to ride on, so there the room is the only channel and this key
           // reaches the agent at `ctx.room.metadata` alone.
           metadata: optional(jsonObjectText),

--- a/packages/db/test/connection-catalog.test.ts
+++ b/packages/db/test/connection-catalog.test.ts
@@ -106,10 +106,17 @@ describe("what a browser is told about a simulation connection", () => {
       label: "LiveKit agent name",
       required: false,
     });
+    // The label and the help both name two channels, because the value rides
+    // on two: the room always, the dispatch wherever an agent name is given.
+    // A string promising only the room would send a customer looking for
+    // their JSON in one of the two places it can be.
     expect(fields.get("metadata")).toMatchObject({
+      label: "Agent metadata",
       required: false,
       afterCredentials: true,
     });
+    expect(fields.get("metadata")?.help).toContain("ctx.room.metadata");
+    expect(fields.get("metadata")?.help).toContain("ctx.job.metadata");
 
     const endpoint = connectionOptionMetadata().find(
       (one) => one.accessVariant === "livekit_room.customer_token_endpoint",

--- a/packages/db/test/connection-registry.test.ts
+++ b/packages/db/test/connection-registry.test.ts
@@ -247,9 +247,10 @@ describe("a LiveKit room connection's agent name", () => {
 
 describe("a LiveKit room connection's metadata", () => {
   /**
-   * It rides to the agent verbatim as the room's metadata, so a typo has to
-   * die here. Refused at create, a person is looking at the mistake; refused
-   * at dispatch, a run has already started and the agent is the one confused.
+   * It rides to the agent verbatim, on the room's metadata and on the
+   * dispatch's, so a typo has to die here. Refused at create, a person is
+   * looking at the mistake; refused at dispatch, a run has already started and
+   * the agent is the one confused.
    */
   it("may be left out, and is kept exactly as written when it is there", () => {
     const url = "wss://acme.livekit.cloud";
@@ -275,6 +276,45 @@ describe("a LiveKit room connection's metadata", () => {
         /config's metadata/,
       );
     }
+  });
+
+  /**
+   * LiveKit carries at most 512 KiB in a metadata field, and egma merges a
+   * small block of its own into the dispatch copy, so what is admitted here
+   * stops short of the ceiling. A value refused at the dispatch instead would
+   * be a room already opened and every simulation on the connection failing
+   * for a reason the record cannot act on.
+   *
+   * The number in the refusal is egma's, not LiveKit's, and the sentence has
+   * to say so. A customer who reads "livekit carries at most 520192" and then
+   * reads LiveKit's own documented 512 KiB is looking at two numbers that
+   * disagree with nothing to tell them which one refused their value, so the
+   * refusal names both limits and whose each one is.
+   */
+  it("refuses a value too large for livekit to carry, and says the size", () => {
+    const url = "wss://acme.livekit.cloud";
+    const roomy = `{"tenant":"${"a".repeat(520 * 1024)}"}`;
+    expect(() =>
+      validConfig("livekit_room", "livekit_room.project_credentials", { url, metadata: roomy }),
+    ).toThrow(/the config's metadata is \d+ bytes and egma admits at most \d+/);
+    expect(() =>
+      validConfig("livekit_room", "livekit_room.project_credentials", { url, metadata: roomy }),
+    ).toThrow(/livekit's own ceiling is 524288 bytes/);
+
+    // Measured in UTF-8 bytes rather than characters, because bytes are what
+    // goes on the wire: this one is a fifth of the ceiling in characters and
+    // over it in bytes, and a length check would let it through to the room.
+    const multibyte = `{"tenant":"${"€".repeat(200_000)}"}`;
+    expect(multibyte.length).toBeLessThan(504 * 1024);
+    expect(() =>
+      validConfig("livekit_room", "livekit_room.project_credentials", { url, metadata: multibyte }),
+    ).toThrow(/the config's metadata is \d+ bytes and egma admits at most \d+/);
+
+    // What a real value looks like beside those two: admitted whole.
+    const ordinary = `{"tenant":"acme","locale":"en-GB"}`;
+    expect(
+      validConfig("livekit_room", "livekit_room.project_credentials", { url, metadata: ordinary }),
+    ).toEqual({ url, metadata: ordinary });
   });
 });
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -14,8 +14,14 @@ Calling one function never enables or changes the other.
 ## Install
 
 ```bash
-pip install egma
+pip install 'egma>=0.2.0'
 ```
+
+`0.2.0` is the floor because it is the first release that knows a
+simulation by the room's name, and so the first that holds on every one of
+the four dispatch paths. An unpinned install can resolve to a release that
+reads the dispatch metadata instead, which is inert inside a real
+simulation on three of them.
 
 For a LiveKit agent on Python 3.11 or newer.
 
@@ -79,9 +85,14 @@ does not remove LiveKit Cloud observability or another existing span
 processor. It sends spans in batches and flushes the final batch when the
 LiveKit job stops.
 
-If this job was dispatched by Egma for a simulation, the helper returns
-without adding a production exporter. The simulation keeps its own trace and
-does not appear a second time in Monitoring.
+If this job runs in an Egma simulation room, the helper returns without
+adding a production exporter and says so at `WARNING`. The simulation keeps
+its own trace and does not appear a second time in Monitoring.
+
+The helper reads the room's name for that and nothing else. Every Egma
+simulation room is named `egma-sim-…`; a room named anything else gets the
+production exporter. The name arrives with the job, so this decision costs
+no network and happens before `ctx.connect()`.
 
 After deployment, open **Monitoring**. Nothing needs to be confirmed in Egma —
 the deployed helper is what sends spans, and the first production conversation
@@ -142,26 +153,64 @@ async def entrypoint(ctx: agents.JobContext) -> None:
 
 That is the whole simulation integration.
 
-`mockable` uses LiveKit's `JobContext.connect()` before its in-room RPC
-when an Egma simulation reaches it before the normal session connection.
-It does not reconnect an already-connected room, and it does not connect
-a production room.
+### How it knows it is in a simulation
 
-In a simulation, `mockable` reports your agent's tools to Egma — names
-and schemas, read off the agent object, so mock authoring starts from
-your real tool names instead of your memory of them — and learns which of
-them this simulation answers for. Calls to those tools go to Egma and
-come back with the authored answer. Every one of them lands on the
-simulation's record with its arguments, its answer, how long it took, and
-which mock tool answered.
+It reads the **room's name** off the job. Every room Egma conducts a
+simulation in is named `egma-sim-…`, and that prefix is fixed. Nothing
+else is read, nothing is asked, and no room is connected to find out.
 
-**In every other room it does nothing at all.** Egma names itself in the
-job's dispatch metadata; a room with no Egma in it — which is every
-production room — is a room where `mockable` returns having touched
-nothing. Your tools are the same objects, called the same way, with no
-wrapper between them and the model. Zero added latency, by construction
-rather than by care. That property is a test in this package
-(`tests/test_inert.py`), not a promise in this file.
+The name is the signal because it is the one that arrives on every
+dispatch path an agent can end up in an Egma room by — whether Egma
+dispatches your worker by name, whether LiveKit walks an unnamed worker
+into the room, and whether your own token endpoint puts the agent there.
+A signal carried by an explicit dispatch arrives on only the first of
+those.
+
+In a simulation room, `mockable` connects the job with LiveKit's own
+`JobContext.connect()` if your startup has not already done so, then finds
+Egma among the room's participants: Egma joins as `egma-persona` or
+`egma-persona-<simulation>`. On three of the four dispatch paths your
+agent is in the room **before** Egma, so it waits for that participant,
+for up to 45 seconds and without polling anything outside the room. That
+is a long time to hold an agent before it greets anybody, and it is the
+price of the wait being correct on every dispatch path rather than on one;
+a simulation ordinarily pays a fraction of it. It does not reconnect an
+already-connected room, and it never connects a production room.
+
+If nobody by that name arrives, nothing is wrapped, your tools all run
+their own implementations, and the reason is logged at `ERROR`. If two
+participants answer to that name, the exchange is refused for the same
+reason a room with two claimants has no knowable answer — and your tool
+inventory is not sent to either of them.
+
+Then `mockable` reports your agent's tools to Egma — names and schemas,
+read off the agent object, so mock authoring starts from your real tool
+names instead of your memory of them — and learns which of them this
+simulation answers for. Calls to those tools go to Egma and come back with
+the authored answer. Every one of them lands on the simulation's record
+with its arguments, its answer, how long it took, and which mock tool
+answered.
+
+**In every other room it does nothing at all.** A room your own system
+named — which is every production room — is a room where `mockable`
+returns having touched nothing: no wrapper, no message, no connect. Your
+tools are the same objects, called the same way, with no wrapper between
+them and the model. Zero added latency, by construction rather than by
+care. That property is a test in this package (`tests/test_inert.py`),
+not a promise in this file.
+
+Your job's **dispatch metadata is yours**. This SDK writes nothing into it
+and reads nothing out of it — not one key, in any room, for any purpose.
+
+Egma itself does still add to it, on one of the four dispatch paths. Where
+Egma dispatches your worker by name, it merges four keys *underneath your
+own* configured JSON — `simulationId`, `modality`, `egmaIdentity` and
+`protocolVersion` — for the benefit of SDK releases below `0.2.0`, which
+read them. **Your own keys always win**: if your configured metadata
+already uses any of those four names, or is not a JSON object, your string
+rides alone byte for byte and the block is dropped whole. On the other
+three dispatch paths there is no dispatch to carry it, so nothing of
+Egma's is added at all.
 
 ### Where to call it
 
@@ -199,22 +248,23 @@ Everything this package says goes to the `egma` logger. It is worth
 having on at `INFO` the first time you wire an agent up: the line after
 the census names how many tools you have and how many Egma answers for.
 
+`ERROR` is reserved for a simulation that could not be isolated and can
+be acted on — no Egma participant arrived in a simulation room, two
+participants claimed to be Egma, or the two halves do not speak the same
+version of the exchange. None of those lines is reachable in a production
+room.
+
 ## Before you install anything: the interim recipe
 
 You can get isolation today with no Egma code at all, using LiveKit's own
 `mock_tools` and a guard you write yourself:
 
 ```python
-import json
-
 from livekit.agents import mock_tools
 
 
 def in_a_simulation(ctx: agents.JobContext) -> bool:
-    try:
-        return bool(json.loads(ctx.job.metadata or "{}").get("egmaIdentity"))
-    except ValueError:
-        return False
+    return ctx.job.room.name.startswith("egma-sim-")
 
 
 async def entrypoint(ctx: agents.JobContext) -> None:
@@ -232,8 +282,25 @@ async def entrypoint(ctx: agents.JobContext) -> None:
     await session.start(agent=agent, room=ctx.room)
 ```
 
-This is production-safe by the same absence logic: no Egma in the room
-means the guard is false and nothing is wrapped.
+A room your own system named means the guard is false and nothing is
+wrapped. Note where that safety comes from, because it is not where
+`mockable`'s comes from: this guard fires on a prefix being *present*
+rather than on Egma being *absent*. So it is true in any room whose name
+begins `egma-sim-`, including one Egma is not in — `mockable` waits for
+Egma's participant and gives up out loud, while this guard has nobody to
+wait for and simply mocks. Refuse that prefix wherever your own side mints
+production tokens, or a production room named to look like a simulation
+runs your canned answers against a live caller.
+
+**Write the guard on the room name, and not on `egmaIdentity` in
+`ctx.job.metadata`.** That key is present in only some simulation rooms.
+Egma puts it into your dispatch metadata on the one dispatch path where it
+dispatches your worker by name, and it drops that whole block even there
+whenever your own configured metadata already uses one of its four key
+names or is not a JSON object; on the other three dispatch paths there is
+no dispatch to carry it. A guard on it does not raise — it quietly fails
+to fire, and every real tool it was meant to hold back runs inside a
+simulation.
 
 What it cannot do is the rest of the job. One canned world for every
 test, so you cannot write "the calendar is full" as a *test* — you would
@@ -242,15 +309,30 @@ those calls reaches Egma's record: no arguments, no answers, no timings,
 no coverage stamp, so graders that read tool facts have nothing to read.
 No declared delay, so latency numbers from a mocked run flatter you.
 
-**And the honest caveat: that guard couples your agent's source to the
-exact shape of Egma's dispatch metadata today.** If the metadata grows or
-moves, your agent breaks in a way no test of yours would catch. That
-coupling is precisely what `mockable` exists to own — the shape stays
-Egma's to evolve, and your side stays one line.
+**And the honest caveat: that guard couples your agent's source to how
+Egma announces itself.** The room-name prefix is a stated contract rather
+than an implementation detail, so it is the safe thing to key off — but
+the *rest* of the mechanism is not: where Egma sits in the room, what
+it is called, how long it takes to arrive, and what a room with two
+claimants means are all Egma's to evolve. That is precisely what
+`mockable` exists to own, and your side stays one line.
 
 Use the recipe as the bridge, not as the small tier.
 
 ## Compatibility
+
+The `egma-sim-` room-name prefix is a stated contract, not an internal
+detail. Every room Egma opens for a simulation begins with it, on every
+dispatch path, and it is there to be relied on and to be allowlisted in
+a token endpoint. This SDK keys its whole simulation/production decision
+off it.
+
+Every Egma deployment names its rooms that way, so this package works
+against a self-hosted Egma on whatever schedule its owner upgrades it.
+Nothing else is consulted — in particular, it never reads the context
+block Egma still merges into named-dispatch metadata for SDK releases
+below `0.2.0`. One of those key names in *your* metadata is your key, and
+it changes nothing here.
 
 This package pins `livekit-agents` to one minor version
 (`>=1.6.7,<1.7`), and that is deliberate. Interception uses LiveKit's

--- a/sdks/python/package.json
+++ b/sdks/python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egma/sdk-python",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "description": "pnpm's door into the Python package customers install: the real toolchain is uv. See README.md.",
   "scripts": {

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "egma"
-version = "0.1.1"
+version = "0.2.0"
 description = "Test and monitor LiveKit agents with Egma."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdks/python/src/egma/__init__.py
+++ b/sdks/python/src/egma/__init__.py
@@ -13,9 +13,9 @@ the agent is built and before the session starts::
 
     await mockable(agent, ctx, session)
 
-In a room with no egma participant — every production room — it returns
-having touched nothing. Your tools are the same objects, called the same
-way, with no wrapper between them and the model. That is a test in this
+In a room egma did not name — every production room — it returns having
+touched nothing. Your tools are the same objects, called the same way,
+with no wrapper between them and the model. That is a test in this
 package, not a promise in this docstring.
 
 Production monitoring is a separate explicit call made before the session

--- a/sdks/python/src/egma/mockable.py
+++ b/sdks/python/src/egma/mockable.py
@@ -10,24 +10,63 @@ Call it once, after the agent is built and before the session starts::
         await mockable(agent, ctx, session)
         await session.start(agent=agent, room=ctx.room)
 
-## What it does, in order
+## How it knows it is in a simulation
 
-It reads the dispatch metadata **once**. A room with no egma context in
-it — every production room — is where this returns having touched
-nothing at all: no wrapping, no side table, no call. That inertness is
-the whole safety story, and it is a test in this package rather than a
-promise in a document.
+It reads the **room's name** off the job, before it connects anything and
+without asking anybody. Every room egma conducts a simulation in is named
+``egma-sim-…``, and that prefix is fixed and published. A room named
+anything else — which is every production room — is where this returns
+having touched nothing at all: no wrapping, no side table, no message, no
+connect. That inertness is the whole safety story for production, and it
+is a test in this package rather than a promise in a document.
 
-In a simulation it connects the job to its LiveKit room, if the agent's
-normal startup has not already done so. This uses ``JobContext.connect``
-before reading the room's local participant; an already-connected job is
-left alone.
+The name is read rather than the job's dispatch metadata because dispatch
+metadata belongs to the customer. LiveKit teaches it as the channel for a
+caller's own identifiers, so anything of egma's written there both
+collides with what a customer already reads and, worse, arrives on only
+one of the four dispatch paths that can put an agent in an egma room: it
+is carried by an explicit dispatch, and three of the four paths have
+none. A room name arrives on all four. Mock tools and the monitoring
+guard therefore hold on all four, instead of on the one dispatch path
+where egma dispatches the worker itself.
 
-In a simulation it sends the **census** first: every tool the initial
-agent has, by name and schema, read off the agent object. That is the
-first message of the exchange on purpose — an egma that is not there is
-discovered here, before a single tool call, rather than half way through
-a simulation with somebody waiting on the line.
+It is also the only signal. Nothing in that metadata is read as a second
+way of saying "simulation", because a second way could catch no
+simulation room the prefix does not already catch — every one of them
+carries it, on all four dispatch paths — and could only add rooms that
+are not simulations at all. A production room whose own JSON happened to
+use the same key names would have its tools wrapped and its spans held
+back from production Monitoring, and a dropped trace is evidence a
+customer cannot get back. One signal that is honest about being weak
+beats two where the second can only be wrong.
+
+## What it does in a simulation, in order
+
+It connects the job to its LiveKit room, if the agent's normal startup has
+not already done so. This is the one connect this SDK forces, it happens
+only in a room whose name already said simulation, and it is a stated
+consequence rather than an implementation detail: reading a room's
+participants needs a connected room, and on three of the four dispatch
+paths the agent is in the room **before** egma is.
+
+It then finds egma among the room's remote participants, by name. egma
+joins as ``egma-persona`` or as ``egma-persona-<simulation>``, so exactly
+those two forms are matched and nothing else is. Because the room's name
+has already established that this is a simulation, this side may **wait**
+for that participant — bounded, woken by the room's own arrival event,
+and never reached in a production room. Where two participants answer to
+that name the exchange is refused rather than guessed at: a room with two
+claimants is a room where the answer is not knowable, and the loser of
+that guess would be handed this agent's whole tool inventory.
+
+It sends the **census** next: every tool the initial agent has, by name
+and schema, read off the agent object. That is the first message of the
+exchange on purpose — an egma that is not answering is discovered here,
+before a single tool call, rather than half way through a simulation with
+somebody waiting on the line. A census the far side answers with
+``UNSUPPORTED_METHOD`` is asked again until the bound runs out, because
+egma registers the exchange after it joins and this side can arrive in
+between; every other refusal is taken at its word.
 
 egma answers with the names it covers, and one **courier** is stood in
 front of each. Couriers go in through LiveKit's own ``mock_tools``, which
@@ -48,6 +87,15 @@ call installs couriers for the selected class, then reports a cumulative
 census containing every tool discovered in the session so far. Returning
 to an earlier agent never removes tools from Egma's coverage record.
 
+## Which version of the exchange either side speaks
+
+Nothing here pre-checks it. The version rides the hello in both
+directions and :func:`egma.seam.mocked_tools_in` refuses a reply in a
+version this SDK does not speak, which is the only reading that stays
+true when the two halves are deployed apart. A number carried anywhere
+else would be a second answer to the same question, and the second answer
+is the one that goes stale.
+
 ## What a courier does with one call
 
 It asks egma, and hands back what egma answers. Around that:
@@ -64,7 +112,7 @@ It asks egma, and hands back what egma answers. Around that:
   default is shorter than a delay a mock tool may legally declare.
 - It **runs the real tool** when the transport says egma was never
   reached. A room that lost its egma participant behaves as a room that
-  never had one, which is the same fail-open the absent-metadata path
+  never had one, which is the same fail-open the production-room path
   takes one level up.
 - It **raises what egma refuses**, as the tool's own error, so the model
   sees a tool that failed and can say so. egma's refusals are honest
@@ -77,20 +125,22 @@ this file is written around.
 
 ## What it deliberately does not do
 
-It never aborts the agent. Where egma is present but will not talk — a
-version neither side shares, a reply in a shape this SDK cannot read —
-the couriers are simply not installed, the agent's own tools run, and it
-is said out loud in the log. egma's record already tells that truth from
-its own side: a hello it refused covers nothing, so the coverage stamp
-shows those tools uncovered rather than isolated. Taking the customer's
-agent down to make the same point would only lose the simulation as well.
+It never aborts the agent. Where egma cannot be reached or will not talk
+— a room that would not open, a room where nobody by that name ever
+arrived, a version neither side shares, a reply in a shape this SDK
+cannot read — the couriers are simply not installed, the agent's own
+tools run, and it is said out loud in the log.
+egma's record already tells that truth from its own side: a hello it
+refused covers nothing, so the coverage stamp shows those tools uncovered
+rather than isolated. Taking the customer's agent down to make the same
+point would only lose the simulation as well.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
-import json
 import logging
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -118,6 +168,119 @@ from . import seam
 
 logger = logging.getLogger("egma")
 
+SIMULATION_ROOM_PREFIX = "egma-sim-"
+"""What every room egma conducts a simulation in is named.
+
+Fixed and published, which is the only reason a customer's SDK may key
+off it: egma mints ``egma-sim-<run>`` itself where it holds the project's
+keys, and asks the customer's own token endpoint for the same name where
+it does not, so the prefix is on the room on all four dispatch paths that
+can put an agent into one.
+
+It is a weaker anchor than it looks and this side says so rather than
+pretending otherwise. A room name is chosen by whoever mints the join
+token, and on the token-endpoint access variant that is an internet-facing
+endpoint whose whole contract is "the caller names the room". So the
+prefix is trusted for the two things a wrong answer merely wastes — the
+decision to look for egma at all, and the decision to keep this job's
+spans out of production Monitoring — and it is never, by itself, what
+this SDK hands a tool inventory to. That is the participant below, and
+the tension is real: closing it properly needs egma's own control plane
+to confirm the room, which is not a thing this side can do alone today.
+"""
+
+EGMA_IDENTITY = "egma-persona"
+"""Who egma is in the room: the address every message is sent to.
+
+Two forms, because egma joins under two: exactly this where egma mints
+its own token, and this with the simulation appended where a customer's
+token endpoint mints it. Both are matched, and nothing that merely begins
+with these letters is — an identity is either the name or the name with a
+``-`` and a simulation after it.
+
+Matching two forms rather than one exact string is the concession this
+side makes to egma joining under two, and it costs the guarantee LiveKit
+would otherwise give for free: one identity is unique per room, so an
+impersonator taking the exact name would be evicted by the server, while
+one taking a name merely *like* it sits quietly beside the real thing.
+That is why more than one match is refused outright below rather than
+resolved by picking the first.
+"""
+
+EGMA_CONNECT_SECONDS = 30.0
+"""How long egma allows itself to get into the room.
+
+One of egma's own bounds, restated here rather than imported. This
+package is the half a customer installs, so it may not reach back into
+egma's services for a constant — the same reason :mod:`egma.seam` gives
+for writing the exchange twice. The number it restates is
+``CONNECT_SECONDS`` in the simulator's ``media/room.py``, and a
+simulation whose room does not open inside it ends saying so.
+"""
+
+ARRIVAL_MARGIN_SECONDS = 15.0
+"""What this side allows on top, for the part of the journey with no bound.
+
+**Chosen, not derived, and said to be so.** The two things it covers have
+no constant on egma's side to restate, and a derivation from a number
+nobody wrote down is a number nobody can check.
+
+What it covers is the time before the bound above even starts running,
+plus the sliver at the far end of it:
+
+- On the token-endpoint access variant egma does not hold the project's
+  keys, so before it can begin connecting it must ask the customer's own
+  endpoint for a token. egma allows that request 20 seconds of its own
+  (``TOKEN_SECONDS`` in the simulator's ``media/livekit_room.py``), and
+  none of it is part of the connect above.
+- egma's participant becomes visible in the room a moment before its two
+  methods answer, because the room announces an arrival to everybody in
+  it before the joining side's own connect handler has run. egma
+  registers the methods in that handler, which is the earliest it can, so
+  the window is small — but it is not nothing, and it is the window
+  :data:`egma.seam.EGMA_NOT_LISTENING_YET` exists to sit out.
+
+It does not cover the worst case of the first bullet, and that is a trade
+rather than an oversight: a token endpoint that takes all 20, followed by
+a connect that takes all 30, is 50 seconds against the 45 below. What
+runs out here is not a failure this side has to survive intact — it is a
+fail-open, said out loud in the log — and holding a customer's agent
+silent in front of a caller for longer than the sum below is the worse of
+the two outcomes. Both numbers are here to be revised together if a real
+simulation is ever found to have run out of them.
+"""
+
+STARTUP_SECONDS = EGMA_CONNECT_SECONDS + ARRIVAL_MARGIN_SECONDS
+"""How long this SDK may spend finding egma before it gives up. 30 + 15 = 45.
+
+Added up rather than picked, because the worst case this has to cover is
+an agent whose job starts at the very moment egma begins connecting —
+which is the ordinary case on three of the four dispatch paths. Written
+as the sum rather than as its answer so the two halves stay separately
+checkable: the 30 against egma's own constant, the 15 against the
+sentence above that says what it is for and what it deliberately leaves
+uncovered.
+
+One deadline covers both halves of the search, the wait for egma's
+participant and the retries against a participant that has not registered
+the exchange yet, so the whole of this call is bounded by this number
+however the time inside it is spent.
+
+It is a long time to hold an agent before it greets anybody, and that is
+the trade taken deliberately: the alternative to waiting is a simulation
+in which every mocked tool ran its real implementation, which is a real
+appointment booked and a real card charged. Nothing waits here unless the
+room's name says simulation, so a production room pays none of it.
+"""
+
+POLL_SECONDS = 0.25
+"""How long to sleep between looks, when nothing has woken this side.
+
+The room's own arrival event is what makes finding egma prompt; this is
+the floor under it, so a transport that renames that event degrades to
+slow rather than to broken.
+"""
+
 RAW_ARGUMENTS = "raw_arguments"
 """The one parameter a raw-schema tool takes: the call's arguments, whole.
 
@@ -134,21 +297,11 @@ async def mockable(agent: Agent, ctx: JobContext, session: AgentSession) -> None
     egma's account: what it cannot arrange, it says in the log and leaves
     alone.
     """
-    context = _egma_context(ctx)
-    if context is None:
+    simulation = _simulation_in(ctx)
+    if simulation is None:
         logger.debug(
-            "no Egma context in this job's dispatch metadata, so nothing is "
+            "this job's room is not an Egma simulation room, so nothing is "
             "wrapped and every tool runs its own implementation"
-        )
-        return
-
-    if not _speaks_this_version(context.protocol_version):
-        logger.error(
-            "Egma speaks protocol version %r here and this SDK speaks %d, so "
-            "no mock tool can be served: every tool ran its own "
-            "implementation. Upgrade the Egma SDK",
-            context.protocol_version,
-            seam.PROTOCOL_VERSION,
         )
         return
 
@@ -161,6 +314,9 @@ async def mockable(agent: Agent, ctx: JobContext, session: AgentSession) -> None
         # complaint about a message too big arrives as a census that
         # mysteriously failed, where this one names what outgrew it —
         # which for a census is an agent with a great many tools.
+        #
+        # Measured before the connect as well, so an agent that can never
+        # report its tools does not pay for a room it will not use.
         seam.fits_on_the_wire("this agent's census of tools", census)
     except seam.SeamError as too_much:
         logger.error(
@@ -170,15 +326,37 @@ async def mockable(agent: Agent, ctx: JobContext, session: AgentSession) -> None
         )
         return
 
-    if not ctx.room.isconnected():
-        await ctx.connect()
+    # The one deadline. It starts here rather than at the first wait,
+    # because what it has to cover is egma's own journey into the room and
+    # that began when this job did.
+    deadline = asyncio.get_running_loop().time() + STARTUP_SECONDS
 
-    seat = _Seat(room=ctx.room, identity=context.identity)
+    if not ctx.room.isconnected():
+        try:
+            await ctx.connect()
+        except Exception:
+            # The one connect this SDK forces is also the one place it
+            # could take an agent down that was going to connect for
+            # itself a moment later. It does not: a room this side could
+            # not open is a room it cannot find egma in, which is the
+            # fail-open every other unreachable-egma branch takes.
+            logger.exception(
+                "simulation %s: this room could not be connected, so nothing "
+                "is wrapped and every tool runs its own implementation",
+                simulation.named,
+            )
+            return
+
+    identity = await _egma_in_the_room(ctx.room, deadline, simulation)
+    if identity is None:
+        return
+
+    seat = _Seat(room=ctx.room, identity=identity)
     try:
-        answered = await seat.ask(seam.HELLO_METHOD, census)
+        answered = await _asked_until_egma_is_listening(seat, census, deadline)
         mocked = seam.mocked_tools_in(answered)
     except RpcError as refused:
-        _hello_refused(refused, context)
+        _hello_refused(refused, identity)
         return
     except seam.SeamError as unreadable:
         logger.error(
@@ -190,11 +368,11 @@ async def mockable(agent: Agent, ctx: JobContext, session: AgentSession) -> None
         return
 
     couriers = _install_couriers(agent, mocked, seat, session)
-    _install_handoff_couriers(agent, mocked, seat, session, context)
+    _install_handoff_couriers(agent, mocked, seat, session, simulation)
     logger.info(
         "simulation %s: the agent reported %d tool(s) and Egma answers for "
         "%d of them (%s); every other tool runs its own implementation",
-        context.simulation_id,
+        simulation.named,
         len(tools),
         len(couriers),
         ", ".join(couriers) or "none",
@@ -221,7 +399,7 @@ def _install_handoff_couriers(
     mocked: Sequence[str],
     seat: _Seat,
     session: AgentSession,
-    context: _EgmaContext,
+    simulation: _Simulation,
 ) -> None:
     """Cover each agent LiveKit selects before that agent starts running.
 
@@ -267,7 +445,7 @@ def _install_handoff_couriers(
                 logger.exception(
                     "simulation %s: Egma could not prepare LiveKit's selected "
                     "%s; that agent will run its own tools",
-                    context.simulation_id,
+                    simulation.named,
                     type(current).__name__,
                 )
                 return
@@ -275,7 +453,7 @@ def _install_handoff_couriers(
             logger.info(
                 "simulation %s: LiveKit handed off to %s; Egma answers for %d "
                 "tool name(s) on that agent (%s)",
-                context.simulation_id,
+                simulation.named,
                 type(current).__name__,
                 len(couriers),
                 ", ".join(couriers) or "none",
@@ -299,20 +477,20 @@ def _install_handoff_couriers(
                         if previous_refresh is not None:
                             await previous_refresh
                         await _refresh_census(
-                            cumulative_census, active_mocked, seat, context
+                            cumulative_census, active_mocked, seat, simulation
                         )
                     except (RpcError, seam.SeamError) as refused:
                         logger.warning(
                             "simulation %s: the cumulative tool census could not "
                             "be refreshed (%s); its already-installed couriers remain",
-                            context.simulation_id,
+                            simulation.named,
                             refused,
                         )
                     except Exception:
                         logger.exception(
                             "simulation %s: the cumulative tool census could not "
                             "be refreshed; its already-installed couriers remain",
-                            context.simulation_id,
+                            simulation.named,
                         )
 
                 refresh_tail = asyncio.create_task(refresh_in_handoff_order())
@@ -322,7 +500,7 @@ def _install_handoff_couriers(
                 logger.exception(
                     "simulation %s: Egma installed this handoff's couriers but "
                     "could not add its tools to the cumulative census",
-                    context.simulation_id,
+                    simulation.named,
                 )
         except Exception:
             # LiveKit's event emitter re-raises TypeError from synchronous
@@ -330,7 +508,7 @@ def _install_handoff_couriers(
             logger.exception(
                 "simulation %s: Egma's LiveKit handoff hook failed; LiveKit "
                 "will continue without new courier state from this event",
-                context.simulation_id,
+                simulation.named,
             )
 
     def on_close(_: Any) -> None:
@@ -350,17 +528,19 @@ async def _refresh_census(
     reported_tools: Sequence[dict[str, Any]],
     expected_mocked: Sequence[str],
     seat: _Seat,
-    context: _EgmaContext,
+    simulation: _Simulation,
 ) -> None:
     """Report every tool discovered so far without changing the mock world."""
     census = seam.hello_request(list(reported_tools))
     seam.fits_on_the_wire("the cumulative handoff census", census)
-    answered = await seat.ask(seam.HELLO_METHOD, census)
+    answered = await seat.ask(
+        seam.HELLO_METHOD, census, seam.HELLO_TIMEOUT_SECONDS
+    )
     answered_mocked = seam.mocked_tools_in(answered)
     logger.info(
         "simulation %s: the cumulative census now reports %d tool(s) and "
         "Egma answers for %d of them (%s)",
-        context.simulation_id,
+        simulation.named,
         len(reported_tools),
         len(answered_mocked),
         ", ".join(answered_mocked) or "none",
@@ -369,7 +549,7 @@ async def _refresh_census(
         logger.warning(
             "simulation %s: Egma changed the mock-tool names in a later "
             "census; this session keeps the names negotiated at startup",
-            context.simulation_id,
+            simulation.named,
         )
 
 
@@ -392,91 +572,298 @@ class _Seat:
     room: Any
     identity: str
 
-    async def ask(self, method: str, payload: str) -> str:
+    async def ask(
+        self, method: str, payload: str, response_timeout: float | None = None
+    ) -> str:
         return await self.room.local_participant.perform_rpc(
             destination_identity=self.identity,
             method=method,
             payload=payload,
-            response_timeout=seam.RESPONSE_TIMEOUT_SECONDS,
+            response_timeout=(
+                seam.RESPONSE_TIMEOUT_SECONDS
+                if response_timeout is None
+                else response_timeout
+            ),
             max_round_trip_latency=seam.MAX_ROUND_TRIP_SECONDS,
         )
 
 
 @dataclass(frozen=True)
-class _EgmaContext:
-    """Where egma is, read off the dispatch metadata and nowhere else.
+class _Simulation:
+    """That this room is one, and what this side may call it.
 
-    Three facts, and every one of them is about *where egma is* rather
-    than what the test asks. There is no test content in dispatch
-    metadata by design — an agent that could read its own script would
-    stop being under test — so nothing here could leak one if it tried.
+    One fact, and it is about the *room* rather than about what the test
+    asks. A room's name could carry no test content by design — an agent
+    able to read its own script would stop being under test — so nothing
+    here could leak one if it tried.
+
+    It is a type rather than a bare string because the question this
+    answers is "is this a simulation", and ``None`` for a production room
+    says that in one reading at every call site.
     """
 
-    identity: str
-    """Who egma is in this room: the address every call is sent to, and
-    the whole of the authorisation. A room with nobody by this name has
-    nobody to ask, which is every production room."""
-
-    simulation_id: str
-    """Which simulation this room conducts. Logged, so a developer can
-    line their own worker's logs up with egma's record."""
-
-    protocol_version: object
-    """Which version of the exchange egma speaks here. Kept as it arrived
-    rather than coerced, so a mismatch can be named in the words it came
-    in."""
+    named: str
+    """What to call this simulation in a log line, so a developer can line
+    their own worker's output up with egma's record. The room's name,
+    which is the whole of what this side was told and the whole of what it
+    needs."""
 
 
-def _speaks_this_version(declared: object) -> bool:
-    """Whether that is the version of the exchange this SDK speaks.
+def _simulation_in(ctx: JobContext) -> _Simulation | None:
+    """Whether this job conducts an egma simulation: the room's name, alone.
 
-    A boolean is refused explicitly. Python counts ``True`` as equal to
-    ``1``, so a metadata field carrying ``true`` would otherwise be read
-    as version 1 and this SDK would go on to speak an exchange nobody
-    declared.
+    Nothing is the ordinary case, and it is reached without a network, a
+    connect or a single message: a production room is a room whose name is
+    the customer's own, and every way of not being an egma room ends here
+    the same way.
+
+    One signal on purpose. The other thing this side could read is the
+    job's dispatch metadata, and that channel is the customer's own — so a
+    second reading could add no simulation room the prefix does not
+    already cover, and could only take a room that is *not* a simulation
+    and treat it as one. This decision suppresses a job's production
+    telemetry as well as wrapping its tools, and a trace dropped on a
+    false positive is evidence nobody can get back.
     """
-    if isinstance(declared, bool) or not isinstance(declared, int):
-        return False
-    return declared == seam.PROTOCOL_VERSION
-
-
-def _egma_context(ctx: JobContext) -> _EgmaContext | None:
-    """egma's context for this job, or nothing where there is none.
-
-    Nothing is the ordinary case: production dispatch metadata is the
-    customer's own, or empty, and either way it names no egma participant.
-    Every way of not finding one ends here the same way, because the
-    difference between "no metadata", "somebody else's metadata" and
-    "metadata that is not JSON" is a difference about *them*, and about
-    egma they all say the same thing.
-    """
-    metadata = getattr(getattr(ctx, "job", None), "metadata", None)
-    if not isinstance(metadata, str) or not metadata.strip():
+    room_name = _room_name(ctx)
+    if not room_name.startswith(SIMULATION_ROOM_PREFIX):
         return None
+    return _Simulation(named=room_name)
+
+
+def _room_name(ctx: JobContext) -> str:
+    """This job's room name, or nothing where there is not one to read.
+
+    Read defensively, through the job rather than through the room this
+    process connected: the job's copy is the one the server handed the
+    worker. Anything that is not a job with a room in it answers the same
+    way an ordinary production room does, which is also what keeps a
+    caller who passed the wrong object reaching the worded complaint
+    further down instead of an attribute error here.
+    """
+    name = getattr(getattr(getattr(ctx, "job", None), "room", None), "name", None)
+    return name if isinstance(name, str) else ""
+
+
+def _answers_to_egmas_name(identity: str) -> bool:
+    """Whether a participant in this room is egma, by the name it joined as.
+
+    Two forms and no others: the bare name, which is what egma joins as
+    where it mints its own token, and the name with the simulation after
+    it, which is what a customer's token endpoint is asked to mint. A
+    plain prefix test would also match a name that merely starts with
+    these letters, and the whole of the addressing rests on this.
+    """
+    return identity == EGMA_IDENTITY or identity.startswith(f"{EGMA_IDENTITY}-")
+
+
+def _egma_candidates(room: Any) -> list[str]:
+    """Every remote participant in this room answering to egma's name.
+
+    The room's table is asked whether it can be walked rather than checked
+    against a concrete type: LiveKit declares it as a mapping, and a room
+    that hands back some other mapping is a room this side can still read.
+
+    A table that cannot be walked at all is read as a room nobody is
+    visible in, which is the fail-open every other defensive read here
+    takes. It is said at debug level because this runs on every look, and
+    the outcome a developer has to act on — a simulation room egma was
+    never found in — is already said once, at error, when the search gives
+    up.
+    """
+    participants = getattr(room, "remote_participants", None)
+    items = getattr(participants, "items", None)
+    if not callable(items):
+        logger.debug(
+            "this room does not list who is in it, so Egma's participant "
+            "cannot be found in it"
+        )
+        return []
+    found: set[str] = set()
+    for key, participant in list(items()):
+        identity = getattr(participant, "identity", None)
+        if not isinstance(identity, str):
+            identity = key
+        if isinstance(identity, str) and _answers_to_egmas_name(identity):
+            found.add(identity)
+    return sorted(found)
+
+
+def _listen_for_arrivals(room: Any, arrived: asyncio.Event) -> Callable[[], None]:
+    """Wake the search when somebody joins, if this room will say so.
+
+    The waiting below polls whatever happens, so this is what makes it
+    prompt rather than what makes it work: a transport that renamed this
+    event would cost seconds, not correctness.
+    """
+    listen = getattr(room, "on", None)
+    if not callable(listen):
+        return lambda: None
+
+    def woken(*_participant: Any) -> None:
+        arrived.set()
+
     try:
-        context = json.loads(metadata)
-    except ValueError:
-        return None
-    if not isinstance(context, dict):
-        return None
-    identity = context.get("egmaIdentity")
-    if not isinstance(identity, str) or not identity.strip():
-        return None
-    simulation = context.get("simulationId")
-    return _EgmaContext(
-        identity=identity.strip(),
-        simulation_id=simulation if isinstance(simulation, str) else "unnamed",
-        protocol_version=context.get("protocolVersion"),
-    )
+        listen("participant_connected", woken)
+    except Exception:
+        logger.debug(
+            "this room does not announce arrivals, so Egma's participant is "
+            "waited for by looking rather than by being told",
+            exc_info=True,
+        )
+        return lambda: None
+
+    def stop() -> None:
+        forget = getattr(room, "off", None)
+        if callable(forget):
+            with contextlib.suppress(Exception):
+                forget("participant_connected", woken)
+
+    return stop
 
 
-def _hello_refused(refused: RpcError, context: _EgmaContext) -> None:
+async def _egma_in_the_room(
+    room: Any, deadline: float, simulation: _Simulation
+) -> str | None:
+    """egma's identity in this room, waited for, or nothing at the deadline.
+
+    Only ever reached in a room whose name already said simulation, which
+    is what makes waiting legitimate at all: a production room never gets
+    here, so nothing about a production start is slower than it was.
+
+    The listener is attached before the first look, not after it, because
+    a participant who joins between a look and a subscription is a
+    participant this side would then wait the whole bound for.
+    """
+    loop = asyncio.get_running_loop()
+    arrived = asyncio.Event()
+    stop_listening = _listen_for_arrivals(room, arrived)
+    try:
+        while True:
+            arrived.clear()
+            found = _egma_candidates(room)
+            if len(found) == 1:
+                return found[0]
+            if len(found) > 1:
+                # Refused rather than resolved. LiveKit makes one identity
+                # unique per room, so an impersonator taking egma's exact
+                # name is evicted by the server; one taking a variant of it
+                # sits quietly beside the real thing, and whichever this
+                # side picked would receive every tool name and schema this
+                # agent has. There is no reading of two claimants that is
+                # safe to act on.
+                logger.error(
+                    "simulation %s: %d participants in this room answer to "
+                    "Egma's name (%s), so which one is Egma is not knowable: "
+                    "nothing is wrapped and every tool runs its own "
+                    "implementation",
+                    simulation.named,
+                    len(found),
+                    ", ".join(found),
+                )
+                return None
+
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                logger.error(
+                    "simulation %s: this room is an Egma simulation room and no "
+                    "Egma participant joined it within %.0fs, so nothing is "
+                    "wrapped and every tool runs its own implementation. Egma "
+                    "joins as %r, or as that name with the simulation after "
+                    "it: check that Egma's own side of this simulation "
+                    "started, and that the token it was minted carries that "
+                    "identity (this is egma %s). This job's spans stay out of "
+                    "production Monitoring either way, because the room's name "
+                    "already said this is a simulation",
+                    simulation.named,
+                    STARTUP_SECONDS,
+                    EGMA_IDENTITY,
+                    _this_sdk(),
+                )
+                return None
+
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(
+                    arrived.wait(), min(remaining, POLL_SECONDS)
+                )
+    finally:
+        stop_listening()
+
+
+async def _asked_until_egma_is_listening(
+    seat: _Seat, census: str, deadline: float
+) -> str:
+    """Send the census, allowing for an egma that is in but not yet listening.
+
+    egma's participant enters the room before it registers the two methods
+    of the exchange, and on three of the four dispatch paths this agent
+    can be asking in exactly that window. The transport answers an
+    unregistered method with ``UNSUPPORTED_METHOD``, which this side would
+    otherwise read as "there is no egma here" and fall open on for the
+    whole simulation — a mocked tool running its real implementation,
+    which is the one outcome this file exists to prevent.
+
+    Only that one code is asked again. ``RECIPIENT_NOT_FOUND`` is not,
+    even though it is the same kind of race in principle. Nothing reaches
+    this function without having seen egma in the room's own participant
+    table, so a destination that cannot be found a moment later is one
+    that left — and a participant that left is the fail-open every other
+    lost participant gets, not a participant to keep calling. Retrying it
+    would hold the agent silent for the rest of the bound, in the one
+    simulation it was waiting to serve, and end in the same place.
+    """
+    loop = asyncio.get_running_loop()
+    while True:
+        try:
+            return await seat.ask(
+                seam.HELLO_METHOD, census, seam.HELLO_TIMEOUT_SECONDS
+            )
+        except RpcError as refused:
+            if (
+                refused.code not in seam.EGMA_NOT_LISTENING_YET
+                or loop.time() + POLL_SECONDS >= deadline
+            ):
+                raise
+            logger.debug(
+                "Egma is in this room and has not registered %s yet; asking "
+                "again",
+                seam.HELLO_METHOD,
+            )
+            await asyncio.sleep(POLL_SECONDS)
+
+
+def _this_sdk() -> str:
+    """This package's own version, for a line that asks somebody to act."""
+    try:
+        from importlib.metadata import version
+
+        return version("egma")
+    except Exception:
+        return "unknown"
+
+
+def _hello_refused(refused: RpcError, identity: str) -> None:
     """Say what a refused census means, in the terms it means it in."""
+    if refused.code == seam.UNSUPPORTED_PROTOCOL_VERSION:
+        # The one refusal a customer can act on alone, so it is the one
+        # refusal that names the action. Egma's own sentence carries the
+        # two version numbers; this side carries the package they belong
+        # to, because "Egma speaks 1 and this one declared 2" reads as an
+        # SDK that is too new when the fix is usually the other half.
+        logger.error(
+            "Egma here speaks a version of the mock-tool exchange this SDK "
+            "does not, so nothing is wrapped and every tool ran its own "
+            "implementation: %s. Upgrade that Egma deployment, or install "
+            "the `egma` package that shipped with it (this is egma %s)",
+            refused.message,
+            _this_sdk(),
+        )
+        return
     if refused.code in seam.EGMA_NOT_REACHED:
         logger.warning(
             "no Egma participant answered at %r in this room, so nothing is "
             "wrapped and every tool runs its own implementation (%s)",
-            context.identity,
+            identity,
             refused.message,
         )
         return
@@ -687,7 +1074,7 @@ async def _really(
 
     The room lost its egma participant, or never had one by the time this
     call was made. Either way the agent behaves exactly as it would with
-    no SDK installed — which is the same answer the absent-metadata path
+    no SDK installed — which is the same answer the production-room path
     gives one level up, arrived at from the other direction.
     """
     tool = original or ToolContext(agent.tools).function_tools.get(name)

--- a/sdks/python/src/egma/monitoring.py
+++ b/sdks/python/src/egma/monitoring.py
@@ -2,7 +2,14 @@
 
 ``monitor_livekit`` is separate from :func:`egma.mockable`. Monitoring is
 enabled explicitly in a production worker. Mock tools remain active only in
-simulations that Egma dispatches.
+the rooms Egma conducts a simulation in.
+
+Both halves read the same one fact to tell those apart, and only that
+fact: the name of the room this job was given. For ``monitor_livekit``
+that name is also all there is to read — it is synchronous and runs
+before the room is connected, so there is nobody in the room to ask — and
+it is all there is to need, because a room Egma named is a simulation
+whether or not anybody has joined it yet.
 """
 
 from __future__ import annotations
@@ -26,7 +33,7 @@ from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter
 
-from .mockable import _egma_context
+from .mockable import _simulation_in
 
 logger = logging.getLogger("egma")
 
@@ -68,7 +75,28 @@ def monitor_livekit(
     # A simulation already has its own trace path. Exporting the agent side of
     # the same room through the production door would make one simulation look
     # like a second production conversation in Monitoring.
-    if _egma_context(ctx) is not None:
+    #
+    # The room's name is the whole of the question, here and in `mockable`,
+    # read straight off the job with no network and nothing connected. What
+    # `mockable` goes on to do — connect, and find Egma's participant among
+    # the people in the room — is how it reaches Egma, not how it decides.
+    # This function needs neither: a room Egma named is a simulation whether
+    # or not anybody has joined it yet.
+    #
+    # Suppression is said out loud. A room name is chosen by whoever mints the
+    # join token, so this guard can in principle be tripped by a production
+    # room named to look like a simulation — and the cost of that would be a
+    # conversation with no record in Monitoring at all. A dropped trace is
+    # evidence the customer cannot get back, so the one thing this side can do
+    # for it is make it visible in the worker's own log.
+    simulation = _simulation_in(ctx)
+    if simulation is not None:
+        logger.warning(
+            "this job runs in the Egma simulation room %r, so its spans are "
+            "not exported to production Monitoring: the simulation keeps its "
+            "own trace and would otherwise appear a second time",
+            simulation.named,
+        )
         return
 
     trace_endpoint = _trace_endpoint(_setting(endpoint, "EGMA_URL"))

--- a/sdks/python/src/egma/seam.py
+++ b/sdks/python/src/egma/seam.py
@@ -53,10 +53,20 @@ from typing import Any
 PROTOCOL_VERSION = 1
 """Which version of this exchange this side speaks.
 
-It rides every hello in both directions, and it arrives ahead of the
-first word in the dispatch metadata, so a mismatch is known before
-anything is wrapped rather than discovered halfway through a
-simulation.
+It rides every hello in both directions, and the hello is the only place
+it rides. One announcement, read where the exchange itself begins, is the
+only reading that stays true when the two halves are deployed apart: a
+number carried anywhere else would be a second answer to the same
+question, and the second answer is the one that goes stale.
+:func:`mocked_tools_in` is where a reply's number is held to this one.
+
+The number moving is a decision this file records rather than a detail.
+It moves when the *bytes* of these messages move, and not otherwise: a
+version raised without a change to the shapes would refuse an egma that
+can read every message this side sends, which is the whole of what a
+self-hoster runs. When a real change does arrive, egma's own half must
+first ship a release that accepts both numbers, and only after that
+population has drained may this side start sending the new one.
 """
 
 HELLO_METHOD = "egma.hello"
@@ -114,6 +124,24 @@ than as its answer so that raising the delay cap moves this with it
 instead of silently leaving it behind.
 """
 
+HELLO_TIMEOUT_SECONDS = MAX_ROUND_TRIP_SECONDS + SERVING_MARGIN_SECONDS
+"""How long a hello may take before this side stops waiting. 10 + 5 = 15.
+
+Shorter than the number above, and deliberately so. The sum above carries
+``LONGEST_DECLARED_DELAY_SECONDS`` because a mock tool may legally hold an
+answer back for that long; a hello has no authored delay to wait out, so
+that term does not belong in it and carrying it anyway would let a stalled
+hello hold the agent silent for 45 seconds.
+
+That matters because of a bound on egma's own side: once egma is in the
+room it gives an agent 30 seconds to join and publish audio, and a
+simulation that runs out of them ends saying the agent never joined. A
+hello is sent before ``AgentSession.start``, so every second spent here is
+a second the agent is not speaking — and a timeout longer than egma's
+would make egma's own record blame the customer's worker for a stall on
+this side of the room.
+"""
+
 MALFORMED_REQUEST = 901
 """A message egma could not read at all."""
 
@@ -161,6 +189,21 @@ because the reading is the same one, and a second constant for the
 difference would be a distinction nothing can produce.
 """
 
+EGMA_NOT_LISTENING_YET = frozenset({1400})
+"""The one code that means "wait", rather than "there is nobody there".
+
+``1400`` is the method the destination does not serve. egma's participant
+is in the room before it registers the two methods of this exchange, and
+on three of the four dispatch paths into an egma room the agent can
+be asking inside that window — so this is the one refusal a census may be
+sent again on, bounded, rather than fallen open on.
+
+It is deliberately a subset of :data:`EGMA_NOT_REACHED` and not of its
+own kind: once the waiting is over, ``1400`` still means egma was never
+reached and the real tool still runs. The two readings do not compete,
+because the first only applies while there is time left to ask again.
+"""
+
 
 class SeamError(Exception):
     """A reply this side cannot read as an answer.
@@ -202,6 +245,21 @@ def hello_request(census: list[dict[str, Any]]) -> str:
     return _serialized({"protocol_version": PROTOCOL_VERSION, "tools": census})
 
 
+def _is_this_version(declared: object) -> bool:
+    """Whether that is the version of the exchange this side speaks.
+
+    Only the number itself will do, and a boolean is refused explicitly.
+    Python counts ``True`` as equal to ``1``, so a reply whose
+    ``protocol_version`` is JSON ``true`` would otherwise pass for version
+    1 and this side would go on to speak an exchange nobody declared —
+    standing couriers in front of an agent's tools on the word of a far
+    side that never said which exchange it was answering in.
+    """
+    if isinstance(declared, bool) or not isinstance(declared, int):
+        return False
+    return declared == PROTOCOL_VERSION
+
+
 def mocked_tools_in(reply: str) -> tuple[str, ...]:
     """The names egma will answer for, read off a hello's reply.
 
@@ -212,7 +270,7 @@ def mocked_tools_in(reply: str) -> tuple[str, ...]:
     """
     answered = _object(HELLO_METHOD, reply)
     version = answered.get("protocol_version")
-    if version != PROTOCOL_VERSION:
+    if not _is_this_version(version):
         raise SeamError(
             f"{HELLO_METHOD} was answered in protocol version {version!r}, and "
             f"this SDK speaks {PROTOCOL_VERSION}"

--- a/sdks/python/tests/conftest.py
+++ b/sdks/python/tests/conftest.py
@@ -34,7 +34,7 @@ from livekit.agents.voice.run_result import (  # noqa: PLC2701
     _run_mock,
     _SessionMockTools,
 )
-from room_stub import StubContext, StubRoom, egma_metadata
+from room_stub import SIMULATION_ROOM, StubContext, StubRoom
 
 
 class ReceptionAgent(Agent):
@@ -79,9 +79,17 @@ async def session() -> AgentSession:
     return AgentSession()
 
 
-def in_a_simulation(room: StubRoom, **metadata: Any) -> StubContext:
-    """A job dispatched by egma into that room."""
-    return StubContext(room, egma_metadata(**metadata))
+def in_a_simulation(
+    room: StubRoom, room_name: str = SIMULATION_ROOM, metadata: str = ""
+) -> StubContext:
+    """A job whose room egma named for a simulation.
+
+    The metadata is empty by default, and that is the point of the
+    default: an egma that names itself nowhere but in the room's name is
+    the ordinary case, and every test that does not say otherwise is
+    written against it.
+    """
+    return StubContext(room, room_name, metadata)
 
 
 def couriers_on(session: AgentSession, agent: Agent) -> dict[str, Any]:

--- a/sdks/python/tests/room_stub.py
+++ b/sdks/python/tests/room_stub.py
@@ -2,10 +2,11 @@
 
 The customer's side of the exchange is proved with no LiveKit server, no
 project, no worker and no network. What this stands in for is exactly the
-one place the SDK reaches a LiveKit — the call it makes to egma's
-participant — and nothing else. Everything above that is the SDK's own
-code: reading the metadata, building the census, standing the couriers,
-reading a reply, falling open.
+two places the SDK reaches a LiveKit — the room's own list of who is in
+it, and the call it makes to egma's participant — and nothing else.
+Everything above that is the SDK's own code: reading the room's name,
+finding egma, building the census, standing the couriers, reading a
+reply, falling open.
 
 Two things it can be, and a test picks by what it builds:
 
@@ -13,13 +14,21 @@ Two things it can be, and a test picks by what it builds:
   received are on the record, in order, so a test can say the census went
   first.
 - **egma absent** — every call refused with the transport's own
-  ``RECIPIENT_NOT_FOUND``, which is the whole of what a production room
-  looks like from in here.
+  ``RECIPIENT_NOT_FOUND``, which is the whole of what a room that lost
+  its egma looks like from in here.
 
 The refusals are real :class:`~livekit.rtc.RpcError` instances, because
 the SDK's fail-open branch reads a code off one and a stand-in with its
 own error type would prove the stand-in's conversion rather than the
 SDK's reading.
+
+## Who is in the room, and when
+
+A room here holds identities rather than participant objects, because
+identity is the whole of what the SDK reads about anybody. ``arrive``
+puts one in after the fact and fires the room's own arrival event, which
+is how the three dispatch paths that put an agent in an egma room before
+egma is behave.
 """
 
 from __future__ import annotations
@@ -33,10 +42,26 @@ from livekit.rtc import RpcError
 from egma import seam
 
 EGMA_IDENTITY = "egma-persona"
-"""Who egma is in the room. The name is the address and the whole of the
-authorisation: a room with nobody by it has nobody to ask."""
+"""Who egma is in the room when it mints its own token. The name is the
+address and the whole of the authorisation: a room with nobody by it has
+nobody to ask."""
 
 A_SIMULATION = "sim-sdk-0001"
+
+SIMULATION_ROOM = f"egma-sim-{A_SIMULATION}"
+"""What egma names a room it conducts a simulation in.
+
+Written here rather than imported so this suite holds the SDK to the
+*contract*, not to a constant the two halves could move together.
+"""
+
+PRODUCTION_ROOM = "acme-support-4711"
+"""What a room nobody named for a simulation looks like."""
+
+
+def persona_in(simulation_id: str = A_SIMULATION) -> str:
+    """Who egma is when a customer's own token endpoint mints for it."""
+    return f"{EGMA_IDENTITY}-{simulation_id}"
 
 
 @dataclass(frozen=True)
@@ -55,7 +80,7 @@ class Asked:
 
 
 class StubParticipant:
-    """The one method of a room the SDK ever calls."""
+    """The one method of a room's local participant the SDK ever calls."""
 
     def __init__(self, room: StubRoom) -> None:
         self._room = room
@@ -80,6 +105,13 @@ class StubParticipant:
         )
 
 
+@dataclass(frozen=True)
+class StubRemoteParticipant:
+    """Somebody else in the room, down to the one thing that addresses them."""
+
+    identity: str
+
+
 @dataclass
 class StubRoom:
     """A room, from the seat the SDK sits in.
@@ -91,18 +123,55 @@ class StubRoom:
 
     ``refuses_with`` puts a code in front of everything instead, which is
     how an absent egma and every honest refusal are both said.
+
+    ``present`` is who is in the room when the SDK looks. It holds egma by
+    default, because the room a test builds is usually one egma is already
+    in; a test that wants the other order builds it empty and calls
+    ``arrive`` later.
     """
 
     mocked_tools: tuple[str, ...] = ()
     answers: dict[str, dict[str, Any]] = field(default_factory=dict)
     refuses_with: RpcError | None = None
     refuses_tool_with: RpcError | None = None
+    refuses_hello_until: int = 0
     hello_reply: str | None = None
     asked: list[Asked] = field(default_factory=list)
     connected: bool = True
+    present: tuple[str, ...] = (EGMA_IDENTITY,)
 
     def __post_init__(self) -> None:
         self._local_participant = StubParticipant(self)
+        self.remote_participants = {
+            identity: StubRemoteParticipant(identity) for identity in self.present
+        }
+        self._listeners: dict[str, list[Any]] = {}
+        self._helloes = 0
+
+    # -- who is in it ---------------------------------------------------------
+
+    def on(self, event: str, callback: Any) -> Any:
+        self._listeners.setdefault(event, []).append(callback)
+        return callback
+
+    def off(self, event: str, callback: Any) -> None:
+        listeners = self._listeners.get(event, [])
+        if callback in listeners:
+            listeners.remove(callback)
+
+    def arrive(self, identity: str) -> None:
+        """Put somebody in the room the way LiveKit announces one."""
+        participant = StubRemoteParticipant(identity)
+        self.remote_participants[identity] = participant
+        for callback in list(self._listeners.get("participant_connected", [])):
+            callback(participant)
+
+    @property
+    def listeners(self) -> dict[str, list[Any]]:
+        """What is still subscribed, so a test can say nothing was left on."""
+        return {event: list(each) for event, each in self._listeners.items() if each}
+
+    # -- what it carries ------------------------------------------------------
 
     @property
     def local_participant(self) -> StubParticipant:
@@ -118,6 +187,13 @@ class StubRoom:
         if self.refuses_with is not None:
             raise self.refuses_with
         if asked.method == seam.HELLO_METHOD:
+            self._helloes += 1
+            if self._helloes <= self.refuses_hello_until:
+                # What the transport says while egma is in the room and has
+                # not registered the exchange yet.
+                raise RpcError(
+                    RpcError.ErrorCode.UNSUPPORTED_METHOD, asked.method
+                )
             if self.hello_reply is not None:
                 return self.hello_reply
             return json.dumps(
@@ -151,18 +227,33 @@ class StubRoom:
 
 
 @dataclass
-class StubJob:
-    """The job's dispatch metadata, which is all the SDK reads of a job."""
+class StubJobRoom:
+    """The room as the server described it to the worker.
 
-    metadata: str
+    Separate from the room the process connected on purpose: the name the
+    SDK reads is the one that arrived with the job, not one this side
+    could have chosen for itself.
+    """
+
+    name: str
+
+
+@dataclass
+class StubJob:
+    """A job, down to the two things the SDK reads of one."""
+
+    room: StubJobRoom
+    metadata: str = ""
 
 
 class StubContext:
     """A job context, down to the two things the SDK touches."""
 
-    def __init__(self, room: StubRoom, metadata: str) -> None:
+    def __init__(
+        self, room: StubRoom, room_name: str, metadata: str = ""
+    ) -> None:
         self.room = room
-        self.job = StubJob(metadata=metadata)
+        self.job = StubJob(room=StubJobRoom(name=room_name), metadata=metadata)
         self.connect_calls = 0
 
     async def connect(self) -> None:
@@ -170,23 +261,29 @@ class StubContext:
         self.room.connected = True
 
 
-def egma_metadata(
-    *,
-    identity: str = EGMA_IDENTITY,
-    simulation_id: str = A_SIMULATION,
-    protocol_version: object = seam.PROTOCOL_VERSION,
-) -> str:
-    """The dispatch metadata egma really sends, byte for byte in shape.
+def egma_metadata(*, identity: str = EGMA_IDENTITY) -> str:
+    """The context block egma merges into a named dispatch's metadata.
 
-    Written here rather than imported so this suite holds the SDK to the
-    *contract*, not to a constant the two halves could move together.
+    Four keys, written underneath whatever the customer configured, for
+    SDK versions older than the room-name contract. This suite carries it
+    so the SDK can be held to reading *none* of it: a simulation room with
+    this in its metadata must behave exactly like the same room without
+    it, and a production room with it must stay a production room.
+
+    ``identity`` is here for the test that names somebody other than egma,
+    which is the case that would matter if this block were ever treated as
+    an address.
+
+    Written out here rather than imported so this suite holds the SDK to
+    the *shape a deployment really sends*, not to a constant the two
+    halves could move together.
     """
     return json.dumps(
         {
-            "simulationId": simulation_id,
+            "simulationId": A_SIMULATION,
             "modality": "voice",
             "egmaIdentity": identity,
-            "protocolVersion": protocol_version,
+            "protocolVersion": seam.PROTOCOL_VERSION,
         },
         separators=(",", ":"),
     )

--- a/sdks/python/tests/test_inert.py
+++ b/sdks/python/tests/test_inert.py
@@ -1,17 +1,20 @@
 """The property this package is safe by: in a production room it does nothing.
 
 Not "adds negligible latency", not "wraps harmlessly" — **nothing**. The
-same tool objects, no side table written, and not one message put on the
-wire. Everything else this SDK does is worth having only if a customer
-can install it and have their production behavior be literally
-unchanged, so this file comes first and is read as the whole safety
-argument.
+same tool objects, no side table written, not one message put on the
+wire, and no connect the agent was not already making. Everything else
+this SDK does is worth having only if a customer can install it and have
+their production behavior be literally unchanged, so this file comes first
+and is read as the whole safety argument.
 
-Every way of not finding egma ends here the same way, and that is on
-purpose: metadata that is absent, empty, somebody else's, unparseable, or
-egma's own in a version this SDK does not speak. The differences between
-those are differences about the *room*; about what this SDK should do
-they all say one thing.
+The question the SDK asks is the room's name, and only the room's name, so
+this file is mostly a list of names that are not egma's. Every one of them
+is crossed with a list of dispatch metadata — including metadata carrying
+egma's own key names — because that channel is the customer's to fill with
+whatever they like and nothing in it may turn their production room into a
+simulation. A room wrapped by mistake is also a room whose spans are held
+out of Monitoring, and a dropped trace is evidence a customer cannot get
+back.
 """
 
 from __future__ import annotations
@@ -20,11 +23,20 @@ import pytest
 from conftest import ReceptionAgent, couriers_on
 from livekit.agents import AgentTask, ConversationItemAddedEvent, function_tool
 from livekit.agents.llm import AgentHandoff
-from room_stub import StubContext, StubRoom, egma_metadata
+from room_stub import PRODUCTION_ROOM, SIMULATION_ROOM, StubContext, StubRoom
 
 from egma import mockable
 
-NO_EGMA = [
+NOT_A_SIMULATION_ROOM = [
+    pytest.param("", id="no room name at all"),
+    pytest.param(PRODUCTION_ROOM, id="the customer's own room"),
+    pytest.param("egma-sim", id="the prefix without its separator"),
+    pytest.param("egma-simulator-demo", id="a name that merely starts alike"),
+    pytest.param("call-egma-sim-0001", id="the prefix in the middle"),
+    pytest.param("EGMA-SIM-0001", id="the prefix in another case"),
+]
+
+THE_CUSTOMER_S_OWN_METADATA = [
     pytest.param("", id="no metadata at all"),
     pytest.param("   ", id="metadata of blanks"),
     pytest.param('{"tenant":"acme","shift":"nights"}', id="the customer's own"),
@@ -32,6 +44,10 @@ NO_EGMA = [
     pytest.param('"a string"', id="json that is not an object"),
     pytest.param('{"egmaIdentity":""}', id="an egma name that names nobody"),
     pytest.param('{"egmaIdentity":42}', id="an egma name that is not a name"),
+    pytest.param(
+        '{"egmaIdentity":"egma-persona","simulationId":"sim-0001"}',
+        id="the customer's own use of egma's key names",
+    ),
 ]
 
 
@@ -47,12 +63,14 @@ class ProductionTask(AgentTask[None]):
         return f"really booked {day}"
 
 
-@pytest.mark.parametrize("metadata", NO_EGMA)
-async def test_a_room_with_no_egma_in_it_is_left_alone(metadata, session):
+@pytest.mark.parametrize("room_name", NOT_A_SIMULATION_ROOM)
+@pytest.mark.parametrize("metadata", THE_CUSTOMER_S_OWN_METADATA)
+async def test_a_room_egma_did_not_name_is_left_alone(room_name, metadata, session):
     agent = ReceptionAgent()
     before = agent.tools
-    room = StubRoom(connected=False)
-    ctx = StubContext(room, metadata)
+    # egma is standing right there, willing to answer. Nothing may ask it.
+    room = StubRoom(connected=False, mocked_tools=("check_calendar",))
+    ctx = StubContext(room, room_name, metadata)
 
     await mockable(agent, ctx, session)
 
@@ -71,15 +89,45 @@ async def test_a_room_with_no_egma_in_it_is_left_alone(metadata, session):
     # production room a round trip on every session start.
     assert room.asked == []
     assert ctx.connect_calls == 0
+    # Nor was anything left listening for somebody to walk in.
+    assert room.listeners == {}
+
+
+@pytest.mark.parametrize("metadata", THE_CUSTOMER_S_OWN_METADATA)
+async def test_the_customers_dispatch_metadata_is_never_read_as_an_instruction(
+    metadata, session
+):
+    """The channel that is the customer's, down to egma's own key names.
+
+    Dispatch metadata is where LiveKit teaches customers to put a caller's
+    own identifiers, so whatever is in it belongs to them — including the
+    four names egma writes there for older SDK versions. A customer whose
+    own JSON happens to use ``egmaIdentity`` gets exactly the production
+    room they had: their tools untouched, and their conversation still on
+    the record in Monitoring.
+
+    The last parameter is the one this test exists for. The rest are here
+    so the reading is proved to be no reading at all, rather than a
+    reading that this particular JSON happened to fail.
+    """
+    agent = ReceptionAgent()
+    room = StubRoom(connected=False, mocked_tools=("check_calendar",))
+    ctx = StubContext(room, PRODUCTION_ROOM, metadata)
+
+    await mockable(agent, ctx, session)
+
+    assert couriers_on(session, agent) == {}
+    assert room.asked == []
+    assert ctx.connect_calls == 0
 
 
 async def test_a_production_handoff_stays_inert_after_mockable_returns(session):
-    """No metadata also means no listener waiting to wrap a later task."""
+    """A production room also means no listener waiting to wrap a later task."""
     agent = ReceptionAgent()
     task = ProductionTask()
     room = StubRoom(connected=False)
 
-    await mockable(agent, StubContext(room, ""), session)
+    await mockable(agent, StubContext(room, PRODUCTION_ROOM), session)
     session.update_agent(task)
     session.emit(
         "conversation_item_added",
@@ -93,54 +141,24 @@ async def test_a_production_handoff_stays_inert_after_mockable_returns(session):
     assert room.asked == []
 
 
-@pytest.mark.parametrize(
-    "declared",
-    [
-        pytest.param(99, id="a version from the future"),
-        pytest.param(True, id="a boolean, which python counts as one"),
-        pytest.param("1", id="a version written as text"),
-        pytest.param(None, id="no version at all"),
-    ],
-)
-async def test_a_version_this_sdk_cannot_read_wraps_nothing(session, declared):
-    """Only the number itself will do.
+async def test_a_production_room_is_answered_without_a_job_room_object(session):
+    """A context that carries no room on its job is a production room.
 
-    A boolean is the one worth naming: Python counts ``True`` as equal to
-    ``1``, so a metadata field carrying ``true`` would otherwise pass for
-    version 1 and this SDK would speak an exchange nobody declared.
+    Read defensively on purpose. Whatever this is handed, the answer that
+    costs nobody anything is the one it gives — and a caller who passed
+    the wrong object entirely still reaches a worded complaint elsewhere
+    rather than an attribute error raised from inside this SDK.
     """
     agent = ReceptionAgent()
-    room = StubRoom(mocked_tools=("check_calendar",))
+    room = StubRoom(connected=False)
+    ctx = StubContext(room, PRODUCTION_ROOM)
+    ctx.job.room = None
 
-    await mockable(
-        agent, StubContext(room, egma_metadata(protocol_version=declared)), session
-    )
+    await mockable(agent, ctx, session)
 
     assert couriers_on(session, agent) == {}
     assert room.asked == []
-
-
-async def test_a_version_neither_side_speaks_wraps_nothing(session, caplog):
-    """egma is there, and this SDK does not speak its exchange.
-
-    Nothing is wrapped, so every tool runs its own implementation — the
-    same place the absent-egma path lands, reached from the other
-    direction. It is said at error level because, unlike an absent egma,
-    this one is a fault somebody must fix: a simulation ran unisolated.
-    """
-    agent = ReceptionAgent()
-    room = StubRoom(mocked_tools=("check_calendar",))
-
-    with caplog.at_level("ERROR", logger="egma"):
-        await mockable(
-            agent, StubContext(room, egma_metadata(protocol_version=99)), session
-        )
-
-    assert couriers_on(session, agent) == {}
-    # Not even the census: a version mismatch is known before anything is
-    # said, which is the whole reason the version rides the metadata.
-    assert room.asked == []
-    assert "99" in caplog.text
+    assert ctx.connect_calls == 0
 
 
 async def test_an_agent_with_no_tools_still_reports_and_wraps_nothing(session):
@@ -155,7 +173,7 @@ async def test_an_agent_with_no_tools_still_reports_and_wraps_nothing(session):
     agent = ToollessAgent()
     room = StubRoom()
 
-    await mockable(agent, StubContext(room, egma_metadata()), session)
+    await mockable(agent, StubContext(room, SIMULATION_ROOM), session)
 
     assert [asked.method for asked in room.asked] == ["egma.hello"]
     assert room.asked[0].body["tools"] == []

--- a/sdks/python/tests/test_live_mockable.py
+++ b/sdks/python/tests/test_live_mockable.py
@@ -192,11 +192,20 @@ class EgmaInTheRoom:
 
 
 class LiveContext:
-    """A job context, down to the two things the SDK reads of one."""
+    """A job context, down to the two things the SDK reads of one.
 
-    def __init__(self, room: rtc.Room, metadata: str) -> None:
+    The room's name is carried on the job rather than read off the room
+    this process connected, because the job's copy is the one a LiveKit
+    server hands a worker and that is the one the SDK reads.
+    """
+
+    def __init__(self, room: rtc.Room, room_name: str) -> None:
         self.room = room
-        self.job = type("Job", (), {"metadata": metadata})()
+        self.job = type(
+            "Job",
+            (),
+            {"room": type("JobRoom", (), {"name": room_name})(), "metadata": ""},
+        )()
 
 
 def _token(room_name: str, identity: str) -> str:
@@ -222,25 +231,15 @@ async def _each(*teardowns: Coroutine) -> None:
             print(f"teardown step did not finish: {failed}")
 
 
-def _metadata() -> str:
-    """The dispatch metadata egma really sends, byte for byte in shape."""
-    return json.dumps(
-        {
-            "simulationId": A_SIMULATION,
-            "modality": "voice",
-            "egmaIdentity": EGMA_IDENTITY,
-            "protocolVersion": seam.PROTOCOL_VERSION,
-        },
-        separators=(",", ":"),
-    )
-
-
 @pytest.mark.timeout(WITHIN_SECONDS + 30)
 async def test_livekit_still_honours_the_couriers_this_sdk_registers():
     global really_ran
     really_ran = False
 
-    room_name = f"egma-sdk-live-{uuid.uuid4().hex}"
+    # Named the way egma names one, because the name is what tells the SDK
+    # this is a simulation at all — on a real server, with a real room
+    # object, and with egma really in it under the name it really joins as.
+    room_name = f"egma-sim-{A_SIMULATION}-{uuid.uuid4().hex}"
     lkapi = api.LiveKitAPI(LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET)
     egma = EgmaInTheRoom()
     agent_room = rtc.Room()
@@ -264,7 +263,7 @@ async def test_livekit_still_honours_the_couriers_this_sdk_registers():
         await agent_room.connect(LIVEKIT_URL, _token(room_name, AGENT_IDENTITY))
 
         agent = ReceptionAgent()
-        await mockable(agent, LiveContext(agent_room, _metadata()), session)
+        await mockable(agent, LiveContext(agent_room, room_name), session)
 
         # The census really travelled a wire and really came back.
         census = egma.asked_for(seam.HELLO_METHOD)

--- a/sdks/python/tests/test_livekit_monitoring.py
+++ b/sdks/python/tests/test_livekit_monitoring.py
@@ -20,7 +20,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
-from room_stub import egma_metadata
+from room_stub import PRODUCTION_ROOM, SIMULATION_ROOM, egma_metadata
 
 from egma import monitor_livekit
 from egma import monitoring as livekit_monitoring
@@ -29,7 +29,15 @@ PROJECT_KEY = f"egma_sk_{'a' * 43}"
 
 
 @dataclass
+class StubJobRoom:
+    name: str = PRODUCTION_ROOM
+
+
+@dataclass
 class StubJob:
+    """A job, down to the two things the monitoring guard reads of one."""
+
+    room: StubJobRoom = field(default_factory=StubJobRoom)
     metadata: str = ""
 
 
@@ -42,6 +50,11 @@ class StubJobContext:
 
     def add_shutdown_callback(self, callback: Any) -> None:
         self.shutdown_callbacks.append(callback)
+
+
+def in_the_room(name: str, metadata: str = "") -> StubJobContext:
+    """A job whose room is named that."""
+    return StubJobContext(job=StubJob(room=StubJobRoom(name=name), metadata=metadata))
 
 
 @pytest.fixture(autouse=True)
@@ -135,15 +148,106 @@ async def test_real_exporter_posts_protobuf_with_the_project_key(monkeypatch):
         provider.shutdown()
 
 
-def test_an_egma_simulation_does_not_create_a_production_exporter(monkeypatch):
+@pytest.mark.parametrize(
+    "context",
+    [
+        pytest.param(
+            in_the_room(SIMULATION_ROOM, egma_metadata()),
+            id="egma dispatched this worker by name",
+        ),
+        pytest.param(
+            in_the_room(SIMULATION_ROOM),
+            id="whichever worker was listening took the room",
+        ),
+        pytest.param(
+            in_the_room("egma-sim-a1b2c3d4"),
+            id="a room egma minted for itself",
+        ),
+        pytest.param(
+            in_the_room("egma-sim-sim-0002"),
+            id="a room a customer's own token endpoint opened",
+        ),
+    ],
+)
+def test_an_egma_simulation_does_not_create_a_production_exporter(
+    monkeypatch, caplog, context
+):
+    """All four dispatch paths into an egma room, not just the one.
+
+    A simulation's spans have their own trace, so exporting the agent's
+    side of the same room through the production door would put an
+    invented second conversation into Monitoring. The room's name is the
+    one signal that arrives on all four paths: only an explicit dispatch
+    carries metadata, and the other three would otherwise export.
+    """
     monkeypatch.delenv("EGMA_URL", raising=False)
     monkeypatch.delenv("EGMA_API_KEY", raising=False)
-    context = StubJobContext(job=StubJob(metadata=egma_metadata()))
 
-    monitor_livekit(context)
+    with caplog.at_level("WARNING", logger="egma"):
+        monitor_livekit(context)
 
     assert livekit_monitoring._state is None
     assert context.shutdown_callbacks == []
+    # Said out loud, because a room's name is chosen by whoever mints the
+    # join token: a production room named to look like a simulation would
+    # lose its Monitoring record, and a dropped trace is evidence the
+    # customer cannot get back.
+    assert "not exported" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        pytest.param(
+            '{"tenant":"acme","shift":"nights"}', id="the customer's own keys"
+        ),
+        pytest.param(egma_metadata(), id="egma's own key names, in a real room"),
+    ],
+)
+def test_a_production_room_is_still_exported_whatever_its_metadata_says(
+    monkeypatch, metadata
+):
+    """Dispatch metadata is the customer's channel and says nothing here.
+
+    The second parameter is the one that has to hold. Dispatch metadata is
+    the customer's to fill, so a production room whose JSON happens to use
+    egma's key names is still a production room — and the cost of reading
+    it otherwise is not a stray span but a missing one: a real
+    conversation with no record in Monitoring at all, which is evidence
+    nobody can get back.
+    """
+    provider = TracerProvider()
+    install_provider(monkeypatch, provider)
+    monkeypatch.setattr(
+        livekit_monitoring,
+        "_build_exporter",
+        lambda _endpoint, _key: InMemorySpanExporter(),
+    )
+    context = in_the_room(PRODUCTION_ROOM, metadata)
+
+    monitor_livekit(
+        context, endpoint="https://api.egma.ai", api_key=PROJECT_KEY
+    )
+
+    assert livekit_monitoring._state is not None
+    assert len(context.shutdown_callbacks) == 1
+    provider.shutdown()
+
+
+def test_a_context_with_no_room_still_reaches_the_worded_complaint():
+    """The guard is read defensively so a wrong argument stays worded.
+
+    ``monitor_livekit`` names what it needs when it is handed something
+    that is not a LiveKit job context. A guard that reached straight
+    through the job for a room name would raise an attribute error from
+    inside the SDK instead, one step before that sentence.
+    """
+    with pytest.raises(ValueError) as refused:
+        monitor_livekit(
+            object(), endpoint="https://api.egma.ai", api_key=PROJECT_KEY
+        )
+
+    assert "JobContext" in str(refused.value)
 
 
 @pytest.mark.parametrize(

--- a/sdks/python/tests/test_mockable.py
+++ b/sdks/python/tests/test_mockable.py
@@ -1,10 +1,10 @@
 """The exchange, from the customer's seat: census, couriers, and answers.
 
 Every test here runs against a room-shaped stand-in for egma's
-participant, so the whole of the SDK's own code is exercised — the
-metadata read, the census built off a real agent, the couriers stood in
-LiveKit's own side table, the reply read, the fail-open — with no LiveKit
-server and no network anywhere.
+participant, so the whole of the SDK's own code is exercised — the room's
+name read, egma found among the people in the room, the census built off
+a real agent, the couriers stood in LiveKit's own side table, the reply
+read, the fail-open — with no LiveKit server and no network anywhere.
 
 Where a courier is called, it is called the way the framework delivers a
 call to one: through LiveKit's own argument trimming. That is the only
@@ -31,9 +31,21 @@ from livekit.agents import (
 )
 from livekit.agents.llm import AgentHandoff
 from livekit.rtc import RpcError
-from room_stub import EGMA_IDENTITY, StubRoom, not_reached
+from room_stub import (
+    EGMA_IDENTITY,
+    SIMULATION_ROOM,
+    StubContext,
+    StubRoom,
+    egma_metadata,
+    not_reached,
+    persona_in,
+)
 
 from egma import mockable, seam
+
+# The module rather than the verb: ``egma.mockable`` is both, and the
+# tests that shorten this SDK's own waits have to reach the module.
+implementation = importlib.import_module("egma.mockable")
 
 
 def answer(value: object) -> dict:
@@ -68,6 +80,34 @@ async def test_an_already_connected_simulation_does_not_connect_again(session):
     await mockable(agent, ctx, session)
 
     assert ctx.connect_calls == 0
+
+
+async def test_a_room_that_will_not_open_leaves_the_agent_alone(session, caplog):
+    """The one connect this SDK forces is not a way for it to raise.
+
+    Connecting is the only thing ``mockable`` makes an agent do that the
+    agent had not asked for yet, so it is the one place a fault of egma's
+    could reach a customer's entrypoint. It does not: a room that will not
+    open is a room egma cannot be found in, which lands where every other
+    unreachable egma lands — nothing wrapped, every tool its own, and the
+    reason said out loud. The agent's own startup is left to connect, or
+    to fail on its own terms.
+    """
+    agent = ReceptionAgent()
+    room = StubRoom(connected=False, mocked_tools=("check_calendar",))
+    ctx = in_a_simulation(room)
+
+    async def will_not_open() -> None:
+        raise RuntimeError("the LiveKit server refused this token")
+
+    ctx.connect = will_not_open
+
+    with caplog.at_level("ERROR", logger="egma"):
+        await mockable(agent, ctx, session)
+
+    assert couriers_on(session, agent) == {}
+    assert room.asked == []
+    assert "the LiveKit server refused this token" in caplog.text
 
 
 async def test_the_census_goes_first_and_names_every_tool(session):
@@ -108,14 +148,334 @@ async def test_the_census_carries_each_tool_s_schema(session):
 
 async def test_the_census_sets_both_knobs_explicitly(session):
     """Never a default, on any call. The transport's own timeout is
-    shorter than a delay a mock tool may legally declare."""
+    shorter than a delay a mock tool may legally declare.
+
+    A census gets the shorter of this SDK's two waits, because a hello has
+    no authored delay to wait out and every second spent on one is a
+    second the agent has not greeted anybody in.
+    """
     agent = ReceptionAgent()
     room = StubRoom()
 
     await mockable(agent, in_a_simulation(room), session)
 
-    assert room.asked[0].response_timeout == seam.RESPONSE_TIMEOUT_SECONDS
+    assert room.asked[0].response_timeout == seam.HELLO_TIMEOUT_SECONDS
     assert room.asked[0].max_round_trip_latency == seam.MAX_ROUND_TRIP_SECONDS
+
+
+async def test_the_hello_wait_stays_clear_of_the_time_egma_gives_an_agent(session):
+    """The relation the number is chosen for, asserted rather than trusted.
+
+    egma allows an agent 30 seconds to join and publish audio. A hello is
+    sent before the session starts, so a hello this side would wait longer
+    than that for is a simulation egma ends by blaming the customer's
+    worker for a stall on this side of the room.
+    """
+    assert seam.HELLO_TIMEOUT_SECONDS < seam.RESPONSE_TIMEOUT_SECONDS
+    assert seam.HELLO_TIMEOUT_SECONDS < 30.0
+
+
+# -- Finding egma in the room -------------------------------------------------
+
+
+async def test_egma_arriving_after_the_agent_is_waited_for(session):
+    """The ordinary order, on three of the four dispatch paths into an egma room.
+
+    Nothing dispatches the worker on egma's behalf on those three, so the
+    agent is in the room first and egma walks in afterwards. The room's
+    name already said this is a simulation, so this side may wait — and it
+    connects before it waits, because a room nobody is connected to has
+    nobody in it.
+    """
+    agent = ReceptionAgent()
+    room = StubRoom(
+        connected=False, present=(), mocked_tools=("check_calendar",)
+    )
+    ctx = in_a_simulation(room)
+
+    async def egma_walks_in() -> None:
+        await asyncio.sleep(0.05)
+        room.arrive(EGMA_IDENTITY)
+
+    joining = asyncio.create_task(egma_walks_in())
+    await mockable(agent, ctx, session)
+    await joining
+
+    assert ctx.connect_calls == 1
+    assert room.methods_asked == [seam.HELLO_METHOD]
+    assert room.asked[0].identity == EGMA_IDENTITY
+    assert set(couriers_on(session, agent)) == {"check_calendar"}
+    # Nothing is left subscribed to the room once egma has been found.
+    assert room.listeners == {}
+
+
+async def test_egma_already_in_the_room_is_found_without_waiting(session):
+    """The other order, which is the one an explicit dispatch produces."""
+    agent = ReceptionAgent()
+    room = StubRoom(mocked_tools=("check_calendar",))
+
+    await mockable(agent, in_a_simulation(room), session)
+
+    assert set(couriers_on(session, agent)) == {"check_calendar"}
+    assert room.listeners == {}
+
+
+async def test_the_persona_a_token_endpoint_mints_for_is_found_too(session):
+    """egma joins under two names, and the second is the customer's variant.
+
+    Where a customer's own token endpoint mints egma's token, egma asks it
+    for ``egma-persona-<simulation>`` rather than the bare name. Both are
+    egma, and the address every message goes to is whichever one is really
+    in the room.
+    """
+    agent = ReceptionAgent()
+    persona = persona_in()
+    room = StubRoom(present=(persona,), mocked_tools=("check_calendar",))
+
+    await mockable(agent, in_a_simulation(room), session)
+
+    assert room.asked[0].identity == persona
+    assert set(couriers_on(session, agent)) == {"check_calendar"}
+
+
+async def test_two_participants_answering_to_egmas_name_are_refused(session, caplog):
+    """A room with two claimants is a room where the answer is not knowable.
+
+    LiveKit makes one identity unique per room, so an impersonator taking
+    egma's exact name is evicted by the server. One taking a variant of it
+    sits quietly beside the real thing — and whichever this side picked
+    would be handed every tool name and schema this agent has. So neither
+    is picked.
+    """
+    agent = ReceptionAgent()
+    room = StubRoom(
+        present=(EGMA_IDENTITY, persona_in()), mocked_tools=("check_calendar",)
+    )
+
+    with caplog.at_level("ERROR", logger="egma"):
+        await mockable(agent, in_a_simulation(room), session)
+
+    assert couriers_on(session, agent) == {}
+    # Not one word on the wire: the census is this agent's whole tool
+    # inventory, and it is never sent to somebody who might not be egma.
+    assert room.asked == []
+    assert EGMA_IDENTITY in caplog.text
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [
+        pytest.param("egma-personality-quiz", id="a name that merely starts alike"),
+        pytest.param("caller-8871", id="an ordinary caller"),
+        pytest.param("EGMA-PERSONA", id="the name in another case"),
+    ],
+)
+async def test_a_participant_who_is_not_egma_is_never_asked(
+    session, monkeypatch, identity
+):
+    """The room's name says simulation; who to talk to is a separate question.
+
+    The name gets this side as far as looking, and no further: what the
+    census carries is every tool this agent has, by name and schema, so
+    the only participant it may be sent to is one that answers to egma's
+    name exactly — the bare name, or the name with a ``-`` and a
+    simulation after it. A prefix test would hand that inventory to
+    ``egma-personality-quiz``. Nobody here matches, so the search waits
+    the bound out and ends in the ordinary fail-open instead.
+    """
+    agent = ReceptionAgent()
+    room = StubRoom(present=(identity,), mocked_tools=("check_calendar",))
+    monkeypatch.setattr(implementation, "STARTUP_SECONDS", 0.2)
+
+    await mockable(agent, in_a_simulation(room), session)
+
+    assert couriers_on(session, agent) == {}
+    assert room.asked == []
+
+
+async def test_a_room_that_will_not_say_who_is_in_it_wraps_nothing(
+    session, monkeypatch, caplog
+):
+    """A room this side cannot see into is read as a room egma is not in.
+
+    Who is in the room is read through the mapping LiveKit declares, so
+    anything that answers ``items()`` is walked and anything that does not
+    is treated as an empty room rather than raised from. The end is the
+    ordinary fail-open, and nothing is sent anywhere on the way there.
+    """
+    agent = ReceptionAgent()
+    room = StubRoom(mocked_tools=("check_calendar",))
+    room.remote_participants = None
+    monkeypatch.setattr(implementation, "STARTUP_SECONDS", 0.2)
+
+    with caplog.at_level("ERROR", logger="egma"):
+        await mockable(agent, in_a_simulation(room), session)
+
+    assert couriers_on(session, agent) == {}
+    assert room.asked == []
+    assert "Monitoring" in caplog.text
+
+
+async def test_a_simulation_room_egma_never_joined_says_what_to_do(
+    session, monkeypatch, caplog
+):
+    """The branch that is unreachable in production, by construction.
+
+    The room's name said simulation and nobody by egma's name ever
+    arrived, which is a simulation that will run its real tools unless
+    somebody acts. So this is the one line in the SDK that asks for
+    action: it names who to look for in the room and this package's own
+    version, and it says that this job's spans stay out of Monitoring
+    regardless, because the room's name settled that on its own.
+    """
+    agent = ReceptionAgent()
+    room = StubRoom(present=(), mocked_tools=("check_calendar",))
+    monkeypatch.setattr(implementation, "STARTUP_SECONDS", 0.2)
+
+    with caplog.at_level("ERROR", logger="egma"):
+        await mockable(agent, in_a_simulation(room), session)
+
+    assert couriers_on(session, agent) == {}
+    assert room.asked == []
+    assert "egma" in caplog.text
+    assert "Monitoring" in caplog.text
+    assert room.listeners == {}
+
+
+async def test_a_census_sent_before_egma_registered_the_exchange_is_asked_again(
+    session,
+):
+    """egma is in the room a while before it answers to anything.
+
+    Its participant enters when its transport connects; the two methods of
+    this exchange are registered later. An SDK that read the transport's
+    "no such method" as "there is no egma here" would fall open for the
+    whole simulation — every mocked tool running its real implementation,
+    which is a real appointment booked.
+    """
+    agent = ReceptionAgent()
+    room = StubRoom(mocked_tools=("check_calendar",), refuses_hello_until=2)
+
+    await mockable(agent, in_a_simulation(room), session)
+
+    assert room.methods_asked == [seam.HELLO_METHOD] * 3
+    assert set(couriers_on(session, agent)) == {"check_calendar"}
+
+
+async def test_a_census_asked_again_until_the_deadline_wraps_nothing(
+    session, monkeypatch, caplog
+):
+    """The retry is bounded, and what it ends in is the ordinary fail-open."""
+    agent = ReceptionAgent()
+    room = StubRoom(mocked_tools=("check_calendar",), refuses_hello_until=10_000)
+    monkeypatch.setattr(implementation, "STARTUP_SECONDS", 0.3)
+
+    with caplog.at_level("WARNING", logger="egma"):
+        await mockable(agent, in_a_simulation(room), session)
+
+    assert couriers_on(session, agent) == {}
+    assert room.methods_asked
+    assert EGMA_IDENTITY in caplog.text
+
+
+async def test_a_room_that_lost_egma_is_not_waited_out(session):
+    """``RECIPIENT_NOT_FOUND`` is answered at once, not asked again.
+
+    It is the same kind of race as an unregistered method in principle,
+    and it is treated differently on purpose: nothing gets as far as
+    asking without having seen egma in this room's own participant table,
+    so a destination that cannot be found now is one that left. A
+    participant that left gets the fail-open every lost participant gets.
+    Asking it again for the rest of the bound would hold this agent silent
+    through the simulation it was waiting to serve, and end in the same
+    place.
+    """
+    agent = ReceptionAgent()
+    room = StubRoom(refuses_with=not_reached())
+
+    await mockable(agent, in_a_simulation(room), session)
+
+    assert room.methods_asked == [seam.HELLO_METHOD]
+    assert couriers_on(session, agent) == {}
+
+
+# -- What dispatch metadata is worth in a simulation room ---------------------
+
+
+async def test_the_legacy_context_block_changes_nothing_in_a_simulation_room(session):
+    """egma's own four keys arrive on one dispatch path, and are not read.
+
+    Where egma dispatches the worker by name it merges a context block
+    into the job's metadata, underneath the customer's keys, for SDK
+    releases below the room-name floor. This side reads none of
+    it. The room is what said simulation, and egma is found by looking for
+    it — so this room behaves exactly like the same room with empty
+    metadata, which is the property that keeps that block deletable.
+    """
+    agent = ReceptionAgent()
+    room = StubRoom(mocked_tools=("check_calendar",))
+
+    await mockable(
+        agent,
+        StubContext(room, SIMULATION_ROOM, egma_metadata()),
+        session,
+    )
+
+    assert room.asked[0].identity == EGMA_IDENTITY
+    assert set(couriers_on(session, agent)) == {"check_calendar"}
+
+
+async def test_an_identity_named_in_metadata_is_never_the_address(
+    session, monkeypatch
+):
+    """The address comes from the room, never from a string handed to it.
+
+    The census is this agent's whole tool inventory, so who receives it is
+    the one decision in this file that a name in the customer's own
+    dispatch metadata may not make. Here that metadata names somebody who
+    is not in the room and is not egma; the room holds nobody by egma's
+    name; and the answer is the ordinary fail-open, with nothing sent to
+    anyone.
+    """
+    agent = ReceptionAgent()
+    room = StubRoom(present=("caller-8871",), mocked_tools=("check_calendar",))
+    monkeypatch.setattr(implementation, "STARTUP_SECONDS", 0.2)
+
+    await mockable(
+        agent,
+        StubContext(room, SIMULATION_ROOM, egma_metadata(identity="caller-8871")),
+        session,
+    )
+
+    assert room.asked == []
+    assert couriers_on(session, agent) == {}
+
+
+async def test_a_version_neither_side_speaks_is_learned_from_the_reply(
+    session, caplog
+):
+    """The version rides the hello, and that is where it is read.
+
+    It rides the hello in both directions. An egma that will not speak
+    this side's version refuses the census with its own code, and the one
+    thing this SDK adds to that sentence is the package the two numbers
+    belong to — because "Egma speaks 1 and this one declared 2" reads as
+    an SDK that is too new when the fix is usually the other half.
+    """
+    agent = ReceptionAgent()
+    room = StubRoom(
+        refuses_with=RpcError(
+            seam.UNSUPPORTED_PROTOCOL_VERSION,
+            "egma.hello declares which version of this exchange it speaks",
+        )
+    )
+
+    with caplog.at_level("ERROR", logger="egma"):
+        await mockable(agent, in_a_simulation(room), session)
+
+    assert couriers_on(session, agent) == {}
+    assert "egma" in caplog.text
+    assert "Upgrade" in caplog.text
 
 
 # -- Which tools get a courier ------------------------------------------------
@@ -943,6 +1303,17 @@ async def test_a_census_egma_refuses_wraps_nothing_and_says_so(session, caplog):
         pytest.param('{"protocol_version":1}', id="no names at all"),
         pytest.param('{"protocol_version":2,"mocked_tools":[]}', id="another version"),
         pytest.param(
+            '{"protocol_version":true,"mocked_tools":["check_calendar"]}',
+            id="a boolean, which python counts as one",
+        ),
+        pytest.param(
+            '{"protocol_version":"1","mocked_tools":["check_calendar"]}',
+            id="a version written as text",
+        ),
+        pytest.param(
+            '{"mocked_tools":["check_calendar"]}', id="no version at all"
+        ),
+        pytest.param(
             '{"protocol_version":1,"mocked_tools":[7]}', id="a name that is a number"
         ),
     ],
@@ -950,6 +1321,15 @@ async def test_a_census_egma_refuses_wraps_nothing_and_says_so(session, caplog):
 async def test_a_census_reply_this_side_cannot_read_wraps_nothing(
     session, reply, caplog
 ):
+    """Only the number itself will do, in the one place the number is read.
+
+    The boolean is the parameter worth naming: Python counts ``True`` as
+    equal to ``1``, so a reply carrying ``true`` would otherwise pass for
+    version 1 and this side would stand couriers on the word of a far side
+    that never said which exchange it was answering in. Each of these
+    carries a real tool name, so the only thing that can refuse them is
+    the version reading itself.
+    """
     agent = ReceptionAgent()
     room = StubRoom(hello_reply=reply)
 
@@ -1055,10 +1435,14 @@ async def test_every_message_is_one_compact_json_object(session):
     await mockable(agent, in_a_simulation(room), session)
     await called(couriers_on(session, agent)["check_calendar"], day="Tuesday")
 
+    waits = {
+        seam.HELLO_METHOD: seam.HELLO_TIMEOUT_SECONDS,
+        seam.TOOL_METHOD: seam.RESPONSE_TIMEOUT_SECONDS,
+    }
     for asked in room.asked:
         assert isinstance(json.loads(asked.payload), dict)
         assert ", " not in asked.payload
         assert len(asked.payload.encode()) <= seam.LARGEST_PAYLOAD_BYTES
         assert asked.identity == EGMA_IDENTITY
-        assert asked.response_timeout == seam.RESPONSE_TIMEOUT_SECONDS
+        assert asked.response_timeout == waits[asked.method]
         assert asked.max_round_trip_latency == seam.MAX_ROUND_TRIP_SECONDS

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "egma"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "livekit-agents" },

--- a/skills/integrate-egma/references/integrate-egma-sdk.md
+++ b/skills/integrate-egma/references/integrate-egma-sdk.md
@@ -12,8 +12,10 @@ every requested entry is present and preserve every existing Egma entry. An
 integration task adds capabilities; it removes one only when the developer asks
 for that removal explicitly.
 
-The Python package is named `egma`. Require `egma>=0.1.1` and add it through the
-dependency file the repository already uses. The Egma SDK does not yet support
+The Python package is named `egma`. Require `egma>=0.2.0` and add it through the
+dependency file the repository already uses. `0.2.0` is the first release in
+which both entries read the job's room name, which is the only signal that
+reaches the worker on all four LiveKit dispatch paths. The Egma SDK does not yet support
 a worker built with `@livekit/agents`; report that boundary and leave a Node
 worker unchanged.
 

--- a/skills/integrate-egma/references/run-livekit-agent-locally.md
+++ b/skills/integrate-egma/references/run-livekit-agent-locally.md
@@ -18,7 +18,7 @@ The process requires `LIVEKIT_URL`, `LIVEKIT_API_KEY`, and
 arguments and output.
 
 Before the worker starts, the helper checks the same Python environment that
-LiveKit will use for Egma SDK 0.1.1 or newer. When it is missing, the helper
+LiveKit will use for Egma SDK 0.2.0 or newer. When it is missing, the helper
 installs the dependency through the verified project manifest without changing
 the manifest or its lock file, then checks the import again. The helper runs
 from that manifest's project directory, which must also contain the worker.

--- a/skills/integrate-egma/scripts/livekit-local.mjs
+++ b/skills/integrate-egma/scripts/livekit-local.mjs
@@ -7,7 +7,13 @@ import path from "node:path";
 import process from "node:process";
 
 const MINIMUM_VERSION = [2, 18, 2];
-const MINIMUM_EGMA_VERSION = [0, 1, 1];
+// 0.2.0 is the first Egma SDK release whose two entries decide from the job's
+// room name. Below it they read dispatch metadata, which reaches the worker on
+// one of the four LiveKit dispatch paths, so a lower version is inert on the
+// other three without saying so. A local worker that reports ready on such an
+// environment sends the developer into a run whose mock tools never answer.
+const MINIMUM_EGMA_VERSION = [0, 2, 0];
+const MINIMUM_EGMA_SHOWN = MINIMUM_EGMA_VERSION.join(".");
 const LIVEKIT_INSTALLER = "https://get.livekit.io/cli";
 const REQUIRED_ENV = ["LIVEKIT_URL", "LIVEKIT_API_KEY", "LIVEKIT_API_SECRET"];
 const WORKER_ONLY_ENV_PREFIX = "EGMA_";
@@ -417,7 +423,9 @@ async function prepareEgmaDependency(worker) {
   const runtime = await pythonEnvironment(worker);
   const probe = ["-c", egmaVersionProbe()];
   if (pythonSucceeds(runtime, probe)) {
-    process.stderr.write("livekit-local: Egma Python SDK 0.1.1 or newer is ready.\n");
+    process.stderr.write(
+      `livekit-local: Egma Python SDK ${MINIMUM_EGMA_SHOWN} or newer is ready.\n`,
+    );
     return;
   }
 
@@ -430,7 +438,7 @@ async function prepareEgmaDependency(worker) {
   });
   if (!pythonSucceeds(runtime, probe)) {
     throw new Error(
-      "the worker environment still cannot import Egma Python SDK 0.1.1 or newer after dependency installation",
+      `the worker environment still cannot import Egma Python SDK ${MINIMUM_EGMA_SHOWN} or newer after dependency installation`,
     );
   }
 }


### PR DESCRIPTION
## The problem

The egma SDK learned it was inside a simulation by reading egma's own block out of LiveKit **dispatch metadata**. Two things were wrong with that.

**It was the customer's channel.** LiveKit teaches customers to put their per-session context in `ctx.job.metadata` — their own docs call it "useful for including details such as the user's ID, name, or phone number", and they discourage automatic dispatch *because* it cannot carry metadata. So an agent written the way LiveKit teaches reads that key, and egma overwrote it.

**It only arrived on one of four dispatch paths.** A `livekit_room` connection gets an agent into a room four ways. Only one writes a dispatch:

| Dispatch path | Dispatch metadata arrives? |
|---|---|
| Project credentials + named agent | yes |
| Project credentials + blank agent name (automatic dispatch) | **no** — LiveKit carries none |
| Token endpoint, dispatched by API | **no** — egma never dispatches |
| Token endpoint, dispatched inside the token | **no** — same |

On the three silent paths `mockable()` concluded "production" inside a real simulation. Every mocked tool ran its real implementation against a live persona — a real booking made, a real card charged — and the coverage stamp said three empty lists. The same gate is used by `monitor_livekit`, so those simulations also exported their own agent-side spans through the **production** door and appeared in Monitoring as conversations that never happened.

ADR-0008's 2026-08-10 amendment recorded half of this and left it as a follow-up candidate, never filed. The automatic-dispatch half was recorded nowhere. This is that follow-up.

## The change

**Detection is the room's name.** Every simulation room is `egma-sim-*` — a prefix egma chooses on every path, and one already published as fixed and allowlistable in the token-endpoint guide. `_simulation_in()` reads `ctx.job.room.name` before connecting and without a network, and returns nothing for any other name.

**Addressing is the participant identity.** Egma is found among the room's participants by the identity it joined as. Because the name already established this is a simulation, the SDK can *wait* for that participant — which is precisely what makes the three previously-silent paths work, since on them the agent is in the room before egma. A production room never reaches that wait.

**The dispatch channel goes back to the customer.** The configured metadata rides it beside the room copy, so an agent finds its own object wherever it already looks.

**One transition affordance.** A small context block is still merged *under* the customer's own keys, on the one path that has a dispatch, dropped whole on any key collision — so workers below `egma` 0.2.0 keep working. No current SDK reads it; `dispatch_metadata()` records the condition for deleting it.

**The SDK floor moves to `egma>=0.2.0`** across the connect wizard, the integration skills, the local-run helper and the in-product monitoring panel. 0.2.0 is the first release that holds on all four dispatch paths.

## Safety properties

- **Inert in production, with no network.** Unchanged in kind and stronger in reach: the room-name check is pre-connect and cheap, and it now holds on all four paths. Pinned by `sdks/python/tests/test_inert.py`, including a production room whose own metadata carries `egmaIdentity`.
- **Room membership is still the serving auth.** RPC targets egma's participant; a room without one serves nothing.
- **No test content reaches the agent.** The dispatch now carries only what the customer configured.
- **Trust anchor.** Creating an `egma-sim-*` room in the customer's project needs their key pair — the same anchor dispatch metadata had. The room name is read from the job, which is server-assigned.

## Two decisions worth surfacing

**Detection reads one signal, not two.** An earlier revision honoured the room name **or** an `egmaIdentity` in dispatch metadata. That was dropped. Egma names every simulation room `egma-sim-*`, so the second reading catches nothing the first does not — but it would suppress production telemetry for any customer whose own metadata happened to use that key, and a dropped trace is evidence the customer cannot get back.

**The two channels promise the value, not the bytes** (`1e4cb6a`, from Greptile's P1). An earlier revision serialised egma's dispatch copy with `ensure_ascii=False`, so the two channels would be byte-identical for non-ASCII. That was the wrong trade. `{"label":"\ud800"}` is legal JSON and the control plane admits it; the room carries it as the ASCII the customer wrote, but egma's copy is written out again, and a lone surrogate written raw has no UTF-8 form — the simulation died at dispatch over a value the other channel carried without complaint. Escaping costs bytes only on egma's copy, and an agent parses its way to the same value either way. So the room promises the string byte for byte; the dispatch promises the keys.

## Verification

Local, on the final head:

| Check | Result |
|---|---|
| `pnpm lint` | pass |
| `pnpm typecheck` | pass |
| simulator (`ruff` + `pytest`) | 636 passed, 6 skipped |
| `pnpm test:sdk` | 172 passed, 1 skipped (opt-in live test) |
| `pnpm test:fixture` | 27 passed |
| `pnpm test:fast` | 3202 passed; 7 failures reproduced identically on clean `main` with this branch stashed — environmental to that container (tests relying on `chmod 0o500` to force a write failure, which does not stop uid 0; and self-host tests reading env vars leaking from the machine). All 7 pass on CI. |

New coverage pins the two dispatch paths that were silent, a production room carrying egma's key names, a room egma never joins, two claimants to egma's identity, and a configured value with no UTF-8 form. The lost boolean guard on `protocol_version` was restored together with its deleted case. No test was removed, skipped or weakened — `test_the_two_channels_carry_the_same_characters` was rewritten as `..._same_value`, because it pinned the spelling rather than the promise.

A reported intermittent in `test_the_room_carries_the_connections_own_json` did not reproduce in five runs (two full suites, three isolated).

## Companion

Planning record — ADR-0020, the ADR-0008 boundary, the closed follow-up and the guide updates — is `egma-ai/egma-planning#68`.