### PR TITLE
Retell playground plug: the simulator types to the playground

### DIFF
--- a/apps/simulator/README.md
+++ b/apps/simulator/README.md
@@ -393,11 +393,17 @@ where a refused key and an endpoint nobody answers each end the simulation
 The `retell_playground` plug converses with `tests/playground_stub.py`: a
 real local HTTP server shaped like the completion API, which matches and
 serves the mocks each request carries the way the platform does — so a
-plug that forgot to send them would see real answers come back and the
-record would say so. Every wire field name that Retell's documentation
-was not in reach for is marked a guess in both files, in the same places,
-so one live run against a real account corrects both with two edits and
-leaves the whole suite still proving the behaviour.
+plug that forgot to send them would see real answers come back, and the
+plug refuses to stamp a call `mocked` until it has checked that the tool
+was really given Egma's own answer.
+
+Every wire field name that Retell's documentation was not in reach for is
+marked a guess in the plug's docstring. Correcting one after a live run
+means editing **three** places, listed here so none is missed: the plug,
+the stub, and `tests/test_plug_retell_playground.py`, which names several
+of the fields in its assertions. The stub deliberately does not import
+the plug's constants — a counterpart that took its wire from the thing it
+is testing would agree with a mistake instead of catching it.
 
 The `phone` plug converses through the scripted media backend the same way: a
 spec naming a number yields a transcript, an ending, per-turn timings and a

--- a/apps/simulator/README.md
+++ b/apps/simulator/README.md
@@ -43,8 +43,17 @@ touching the others:
   Retell *voice* agent the same way its browser callers do: egma creates
   the call itself — against a named version of the agent, with this
   simulation's variables attached — and Retell answers with a way into a
-  LiveKit room, so the plug creates and the room media joins. To write the
-  next, read the `plugs/__init__.py` docstring; it is the entire brief.
+  LiveKit room, so the plug creates and the room media joins.
+  `retell_playground` reaches the same Retell *voice* agent in **text**:
+  it speaks Retell's agent-playground completion API, which keeps nothing
+  between requests, so every request carries the whole history, the
+  version by name, this simulation's variables, egma's own answers as
+  native mocks, and where the engine had got to. It is the one plug that
+  puts egma in the agent's tool path without standing between the two —
+  the platform serves egma's answers itself — and the one lane with no
+  provider reference to offer, because the playground stores nothing. To
+  write the next, read the `plugs/__init__.py` docstring; it is the
+  entire brief.
 - **The media backends** (`media/`) — how a voice exchange's audio
   travels. One driver per way in, behind a four-method seam: create a
   Pipecat transport, dial, wait until somebody answers, tear it down.
@@ -381,6 +390,15 @@ protocol needs no account, no key and no network — failure paths included,
 where a refused key and an endpoint nobody answers each end the simulation
 `failed` with an honest reason and no leaked secret.
 
+The `retell_playground` plug converses with `tests/playground_stub.py`: a
+real local HTTP server shaped like the completion API, which matches and
+serves the mocks each request carries the way the platform does — so a
+plug that forgot to send them would see real answers come back and the
+record would say so. Every wire field name that Retell's documentation
+was not in reach for is marked a guess in both files, in the same places,
+so one live run against a real account corrects both with two edits and
+leaves the whole suite still proving the behaviour.
+
 The `phone` plug converses through the scripted media backend the same way: a
 spec naming a number yields a transcript, an ending, per-turn timings and a
 recording without contacting LiveKit or a real carrier. Its failure paths are
@@ -499,9 +517,11 @@ src/egma_simulator/
                   plug author's whole brief; scripted.py chats,
                   loopback.py speaks, retell.py is the first real
                   platform, phone.py dials a number, livekit.py holds
-                  an exchange in the agent's own room, and
+                  an exchange in the agent's own room,
                   retell_web_call.py creates a Retell web call and
-                  conducts it in the room that call opens.
+                  conducts it in the room that call opens, and
+                  retell_playground.py conducts a Retell voice agent in
+                  text, with no call and no audio anywhere.
   media/          The media-backend seam: how a voice exchange's Pipecat
                   transport is created. Its __init__ docstring is the
                   driver author's whole brief; livekit.py places real calls over a SIP

--- a/apps/simulator/src/egma_simulator/mock_tools.py
+++ b/apps/simulator/src/egma_simulator/mock_tools.py
@@ -229,12 +229,11 @@ class AuthoredAnswer:
     value, or — where the answer is the failure branch — the failure it
     raises. Untagged, because the tag is how the room exchange tells a
     return from a raise, and a platform serving the answer itself says
-    which one it is in its own words."""
+    which one it is in its own words.
 
-    recorded: str
-    """What the record carries for a call this answer served — the same
-    bytes the room exchange records, so a mocked call reads the same
-    whichever lane served it."""
+    It is also what a lane can hold a platform to: a plug that sees what
+    the tool was really given can compare it with this before letting the
+    record claim egma answered."""
 
     fails: bool
     """Whether this answer is the failure branch."""
@@ -315,7 +314,21 @@ class MockToolSeam:
         impossible.
 
         ``uncovered`` is the discovered names left over — the tools that
-        ran their own implementations, untouched and unobserved.
+        ran their own implementations.
+
+        **The three lists mean the same thing on both lanes, but they are
+        learned differently, and a reader should know which.** Where egma
+        *stands* in the tool path, ``discovered`` is the census the agent's
+        own session reported — every tool it has, called or not — and an
+        uncovered tool ran untouched and **unobserved**, so its presence
+        here is all that is known about it. Where egma's answers are
+        *handed to a platform* that serves them, there is no census to
+        ask: ``discovered`` is the tools the platform reported the agent
+        actually calling during this simulation, so a tool never reached
+        is simply absent, and an uncovered one ran untouched but **was
+        observed** — the platform said it happened. ``covered`` means the
+        same on both: the names egma stood ready to answer, once egma
+        really was in the path.
         """
         if not self._standing_ready:
             return None
@@ -343,7 +356,6 @@ class MockToolSeam:
             AuthoredAnswer(
                 tool_name=mock.tool_name,
                 served=_serialized(mock.answer["error" if mock.fails else "answer"]),
-                recorded=_recorded(mock),
                 fails=mock.fails,
             )
             for mock in self._answers.values()

--- a/apps/simulator/src/egma_simulator/mock_tools.py
+++ b/apps/simulator/src/egma_simulator/mock_tools.py
@@ -41,6 +41,22 @@ receive an answer — a contract rather than a room feature, and it is why
 the room driver can register these against a real LiveKit and against the
 room-shaped stand-in CI runs, with nothing here changing.
 
+## The other way egma stands in the tool path
+
+Some platforms serve egma's answers themselves: the answers ride the
+request, the platform matches them by name, and it reports afterwards
+which tools were called and what each was given. Egma is just as much in
+the tool path there — the agent's real backend was never reached — but
+there is no exchange to conduct, so :meth:`MockToolSeam.hello` and
+:meth:`MockToolSeam.tool` have nothing to do.
+
+That lane uses three other doors: :meth:`MockToolSeam.answers` for the
+answers to send, :meth:`MockToolSeam.handed_over` to say they are in the
+platform's hands, and :meth:`MockToolSeam.reported` for each call the
+platform tells egma about afterwards. The answers are rendered here, once,
+so the bytes a tool is given are the same bytes on every lane and one
+record reads across them.
+
 ## What lands on the record
 
 Every call egma answers becomes a ``tool_call`` span: the name, the
@@ -194,6 +210,36 @@ class ExchangedToolCall:
     ended_unix_nano: int
 
 
+@dataclass(frozen=True)
+class AuthoredAnswer:
+    """One mock tool's answer, rendered for a platform that serves it.
+
+    The whole of what a lane needs to hand egma's answers to somebody
+    else: the name they are matched by, the bytes the tool is given, and
+    whether the answer is the failure branch — which such a platform says
+    its own way, because it is the one serving.
+    """
+
+    tool_name: str
+    """The agent's own name for the tool, verbatim — the whole of how a
+    call is matched, and never parsed or folded."""
+
+    served: str
+    """The value the tool is given, JSON-encoded: the tool's own return
+    value, or — where the answer is the failure branch — the failure it
+    raises. Untagged, because the tag is how the room exchange tells a
+    return from a raise, and a platform serving the answer itself says
+    which one it is in its own words."""
+
+    recorded: str
+    """What the record carries for a call this answer served — the same
+    bytes the room exchange records, so a mocked call reads the same
+    whichever lane served it."""
+
+    fails: bool
+    """Whether this answer is the failure branch."""
+
+
 Sleep = Callable[[float], Awaitable[None]]
 """How the declared delay is spent. Injected so a suite can hold it."""
 
@@ -281,6 +327,85 @@ class MockToolSeam:
                 name for name in self._discovered if name not in set(covered)
             ],
         }
+
+    # -- What a platform that serves egma's answers itself uses ---------------
+
+    def answers(self) -> tuple[AuthoredAnswer, ...]:
+        """Every answer this simulation holds, rendered once.
+
+        For the lane where the platform matches and serves them itself:
+        what it needs is the answers, not a handler. Rendered here rather
+        than by whoever sends them, so two lanes cannot spell one authored
+        answer two ways and leave a reader comparing bytes that only look
+        different.
+        """
+        return tuple(
+            AuthoredAnswer(
+                tool_name=mock.tool_name,
+                served=_serialized(mock.answer["error" if mock.fails else "answer"]),
+                recorded=_recorded(mock),
+                fails=mock.fails,
+            )
+            for mock in self._answers.values()
+        )
+
+    def handed_over(self) -> None:
+        """The answers are in the platform's own hands for this exchange.
+
+        The same claim :meth:`standing_ready` makes, and one more: on this
+        lane the two are one moment. There is no census to answer and no
+        call to serve, so the handing over *is* egma coming to stand
+        between the agent and its backends — every name in the snapshot
+        will be answered by the platform from here on, by the same
+        match-anything rule egma matches by.
+        """
+        self._standing_ready = True
+        self._stood_in_the_path = True
+
+    def reported(self, name: str, *, arguments: str | None = None) -> None:
+        """One tool call the platform says it made.
+
+        Written down the way a call egma served itself is, with two
+        differences that are both the truth about this lane. It is one
+        instant, because egma did not conduct the exchange and did not time
+        it. And the result rides **only** where the snapshot covers the
+        name: a covered call was answered from egma's own authored answer,
+        so recording that answer invents nothing, while an uncovered one
+        ran the customer's real implementation and its return value is
+        neither egma's to vouch for nor the record's to stamp. An uncovered
+        call lands as the observation it is — the name, the arguments, and
+        no stamp at all, which is the record's own way of saying a real
+        backend did the work.
+
+        The answer recorded for a covered call is **egma's own rendering**
+        and never the platform's echo of it, even where the platform
+        reports one. The two are the same value, and only egma's carries
+        the tag that tells a mocked failure from a tool that returned a
+        string — the platform says that part in its own field, which the
+        record has no room for.
+
+        Never *refused*: nothing here was asked of egma, so there was
+        nothing for egma to say no to.
+        """
+        called = name.strip()
+        if not called:
+            raise ValueError("a tool call the platform reported must name a tool")
+        now = self._clock()
+        if called not in self._discovered:
+            self._discovered = (*self._discovered, called)
+        mock = self._answers.get(called)
+        self._write_down(
+            ExchangedToolCall(
+                name=called,
+                arguments=arguments,
+                answer=None if mock is None else _recorded(mock),
+                mock_tool=None if mock is None else mock.tool_name,
+                late_attached=False,
+                refused=False,
+                began_unix_nano=now,
+                ended_unix_nano=now,
+            )
+        )
 
     # -- The two methods ------------------------------------------------------
 
@@ -432,12 +557,7 @@ class MockToolSeam:
         served = _serialized(mock.answer)
         _fits_on_the_wire(f"the mock tool for {name!r}", served)
         #
-        # Known and accepted: a tool whose own return value is an object
-        # with an `error` key records the same bytes a mocked failure
-        # does. The record's vocabulary gives the branch no slot of its
-        # own, and inventing one here would be this file deciding what the
-        # contract says.
-        recorded = served if mock.fails else _serialized(mock.answer["answer"])
+        recorded = _recorded(mock)
         # Answered, so egma really did stand between this tool and its
         # backend — which is what the coverage stamp claims.
         self._stood_in_the_path = True
@@ -505,6 +625,26 @@ def _speaks_this_version(asked: dict) -> None:
         f"{HELLO_METHOD} declares which version of this exchange it speaks; "
         f"Egma speaks {PROTOCOL_VERSION} and this one declared {declared}",
     )
+
+
+def _recorded(mock: MockTool) -> str:
+    """What the record carries for a call one mock tool answered.
+
+    The **wire** carries the tag — ``{"answer": …}`` or ``{"error": …}`` —
+    because whoever serves the answer has to know whether to return it to
+    the model or raise it, and an authored value that happened to look
+    like a failure would otherwise be one. The **record** carries what the
+    call was given: the tool's own return value, untagged, because that is
+    what the agent received and what a grader reads. A failure has no
+    return value to record, so there the tag stays — it is what keeps a
+    mocked failure from reading as a tool that returned a string.
+
+    Known and accepted: a tool whose own return value is an object with an
+    ``error`` key records the same bytes a mocked failure does. The
+    record's vocabulary gives the branch no slot of its own, and inventing
+    one here would be this file deciding what the contract says.
+    """
+    return _serialized(mock.answer if mock.fails else mock.answer["answer"])
 
 
 def _serialized(value: object) -> str:

--- a/apps/simulator/src/egma_simulator/plugs/__init__.py
+++ b/apps/simulator/src/egma_simulator/plugs/__init__.py
@@ -108,10 +108,10 @@ A chat plug's is three steps, for one simulation, in order, always:
    the agent's greeting when the platform opens with one, else ``None``
    (the persona will then speak first). A plug whose platform says more
    about the opening than words may return a whole ``AgentReply`` instead,
-   and the walk reads its ``text`` and ``platform_notes``. It does **not**
-   read ``ended`` there: opening is not where an exchange ends, and a
-   platform that ends on its own greeting is a plug's own to remember and
-   report on the next ``deliver``.
+   and the walk reads all three of its facts — ``text``,
+   ``platform_notes``, and ``ended``. An agent that ends the exchange with
+   its own greeting ends the walk there, reported as the agent's doing;
+   ``deliver`` is then never called at all.
 2. ``await deliver(text)`` — hand the persona's turn to the platform and
    return the agent's answer as an ``AgentReply``:
    - ``text`` — what the agent said, or ``None`` for an answer that

--- a/apps/simulator/src/egma_simulator/plugs/__init__.py
+++ b/apps/simulator/src/egma_simulator/plugs/__init__.py
@@ -64,11 +64,16 @@ nine keyword arguments:
 - ``mock_tools`` — egma's side of the mock-tool exchange for this
   simulation (:class:`egma_simulator.mock_tools.MockToolSeam`), already
   holding the answers the run resolved. Only a plug that can **put egma in
-  the agent's tool path** has any use for it, which today is the room: it
-  offers the exchange to whoever is in the room with it and says so, and
-  that saying-so is what puts a coverage stamp on the record. Every other
-  plug takes it and drops it, and its record honestly claims nothing about
-  tools, because egma was never in the path to learn anything.
+  the agent's tool path** has any use for it, and there are two ways to be
+  in it. A plug can *stand* in the path — the room does: it offers the
+  exchange to whoever is in the room with it and says so. Or it can *hand
+  the answers over* to a platform that serves them itself — the playground
+  does: they ride every request, and the platform matches them by name. In
+  both cases the saying-so is what puts a coverage stamp on the record, and
+  every tool call the plug learns of goes to the seam, which is the only
+  writer that can stamp one ``mocked``. Every other plug takes the seam and
+  drops it, and its record honestly claims nothing about tools, because
+  egma was never in the path to learn anything.
 - ``media`` — how a call reaches the telephone network for this
   simulation (:class:`egma_simulator.config.MediaSettings`), or ``None``
   on a deployment that places no calls. Already resolved: this
@@ -79,7 +84,7 @@ nine keyword arguments:
 
 Constructors validate and hold; they never do I/O. A constructor that
 raises means the simulation fails with an honest reason before the
-connection is ever opened. Two of the eight are read for you where a plug
+connection is ever opened. Two of the nine are read for you where a plug
 uses them — :func:`named_version` and :func:`rendered_variables` below —
 so that two plugs reaching one platform cannot disagree about what a
 version reference is or what a variable may hold.

--- a/apps/simulator/src/egma_simulator/plugs/__init__.py
+++ b/apps/simulator/src/egma_simulator/plugs/__init__.py
@@ -106,7 +106,12 @@ A chat plug's is three steps, for one simulation, in order, always:
 
 1. ``await open()`` — reach the platform and start the exchange. Returns
    the agent's greeting when the platform opens with one, else ``None``
-   (the persona will then speak first).
+   (the persona will then speak first). A plug whose platform says more
+   about the opening than words may return a whole ``AgentReply`` instead,
+   and the walk reads its ``text`` and ``platform_notes``. It does **not**
+   read ``ended`` there: opening is not where an exchange ends, and a
+   platform that ends on its own greeting is a plug's own to remember and
+   report on the next ``deliver``.
 2. ``await deliver(text)`` — hand the persona's turn to the platform and
    return the agent's answer as an ``AgentReply``:
    - ``text`` — what the agent said, or ``None`` for an answer that
@@ -115,6 +120,9 @@ A chat plug's is three steps, for one simulation, in order, always:
      this answer. The walk records any final words and reports the ending
      as the agent's doing. Once returned, ``deliver`` is never called
      again.
+   - ``platform_notes`` — what the platform said about the answer that the
+     agent did not say. Kept on the record beside the turn and never in
+     it, and never shown to the persona.
    ``deliver`` is called once per persona turn, sequentially — a plug
    never sees two deliveries in flight.
 3. ``await close()`` — tear the exchange down. Called exactly once,
@@ -220,6 +228,22 @@ class AgentReply:
     Empty is the ordinary case and never a claim that none happened: most
     ways of reaching an agent say nothing about its tools, and a plug that
     cannot see them reports none rather than guessing."""
+
+    platform_notes: tuple[str, ...] = ()
+    """What the platform said about this answer that the agent did not say.
+
+    A node transition it announced, a message in a role egma has never
+    seen — content that is real, that came from the agent's side, and that
+    **is not speech**. It goes on the record beside the turn and is never
+    part of the turn's own words, for two reasons that are the same
+    reason: the persona is handed the transcript and would read a
+    transition as something said to it, and the whole point of this
+    modality is that one scenario's chat transcript and voice transcript
+    are comparable — which they stop being the moment one of them carries
+    words nobody spoke.
+
+    Empty for every plug that has nothing of the kind, which is most of
+    them."""
 
 
 class PlugError(Exception):
@@ -339,7 +363,7 @@ class ConnectionPlug(Protocol):
     @property
     def provider_reference(self) -> str | None: ...
 
-    async def open(self) -> str | None: ...
+    async def open(self) -> str | AgentReply | None: ...
 
     async def deliver(self, text: str) -> AgentReply: ...
 

--- a/apps/simulator/src/egma_simulator/plugs/__init__.py
+++ b/apps/simulator/src/egma_simulator/plugs/__init__.py
@@ -382,6 +382,7 @@ def plug_for(connection_type: str) -> PlugFactory | None:
     from .loopback import LoopbackCounterpart
     from .phone import PhoneCall
     from .retell import RetellChat
+    from .retell_playground import RetellPlayground
     from .retell_web_call import RetellWebCall
     from .scripted import ScriptedCounterpart
 
@@ -390,6 +391,7 @@ def plug_for(connection_type: str) -> PlugFactory | None:
         "loopback": LoopbackCounterpart,
         "phone_number": PhoneCall,
         "retell_chat_api": RetellChat,
+        "retell_playground": RetellPlayground,
         "retell_web_call": RetellWebCall,
         "scripted": ScriptedCounterpart,
     }.get(connection_type)

--- a/apps/simulator/src/egma_simulator/plugs/retell_playground.py
+++ b/apps/simulator/src/egma_simulator/plugs/retell_playground.py
@@ -373,9 +373,9 @@ class RetellPlayground:
 
         The whole answer rather than its words alone, because a flow can
         move node while it greets and that has to land on the opening turn
-        rather than on the next one. The walk does not read ``ended``
-        here; an agent that ended on its greeting is remembered and
-        reported on the first ``deliver`` instead.
+        rather than on the next one — and because an agent can end the
+        exchange with its greeting, which the walk reads here and reports
+        as the agent's own doing without ever asking the persona to speak.
         """
         self._session = aiohttp.ClientSession()
         return self._read(await self._exchange())
@@ -387,10 +387,13 @@ class RetellPlayground:
                 "opened"
             )
         if self._ended:
-            # The agent ended the exchange with its opening line — rare,
-            # and real: "we are closed today" and a goodbye. Retell would
-            # answer a request continuing an ended exchange with a refusal,
-            # so the ending is reported rather than argued with.
+            # The exchange is already over — the agent ended it with its
+            # opening line, say. The walk stops at the opening for exactly
+            # that case and never gets here, so this is for anything else
+            # that drives a plug: a request continuing an ended exchange
+            # is a refusal from Retell rather than a turn, and reporting
+            # the ending again is the honest answer to a question already
+            # answered.
             return AgentReply(text=None, ended=True)
         self._history.append({"role": USER_ROLE, "content": text})
         return self._read(await self._exchange())

--- a/apps/simulator/src/egma_simulator/plugs/retell_playground.py
+++ b/apps/simulator/src/egma_simulator/plugs/retell_playground.py
@@ -18,7 +18,9 @@ threads the rest forward turn by turn:
 - **the history** — the platform's own message objects, kept **verbatim**,
   with the persona's turns added as they are spoken. Verbatim because a
   stateless engine reconstructs its own context from what it wrote, and a
-  message egma tidied is a message the agent never wrote;
+  message egma tidied is a message the agent never wrote. The one thing
+  not kept is the platform's echo of the persona's own turn, where it
+  makes one: egma wrote that turn and it is in the history already;
 - **the resume state** — the current node (and the component where a flow
   names one) for a conversation flow, the current state for a Retell LLM.
   Carried under the platform's own names, never read and never invented;
@@ -408,7 +410,16 @@ class RetellPlayground:
             raise PlugError(
                 "retell answered a playground completion with no messages list"
             )
-        self._history.extend(messages)
+        # Everything the platform said, verbatim — except its echo of the
+        # persona's own turn, which egma wrote into the history before
+        # sending it. Egma owns that side of the conversation; keeping an
+        # echo would have the caller say everything twice from the next
+        # request onward, and this is the one place that could happen.
+        self._history.extend(
+            message
+            for message in messages
+            if not (isinstance(message, dict) and message.get("role") == USER_ROLE)
+        )
 
         said: list[str] = []
         for message in messages:

--- a/apps/simulator/src/egma_simulator/plugs/retell_playground.py
+++ b/apps/simulator/src/egma_simulator/plugs/retell_playground.py
@@ -54,6 +54,17 @@ served inside Retell's own execution, and a declared delay is speech-world
 fidelity — the layer chat deliberately excludes. Delays keep their whole
 meaning on the voice lanes.
 
+**Which tools may be answered at all is decided before this plug runs**,
+and that is why nothing here names a tool type. The run reads the agent's
+configuration once, classes each tool, and resolves an answer only for the
+ones it means to cover; this plug hands over exactly what it is given and
+marks a call ``mocked`` on exactly that basis. So the safe default for a
+kind nobody has proved yet — an MCP tool today, which Retell's own mocks
+do not match — is simply an answer that never arrives here, and the call
+lands on the record as the real one it was. A plug that guessed instead
+would be the one place a coverage stamp could start claiming isolation
+nobody had.
+
 **No provider reference exists, and the record says so.** The playground
 stores nothing: there is no chat, no call and no id for either side to
 look this exchange up by. The report carries ``null`` rather than a
@@ -290,7 +301,6 @@ class RetellPlayground:
         self._history: list[Any] = []
         self._resume: dict[str, Any] = {}
         self._ended = False
-        self._opened = False
 
     @property
     def base_url(self) -> str:
@@ -323,9 +333,7 @@ class RetellPlayground:
         for the caller answers with nothing, and the persona opens instead.
         """
         self._session = aiohttp.ClientSession()
-        answer = self._read(await self._exchange())
-        self._opened = True
-        return answer.text
+        return self._read(await self._exchange()).text
 
     async def deliver(self, text: str) -> AgentReply:
         if self._session is None:

--- a/apps/simulator/src/egma_simulator/plugs/retell_playground.py
+++ b/apps/simulator/src/egma_simulator/plugs/retell_playground.py
@@ -1,0 +1,614 @@
+"""Retell playground: a Retell **voice** agent, conducted in text.
+
+The fourth plug that reaches an agent where it lives, and the one that
+gives a Retell voice agent a chat door at all. It speaks Retell's
+agent-playground-completion API over outbound HTTPS: egma sends the whole
+conversation so far and Retell answers with the agent's new messages. No
+call is created, no number is dialled, no speech is synthesised, and no
+audio exists anywhere on this lane — which is the whole point. The same
+test run here and over a voice connection is the diagnostic that separates
+a broken prompt from a broken speech stack.
+
+**The exchange is stateless, and egma owns it.** Retell keeps nothing
+between requests, so every request carries the whole history, the version
+to conduct, this simulation's dynamic variables, the native tool mocks,
+and where the engine had got to. Every reply carries only what is new. Egma
+threads the rest forward turn by turn:
+
+- **the history** — the platform's own message objects, kept **verbatim**,
+  with the persona's turns added as they are spoken. Verbatim because a
+  stateless engine reconstructs its own context from what it wrote, and a
+  message egma tidied is a message the agent never wrote;
+- **the resume state** — the current node (and the component where a flow
+  names one) for a conversation flow, the current state for a Retell LLM.
+  Carried under the platform's own names, never read and never invented;
+- **the dynamic variables** — as the last reply left them, so a variable
+  the agent set in turn three is set in turn four.
+
+Its config keys, like every plug's, are its own:
+
+- ``retellAgentId`` (string, required) — the voice agent conducted, exactly
+  as the control plane stores it.
+- ``baseUrl`` (string, optional) — where the API answers, defaulting to
+  Retell itself. What lets a test converse with a playground-shaped server
+  on loopback, and a proxy stand in front of the platform for a deployment
+  that needs one.
+
+**The version is named on every request.** Retell's own default is the
+newest version, which is a moving target: a concurrent edit between one
+turn and the next would move the agent under test mid-conversation. A
+chat result has to speak for the agent real traffic reaches, so the run
+resolves the version once and this plug asks for it by name, every time.
+
+**Mock tools ride the request — and this plug is the one that uses them.**
+Retell matches them by tool name and serves them itself, so egma never
+stands between the agent and its backend here and there is no draft, no
+platform write and nothing to sweep. What egma does have is the answers,
+and it hands them over: one per tool, matched by name with the
+match-anything rule, arguments never read. A tool the run's snapshot does
+not cover runs its real implementation — and on this lane it is observed,
+because Retell reports every call it made.
+
+**Mock-tool delays are deliberately not applied here.** The answer is
+served inside Retell's own execution, and a declared delay is speech-world
+fidelity — the layer chat deliberately excludes. Delays keep their whole
+meaning on the voice lanes.
+
+**No provider reference exists, and the record says so.** The playground
+stores nothing: there is no chat, no call and no id for either side to
+look this exchange up by. The report carries ``null`` rather than a
+synthetic id egma invented, because an id nobody else holds is not a join.
+
+**Roles the record does not know are preserved, never dropped.** Egma
+reads four: the agent's words, the persona's own turns echoed back, a tool
+being called, and what that call was given. Anything else — a node
+transition Retell announces, an SMS leg, whatever a newer platform grows —
+is kept **verbatim as agent-side content** on the turn it arrived in. That
+is also how a transition lands on the record: the platform says it, and
+egma writes down what it said rather than a word of its own.
+
+Credentials are shaped ``{"apiKey": ...}`` — the shape the control plane
+seals — and are read for the ``Authorization`` header and nothing else.
+They are never logged, never returned, and never put into an exception
+message: a refusal names the status the platform answered with and the URL
+it answered from, which is what a person needs, and neither is a secret.
+Everything quoted from the platform is scrubbed of the key first, here,
+where the key is known.
+
+## The wire, and which parts of it are still a guess
+
+Every name below marked **(guess)** was designed from the effort's
+description of this API rather than read off a request that really
+happened, because no agent may probe the live platform. One live run by
+the developer corrects any of them, and the stub in
+``tests/playground_stub.py`` is wrong in exactly the same places — so a
+correction is one edit here and one there, with the whole suite still
+proving the behaviour.
+
+Out, to ``POST {base}/agent-playground-completion/{agent_id}`` (guess: the
+path, named in the planning record's earlier onboarding spec):
+
+- ``agent_version`` — the version to conduct. Retell's own name for it on
+  every other endpoint, so this one is not much of a guess.
+- ``messages`` (guess) — the whole history, oldest first.
+- ``retell_llm_dynamic_variables`` — Retell's own name on every other
+  endpoint.
+- ``tool_mocks`` (guess: that this endpoint takes them at all) — the same
+  shape Retell's test-case definitions take: ``tool_name``,
+  ``input_match_rule`` of ``"any"``, ``output`` as a string, and ``result``
+  saying whether the call succeeded.
+- ``current_node_id`` / ``current_component_id`` (guess) / ``current_state``
+  — the resume state. The first and last are Retell's own names on
+  ``create-web-call``; the component is the guess of the three.
+
+Back:
+
+- ``messages`` (guess) — the agent's **new** messages only.
+- ``agent_ended`` (guess) — the flag that ends the exchange from the
+  agent's side. An end-tool invocation among the messages is honoured too,
+  which is the same fact said the other way.
+- ``retell_llm_dynamic_variables`` or ``dynamic_variables`` (guess) — the
+  variables as they now stand.
+- the same three resume keys.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from urllib.parse import quote
+
+import aiohttp
+
+from ..client import UNREACHABLE
+from ..mock_tools import MockToolSeam
+from . import (
+    AgentReply,
+    PlugError,
+    named_version,
+    quotable,
+    rendered_variables,
+)
+from .retell import CREDENTIAL_KEYS, DEFAULT_BASE_URL, END_TOOL_NAMES
+
+COMPLETION_PATH = "/agent-playground-completion"
+"""Where the completion answers, before the agent's own id. Named here so a
+refusal can say it, and so one live correction is one edit."""
+
+MATCH_ANYTHING = "any"
+"""How a native mock is matched: by tool name, whatever the arguments were.
+
+Egma's own rule, said in Retell's word for it. A mock tool never reads a
+call's arguments — wrong arguments are caught by grading, not by matching,
+because the arguments are on the record either way — so any other rule
+would be egma answering for a tool sometimes, which is not a thing the
+coverage stamp could honestly say."""
+
+TIMEOUT_SECONDS = 60.0
+"""The most one completion may take. Generous because it waits on the
+agent's own model and on any real tool the agent called, and anything past
+it is a platform that has stopped answering rather than one thinking."""
+
+TOO_MANY_REQUESTS = 429
+PAYMENT_REQUIRED = 402
+
+RATE_LIMIT_RETRIES = 3
+"""How many times a throttled request is tried again before the simulation
+fails. Bounded on purpose: a run that quietly waited out a throttle would
+report a shorter exchange than the test asked for, and nothing on the
+record would say why."""
+
+FIRST_BACKOFF_SECONDS = 1.0
+"""How long the first retry waits; each one after it waits twice as long.
+Read at the moment it is spent, so a suite can collapse the waiting without
+changing the attempt sequence."""
+
+RESUME_KEYS = ("current_node_id", "current_component_id", "current_state")
+"""Where the engine had got to, in the platform's own names. Threaded and
+never read: which of them a given agent uses is the agent's business, and a
+plug that decided would be a plug with an opinion about somebody else's
+engine."""
+
+VARIABLE_KEYS = ("retell_llm_dynamic_variables", "dynamic_variables")
+"""What a reply may call the variables as they now stand. Two names because
+the outbound one is well attested and the inbound one is not; the first
+present wins, and a live run settles which it is."""
+
+AGENT_ROLE = "agent"
+USER_ROLE = "user"
+INVOCATION_ROLE = "tool_call_invocation"
+RESULT_ROLE = "tool_call_result"
+KNOWN_ROLES = frozenset({AGENT_ROLE, USER_ROLE, INVOCATION_ROLE, RESULT_ROLE})
+"""The four the record knows how to read. Everything else is preserved
+verbatim as agent-side content rather than dropped, because a platform
+growing a fifth must not cost a simulation part of its transcript."""
+
+_KNOWN_KEYS = {"retellAgentId", "baseUrl"}
+
+
+class RetellPlayground:
+    """One Retell voice agent, conducted in text, per instance."""
+
+    def __init__(
+        self,
+        *,
+        modality: str,
+        access_variant: str,
+        config: dict[str, Any],
+        credentials: object,
+        simulation_id: str | None = None,
+        agent_version: object = None,
+        dynamic_variables: object = None,
+        mock_tools: object = None,
+        media: object = None,
+    ) -> None:
+        # The playground stores nothing, so there is no record on Retell's
+        # side for this plug to tell which simulation it is. And no audio
+        # exists on this lane at all, so the deployment's carrier is
+        # nothing to it either.
+        del simulation_id, media
+
+        if access_variant != "retell_playground.api_key":
+            raise PlugError(
+                "the retell playground adapter does not support access variant "
+                f"{access_variant!r}"
+            )
+
+        if modality != "chat":
+            raise PlugError(
+                f"the retell playground plug speaks chat only; a {modality!r} "
+                "simulation over retell needs the plug carrying the speech legs"
+            )
+
+        unknown = set(config) - _KNOWN_KEYS
+        if unknown:
+            raise PlugError(
+                f"the retell playground plug does not know config key(s) "
+                f"{sorted(unknown)}; it knows {sorted(_KNOWN_KEYS)}"
+            )
+
+        agent_id = config.get("retellAgentId")
+        if not isinstance(agent_id, str) or not agent_id.strip():
+            raise PlugError(
+                "retell playground config: retellAgentId must be a non-empty string"
+            )
+
+        base_url = config.get("baseUrl", DEFAULT_BASE_URL)
+        if not isinstance(base_url, str) or not base_url.strip():
+            raise PlugError(
+                "retell playground config: baseUrl must be a non-empty string"
+            )
+
+        if not isinstance(credentials, dict):
+            raise PlugError(
+                "a retell playground connection needs credentials shaped {apiKey}"
+            )
+        stray = set(credentials) - CREDENTIAL_KEYS
+        if stray:
+            raise PlugError(
+                f"retell playground credentials hold no key(s) {sorted(stray)}; "
+                "they are shaped {apiKey}"
+            )
+        api_key = credentials.get("apiKey")
+        if not isinstance(api_key, str) or not api_key.strip():
+            raise PlugError(
+                "retell playground credentials: apiKey must be a non-empty string"
+            )
+
+        self._agent_id = agent_id.strip()
+        self._base_url = base_url.strip().rstrip("/")
+        self._api_key = api_key.strip()
+        self._agent_version = named_version(agent_version)
+        # The spec's own variables, held to the spec's own rule. What comes
+        # back from Retell replaces them and is *not* held to it: those are
+        # the platform's values, and a plug that refused one would be
+        # refusing the agent's own state.
+        self._variables: dict[str, Any] = dict(rendered_variables(dynamic_variables))
+        # Always a seam, even where nobody handed one over: which lane can
+        # put egma in the agent's tool path is the plug's answer to give,
+        # and this one can, so it always has somewhere to say what it saw.
+        self._mock_tools = (
+            mock_tools if isinstance(mock_tools, MockToolSeam) else MockToolSeam()
+        )
+        answers = self._mock_tools.answers()
+        self._mocks = [
+            {
+                "tool_name": answer.tool_name,
+                "input_match_rule": MATCH_ANYTHING,
+                "output": answer.served,
+                # Retell serves the answer either way; this is how it is
+                # told to hand the agent a failure rather than a value.
+                # Egma's own tag never travels — the platform is the one
+                # doing the serving, so it says which branch in its words.
+                "result": not answer.fails,
+            }
+            for answer in answers
+        ]
+        self._timeout = aiohttp.ClientTimeout(total=TIMEOUT_SECONDS)
+        self._session: aiohttp.ClientSession | None = None
+        self._history: list[Any] = []
+        self._resume: dict[str, Any] = {}
+        self._ended = False
+        self._opened = False
+
+    @property
+    def base_url(self) -> str:
+        """Where this exchange is conducted — the URL every refusal names."""
+        return self._base_url
+
+    @property
+    def completion_path(self) -> str:
+        """Where one exchange is asked for, this agent's id included."""
+        return f"{COMPLETION_PATH}/{quote(self._agent_id, safe='')}"
+
+    @property
+    def provider_reference(self) -> str | None:
+        """Nothing, always — and that is the honest answer here.
+
+        The playground keeps no record of its own: no chat is opened, no
+        call is created, and Retell hands back no id for either side to
+        look this exchange up by. A reference exists to join egma's record
+        to the platform's telemetry, and there is no telemetry to join to,
+        so the report says ``null`` rather than carrying an id only egma
+        has ever seen.
+        """
+        return None
+
+    async def open(self) -> str | None:
+        """Ask for the agent's opening line, with nothing said yet.
+
+        One bounded exchange against an empty history. An agent configured
+        to speak first has spoken by the time this answers; one that waits
+        for the caller answers with nothing, and the persona opens instead.
+        """
+        self._session = aiohttp.ClientSession()
+        answer = self._read(await self._exchange())
+        self._opened = True
+        return answer.text
+
+    async def deliver(self, text: str) -> AgentReply:
+        if self._session is None:
+            raise PlugError(
+                "a turn reached the retell playground plug before the exchange "
+                "opened"
+            )
+        if self._ended:
+            # The agent ended the exchange with its opening line — rare,
+            # and real: "we are closed today" and a goodbye. Retell would
+            # answer a request continuing an ended exchange with a refusal,
+            # so the ending is reported rather than argued with.
+            return AgentReply(text=None, ended=True)
+        self._history.append({"role": USER_ROLE, "content": text})
+        return self._read(await self._exchange())
+
+    async def close(self) -> None:
+        """Let go of the connection. Safe from every state.
+
+        There is nothing to tear down: no chat was opened, no call was
+        created, and the playground stored nothing that could be left
+        behind. Closing is closing the socket.
+        """
+        session, self._session = self._session, None
+        if session is not None:
+            await session.close()
+
+    # -- The one request this plug makes, and how it is read ------------------
+
+    def _asked(self) -> dict[str, Any]:
+        """What one exchange is asked for.
+
+        Everything the agent needs to answer this turn, because Retell
+        keeps none of it: the whole history, the version by name, this
+        simulation's variables as they now stand, the answers egma wants
+        served, and where the engine had got to. Absent stays absent — a
+        version Retell was not asked for is a version it chooses itself,
+        and an empty variable block is not the same as none, because
+        Retell renders what it is given.
+        """
+        asked: dict[str, Any] = {"messages": list(self._history)}
+        if self._agent_version is not None:
+            asked["agent_version"] = self._agent_version
+        if self._variables:
+            asked["retell_llm_dynamic_variables"] = self._variables
+        if self._mocks:
+            asked["tool_mocks"] = self._mocks
+        asked.update(self._resume)
+        return asked
+
+    async def _exchange(self) -> dict:
+        """One completion, and egma's answers into Retell's hands with it."""
+        answered = await self._call(self._asked())
+        # Said once the platform has really taken them, and not before: a
+        # request that never landed put egma in nobody's tool path, and a
+        # coverage stamp claiming otherwise is the one thing the stamp
+        # exists to make impossible.
+        self._mock_tools.handed_over()
+        return answered
+
+    def _read(self, answered: dict) -> AgentReply:
+        """The agent's new messages, become one turn on the record.
+
+        The messages join the history verbatim first, because they are
+        what the next request replays. Then they are read: the agent's
+        words are the turn, its tool calls go to the seam that stamps
+        them, and anything in a role this record does not know is kept as
+        agent-side content rather than quietly lost.
+        """
+        messages = answered.get("messages")
+        if not isinstance(messages, list):
+            raise PlugError(
+                "retell answered a playground completion with no messages list"
+            )
+        self._history.extend(messages)
+
+        said: list[str] = []
+        for message in messages:
+            if not isinstance(message, dict) or message.get("role") not in KNOWN_ROLES:
+                # A role nobody here understands, or something that is not
+                # a message at all. Preserved as the agent's own content,
+                # exactly as it arrived: a platform that grows a fifth role
+                # must not cost this simulation part of its transcript.
+                kept = _preserved(message)
+                if kept:
+                    said.append(kept)
+                continue
+            role = message.get("role")
+            if role == AGENT_ROLE:
+                spoken = message.get("content")
+                if isinstance(spoken, str) and spoken.strip():
+                    said.append(spoken.strip())
+            elif role == INVOCATION_ROLE:
+                self._observed(message)
+
+        self._resume_from(answered)
+        self._variables_from(answered)
+        self._ended = _ended(answered, messages)
+        return AgentReply(
+            text="\n".join(said) or None,
+            ended=self._ended,
+            # Deliberately empty: every tool fact this lane sees goes to
+            # the mock-tool seam, which is the only writer that can stamp
+            # a call `mocked` and say what it was given. Reporting them
+            # here as well would put each call on the record twice.
+            tool_calls=(),
+        )
+
+    def _observed(self, message: dict) -> None:
+        """One tool call Retell reported, handed to the seam that stamps it.
+
+        Marked ``mocked`` exactly where the run's snapshot covers the
+        name, and that is sound rather than optimistic: a covered name
+        rode this request as a native mock matched by name alone, so
+        Retell answered it from egma's own answer and the real tool never
+        ran. A name the snapshot does not cover ran for real, and lands as
+        the observation it is.
+
+        What the call was *given* is not read off the reply, even though
+        the reply reports it. For a covered call it is egma's own answer
+        coming back, and the seam holds a better copy — one that still
+        says which branch it was. For an uncovered one it is the
+        customer's real backend answering, which is neither egma's to
+        vouch for nor something the record has an honest stamp for.
+        """
+        name = message.get("name")
+        if not isinstance(name, str) or not name.strip():
+            return
+        arguments = message.get("arguments")
+        self._mock_tools.reported(
+            name,
+            arguments=arguments if isinstance(arguments, str) and arguments else None,
+        )
+
+    def _resume_from(self, answered: dict) -> None:
+        """Where the engine got to, carried to the next request untouched.
+
+        A key the reply names is set to what it says, and a key it names
+        as nothing is dropped — an engine that left a component is not an
+        engine still in one, and sending the emptiness back would be egma
+        arguing with it.
+        """
+        for key in RESUME_KEYS:
+            if key not in answered:
+                continue
+            moved = answered[key]
+            if moved is None:
+                self._resume.pop(key, None)
+            else:
+                self._resume[key] = moved
+
+    def _variables_from(self, answered: dict) -> None:
+        """The variables as the reply left them, carried forward as they came.
+
+        Not held to the contract's rule about what a rendered variable
+        may be. That rule guards the values *egma* sends, and is the last
+        place a mistake in a claimed spec can be named; these are the
+        platform's own values coming back, and a plug that refused one
+        would be refusing the agent's own state.
+        """
+        for key in VARIABLE_KEYS:
+            carried = answered.get(key)
+            if isinstance(carried, dict):
+                self._variables = dict(carried)
+                return
+
+    # -- Reaching the platform, without ever saying the key -------------------
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._api_key}"}
+
+    async def _call(self, payload: dict) -> dict:
+        """One completion, or a refusal saying what happened without the key.
+
+        A throttled reply is tried again a bounded number of times, waiting
+        twice as long each time, and then fails the simulation naming the
+        throttle: a run that waited one out would report a shorter exchange
+        than the test asked for with nothing on the record to say why.
+        """
+        session = self._session
+        if session is None:
+            raise PlugError("the retell playground plug was used outside its lifecycle")
+
+        url = f"{self._base_url}{self.completion_path}"
+        attempts = 0
+        while True:
+            status, body = await self._answered(session, url, payload)
+            if status != TOO_MANY_REQUESTS or attempts >= RATE_LIMIT_RETRIES:
+                break
+            await asyncio.sleep(FIRST_BACKOFF_SECONDS * (2**attempts))
+            attempts += 1
+
+        if status == TOO_MANY_REQUESTS:
+            raise PlugError(
+                f"retell throttled this simulation: it answered {status} to "
+                f"{self.completion_path} at {self._base_url}, on the first try "
+                f"and on {attempts} retries after it. Retell said: "
+                f"{quotable(body, self._api_key)}. Run fewer simulations at once, "
+                "or raise the rate limit on the Retell account — a simulation "
+                "that waited this out would be a shorter exchange than the test "
+                "asked for"
+            )
+        if status == PAYMENT_REQUIRED:
+            raise PlugError(
+                f"retell answered {status} to {self.completion_path} at "
+                f"{self._base_url}: this Retell account cannot be billed for the "
+                f"exchange. Retell said: {quotable(body, self._api_key)}. Settle "
+                "the billing on the Retell account and run the test again — "
+                "nothing about the agent under test is wrong"
+            )
+        if status // 100 != 2:
+            raise PlugError(
+                f"retell answered {status} to {self.completion_path} at "
+                f"{self._base_url}: {quotable(body, self._api_key)}"
+            )
+
+        try:
+            document = json.loads(body)
+        except ValueError as unreadable:
+            raise PlugError(
+                f"retell answered {self.completion_path} with something that is "
+                "not JSON"
+            ) from unreadable
+        if not isinstance(document, dict):
+            raise PlugError(
+                f"retell answered {self.completion_path} with "
+                f"{type(document).__name__}, not an object"
+            )
+        return document
+
+    async def _answered(
+        self, session: aiohttp.ClientSession, url: str, payload: dict
+    ) -> tuple[int, str]:
+        """One attempt: the status it came back with and what it said."""
+        try:
+            async with session.post(
+                url,
+                json=payload,
+                headers=self._headers(),
+                timeout=self._timeout,
+            ) as response:
+                return response.status, await response.text()
+        except UNREACHABLE as unreachable:
+            raise PlugError(
+                f"retell was unreachable at {url}: "
+                f"{quotable(repr(unreachable), self._api_key)}"
+            ) from unreachable
+
+
+def _preserved(message: object) -> str:
+    """One message in a role the record does not know, kept as it arrived.
+
+    Its own content where it has one, because that is what a reader wants
+    to see; the whole message otherwise, because the alternative is
+    dropping something a platform meant to tell egma. Never trimmed:
+    verbatim means verbatim, and a transition or an SMS leg is not this
+    plug's prose to tidy.
+    """
+    if isinstance(message, dict):
+        carried = message.get("content")
+        if isinstance(carried, str):
+            return carried
+    return _compact(message)
+
+
+def _compact(value: object) -> str:
+    """One JSON document, in the compact shape the rest of egma writes."""
+    return json.dumps(value, separators=(",", ":"), ensure_ascii=False, default=str)
+
+
+def _ended(answered: dict, messages: list) -> bool:
+    """Whether the agent ended the exchange with this answer.
+
+    Two ways of saying one thing, and either counts. The platform's own
+    flag is the direct statement. An end-tool invocation among the
+    messages is the agent saying it in the way a Retell agent ends any
+    exchange, and a reply carrying one without the flag still ended.
+    """
+    if answered.get("agent_ended") is True:
+        return True
+    return any(
+        isinstance(message, dict)
+        and message.get("role") == INVOCATION_ROLE
+        and message.get("name") in END_TOOL_NAMES
+        for message in messages
+    )

--- a/apps/simulator/src/egma_simulator/plugs/retell_playground.py
+++ b/apps/simulator/src/egma_simulator/plugs/retell_playground.py
@@ -72,13 +72,32 @@ stores nothing: there is no chat, no call and no id for either side to
 look this exchange up by. The report carries ``null`` rather than a
 synthetic id egma invented, because an id nobody else holds is not a join.
 
-**Roles the record does not know are preserved, never dropped.** Egma
-reads four: the agent's words, the persona's own turns echoed back, a tool
-being called, and what that call was given. Anything else — a node
-transition Retell announces, an SMS leg, whatever a newer platform grows —
-is kept **verbatim as agent-side content** on the turn it arrived in. That
-is also how a transition lands on the record: the platform says it, and
-egma writes down what it said rather than a word of its own.
+**Roles the record does not know are preserved, never dropped — and never
+spoken.** Egma reads four: the agent's words, the persona's own turns
+echoed back, a tool being called, and what that call was given. Anything
+else — a node transition Retell announces, an SMS leg, whatever a newer
+platform grows — is kept **verbatim as agent-side content** on the turn it
+arrived in, as that turn's ``platform_notes``: beside the words, never
+among them. That is also how a transition lands on the record.
+
+Beside rather than among, because the words are not just the record: they
+are handed back to the persona as the transcript it answers, and they are
+what a voice record of the same scenario is compared against. A transition
+in the turn text would have the persona replying to "moved to
+lookup_caller", and would make this lane's transcripts differ from the
+voice lane's by construction — which is the one comparison the whole
+modality exists for.
+
+**The mocks are verified before any call is stamped.** That the playground
+honours the tool-mock field is a guess (below), and it is the guess that
+could cost a customer their isolation: a JSON API that does not know a
+field commonly ignores it, and then the real backend runs while the record
+says egma answered. So what the platform reports the tool being given is
+compared against what egma sent for it, and a mismatch — or a covered call
+the platform says nothing about — fails the simulation loudly rather than
+being stamped. Verifying is not recording: what lands on the record is
+still egma's own rendering, and an uncovered call still lands as the bare
+observation it is.
 
 Credentials are shaped ``{"apiKey": ...}`` — the shape the control plane
 seals — and are read for the ``Authorization`` header and nothing else.
@@ -121,8 +140,14 @@ Back:
   agent's side. An end-tool invocation among the messages is honoured too,
   which is the same fact said the other way.
 - ``retell_llm_dynamic_variables`` or ``dynamic_variables`` (guess) — the
-  variables as they now stand.
+  variables as they now stand. **Whether a reply names all of them or only
+  the ones that changed is itself a guess**, so they are laid *over* what
+  egma holds rather than replacing it: a delta-shaped reply then loses
+  nothing, and a whole-set reply behaves identically.
 - the same three resume keys.
+
+A ``Retry-After`` on a throttled reply is honoured where it is a number of
+seconds, capped at :data:`LONGEST_BACKOFF_SECONDS`.
 """
 
 from __future__ import annotations
@@ -176,6 +201,14 @@ FIRST_BACKOFF_SECONDS = 1.0
 """How long the first retry waits; each one after it waits twice as long.
 Read at the moment it is spent, so a suite can collapse the waiting without
 changing the attempt sequence."""
+
+LONGEST_BACKOFF_SECONDS = 8.0
+"""The longest one retry ever waits, whatever the platform asked for.
+
+A ``Retry-After`` of ten minutes is a platform describing its own day, and
+a simulation that slept through it would report a shorter exchange than the
+test asked for — the very thing the bounded retry exists to prevent. Past
+this the honest answer is to fail naming the throttle."""
 
 RESUME_KEYS = ("current_node_id", "current_component_id", "current_state")
 """Where the engine had got to, in the platform's own names. Threaded and
@@ -285,6 +318,10 @@ class RetellPlayground:
             mock_tools if isinstance(mock_tools, MockToolSeam) else MockToolSeam()
         )
         answers = self._mock_tools.answers()
+        # What Egma sent for each name, kept so that what the platform
+        # reports giving the tool can be checked against it before any
+        # call is stamped mocked. See `_really_served`.
+        self._served = {answer.tool_name: answer.served for answer in answers}
         self._mocks = [
             {
                 "tool_name": answer.tool_name,
@@ -327,15 +364,21 @@ class RetellPlayground:
         """
         return None
 
-    async def open(self) -> str | None:
+    async def open(self) -> AgentReply:
         """Ask for the agent's opening line, with nothing said yet.
 
         One bounded exchange against an empty history. An agent configured
         to speak first has spoken by the time this answers; one that waits
         for the caller answers with nothing, and the persona opens instead.
+
+        The whole answer rather than its words alone, because a flow can
+        move node while it greets and that has to land on the opening turn
+        rather than on the next one. The walk does not read ``ended``
+        here; an agent that ended on its greeting is remembered and
+        reported on the first ``deliver`` instead.
         """
         self._session = aiohttp.ClientSession()
-        return self._read(await self._exchange()).text
+        return self._read(await self._exchange())
 
     async def deliver(self, text: str) -> AgentReply:
         if self._session is None:
@@ -421,16 +464,23 @@ class RetellPlayground:
             if not (isinstance(message, dict) and message.get("role") == USER_ROLE)
         )
 
+        results = {
+            message.get("tool_call_id"): message.get("content")
+            for message in messages
+            if isinstance(message, dict) and message.get("role") == RESULT_ROLE
+        }
         said: list[str] = []
+        noted: list[str] = []
         for message in messages:
             if not isinstance(message, dict) or message.get("role") not in KNOWN_ROLES:
                 # A role nobody here understands, or something that is not
-                # a message at all. Preserved as the agent's own content,
-                # exactly as it arrived: a platform that grows a fifth role
-                # must not cost this simulation part of its transcript.
+                # a message at all. Kept as agent-side content — beside the
+                # turn, never in it — because a platform that grows a fifth
+                # role must not cost this simulation part of its record,
+                # and must not put words in the agent's mouth either.
                 kept = _preserved(message)
                 if kept:
-                    said.append(kept)
+                    noted.append(kept)
                 continue
             role = message.get("role")
             if role == AGENT_ROLE:
@@ -438,7 +488,7 @@ class RetellPlayground:
                 if isinstance(spoken, str) and spoken.strip():
                     said.append(spoken.strip())
             elif role == INVOCATION_ROLE:
-                self._observed(message)
+                self._observed(message, results)
 
         self._resume_from(answered)
         self._variables_from(answered)
@@ -451,32 +501,67 @@ class RetellPlayground:
             # a call `mocked` and say what it was given. Reporting them
             # here as well would put each call on the record twice.
             tool_calls=(),
+            platform_notes=tuple(noted),
         )
 
-    def _observed(self, message: dict) -> None:
-        """One tool call Retell reported, handed to the seam that stamps it.
+    def _observed(self, message: dict, results: dict[Any, Any]) -> None:
+        """One tool call Retell reported, checked and then handed over.
 
-        Marked ``mocked`` exactly where the run's snapshot covers the
-        name, and that is sound rather than optimistic: a covered name
-        rode this request as a native mock matched by name alone, so
-        Retell answered it from egma's own answer and the real tool never
-        ran. A name the snapshot does not cover ran for real, and lands as
-        the observation it is.
+        A call whose name the run's snapshot covers is **verified before
+        it is stamped**. That the platform honours a field egma sends it
+        is the one guess on this lane that could silently cost a customer
+        their isolation: a JSON API that does not know ``tool_mocks``
+        commonly ignores it, and then the real backend runs while the
+        record says egma answered. So the answer the platform reports the
+        tool being given is compared with the answer egma sent for it, and
+        a mismatch fails the simulation loudly instead of stamping it.
 
-        What the call was *given* is not read off the reply, even though
-        the reply reports it. For a covered call it is egma's own answer
-        coming back, and the seam holds a better copy — one that still
-        says which branch it was. For an uncovered one it is the
-        customer's real backend answering, which is neither egma's to
-        vouch for nor something the record has an honest stamp for.
+        Verifying is not recording. What goes on the record is still
+        egma's own rendering — the seam holds the copy that says which
+        branch the answer was — and an uncovered call still lands as the
+        bare observation it is, because its return value is the customer's
+        backend's and nothing egma can vouch for.
         """
         name = message.get("name")
         if not isinstance(name, str) or not name.strip():
             return
+        called = name.strip()
+        if called in self._served:
+            self._really_served(called, results, message.get("tool_call_id"))
         arguments = message.get("arguments")
         self._mock_tools.reported(
-            name,
+            called,
             arguments=arguments if isinstance(arguments, str) and arguments else None,
+        )
+
+    def _really_served(
+        self, called: str, results: dict[Any, Any], call_id: object
+    ) -> None:
+        """Refuse to stamp a covered call the platform did not really serve.
+
+        Loud, and worded for whoever has to go and look: what egma sent,
+        that Retell did not use it, and what that means for the record. It
+        names the tool and neither answer — the served one is the
+        customer's authored data and the other is their backend's, and a
+        sentence about a mistake should not go on to repeat either.
+        """
+        if call_id not in results:
+            raise PlugError(
+                f"retell reported calling {called!r} and said nothing about "
+                "what the call was given, so Egma cannot confirm its own "
+                "answer was served. A tool call Egma cannot vouch for must "
+                "not be recorded as mocked: this simulation is stopped rather "
+                "than reported as isolated when it may not have been"
+            )
+        if _same_answer(results[call_id], self._served[called]):
+            return
+        raise PlugError(
+            f"retell called {called!r} and gave it something other than the "
+            "answer Egma sent for it, so the mock tools Egma passed on the "
+            "request were not used and this agent's real implementation ran. "
+            "Nothing here is safe to report as mocked. Check that this "
+            "version of the playground API takes native tool mocks under the "
+            "field name Egma sends them in"
         )
 
     def _resume_from(self, answered: dict) -> None:
@@ -497,18 +582,28 @@ class RetellPlayground:
                 self._resume[key] = moved
 
     def _variables_from(self, answered: dict) -> None:
-        """The variables as the reply left them, carried forward as they came.
+        """The variables as the reply left them, laid **over** the held set.
 
-        Not held to the contract's rule about what a rendered variable
-        may be. That rule guards the values *egma* sends, and is the last
-        place a mistake in a claimed spec can be named; these are the
-        platform's own values coming back, and a plug that refused one
-        would be refusing the agent's own state.
+        Merged rather than swapped, and that is the fail-safe reading of
+        an unmarked guess: whether a reply names every variable or only
+        the ones that changed is not documented anywhere egma could read,
+        and a plug that swapped would drop every variable a delta-shaped
+        reply left out. Egma's own attribution variable is among those, so
+        swapping would quietly stop this simulation being identifiable to
+        the agent's tools from the turn after the first change. A reply
+        wins for every name it does mention, which is right under both
+        readings.
+
+        The values are not held to the contract's rule about what a
+        rendered variable may be. That rule guards the values *egma*
+        sends, and is the last place a mistake in a claimed spec can be
+        named; these are the platform's own values coming back, and a plug
+        that refused one would be refusing the agent's own state.
         """
         for key in VARIABLE_KEYS:
             carried = answered.get(key)
             if isinstance(carried, dict):
-                self._variables = dict(carried)
+                self._variables = {**self._variables, **carried}
                 return
 
     # -- Reaching the platform, without ever saying the key -------------------
@@ -531,10 +626,12 @@ class RetellPlayground:
         url = f"{self._base_url}{self.completion_path}"
         attempts = 0
         while True:
-            status, body = await self._answered(session, url, payload)
+            status, body, asked_for = await self._attempt(session, url, payload)
             if status != TOO_MANY_REQUESTS or attempts >= RATE_LIMIT_RETRIES:
                 break
-            await asyncio.sleep(FIRST_BACKOFF_SECONDS * (2**attempts))
+            await asyncio.sleep(
+                _waiting(asked_for, FIRST_BACKOFF_SECONDS * (2**attempts))
+            )
             attempts += 1
 
         if status == TOO_MANY_REQUESTS:
@@ -575,10 +672,17 @@ class RetellPlayground:
             )
         return document
 
-    async def _answered(
+    async def _attempt(
         self, session: aiohttp.ClientSession, url: str, payload: dict
-    ) -> tuple[int, str]:
-        """One attempt: the status it came back with and what it said."""
+    ) -> tuple[int, str, str | None]:
+        """One attempt: the status, what it said, and when to come back.
+
+        The third is the platform's ``Retry-After`` where it sent one. A
+        throttled platform saying how long it wants is worth more than any
+        number egma could pick, and it is read here rather than guessed
+        at — bounded, because a header is not a promise this process has
+        to keep for minutes.
+        """
         try:
             async with session.post(
                 url,
@@ -586,12 +690,69 @@ class RetellPlayground:
                 headers=self._headers(),
                 timeout=self._timeout,
             ) as response:
-                return response.status, await response.text()
+                return (
+                    response.status,
+                    await response.text(),
+                    response.headers.get("Retry-After"),
+                )
         except UNREACHABLE as unreachable:
             raise PlugError(
                 f"retell was unreachable at {url}: "
                 f"{quotable(repr(unreachable), self._api_key)}"
             ) from unreachable
+
+
+def _waiting(asked_for: str | None, backing_off: float) -> float:
+    """How long to wait before trying a throttled request again.
+
+    The platform's own ``Retry-After`` where it sent a number egma can
+    read, and egma's own doubling backoff otherwise. Capped either way:
+    a header asking for ten minutes is a platform describing its own day,
+    and a simulation that slept through it would report a shorter exchange
+    than the test asked for — which is the whole thing the bounded retry
+    exists to prevent. Whichever wait is longer is the one taken, so the
+    platform is never asked again sooner than it said.
+    """
+    if asked_for is None:
+        return backing_off
+    try:
+        # Seconds only. `Retry-After` may also be an HTTP date, which is
+        # not read: parsing one would mean trusting two clocks to agree,
+        # and the backoff below is a perfectly good answer without it.
+        wanted = float(asked_for.strip())
+    except ValueError:
+        return backing_off
+    if wanted <= 0:
+        return backing_off
+    return min(max(wanted, backing_off), LONGEST_BACKOFF_SECONDS)
+
+
+def _same_answer(reported: object, served: str) -> bool:
+    """Whether the tool was really given the answer egma sent for it.
+
+    Compared as JSON values wherever both sides parse, because two
+    equivalent documents may be spelled differently — a re-serialized
+    object with spaces in it, keys in another order — and a plug that
+    called those different would fail a working simulation. Where either
+    side is not JSON, the bytes are compared as they are, which is the
+    only honest reading left.
+    """
+    mine, mine_read = _parsed(served)
+    if not isinstance(reported, str):
+        # Some platforms report a structured result rather than a string.
+        return mine_read and mine == reported
+    if reported == served:
+        return True
+    theirs, theirs_read = _parsed(reported)
+    return mine_read and theirs_read and mine == theirs
+
+
+def _parsed(document: str) -> tuple[object, bool]:
+    """One JSON document as its value, and whether it was one at all."""
+    try:
+        return json.loads(document), True
+    except ValueError:
+        return document, False
 
 
 def _preserved(message: object) -> str:

--- a/apps/simulator/src/egma_simulator/service.py
+++ b/apps/simulator/src/egma_simulator/service.py
@@ -407,12 +407,14 @@ class RunningSimulation:
             },
         )
 
-    async def _on_turn(self, speaker: str, text: str) -> None:
+    async def _on_turn(
+        self, speaker: str, text: str, platform_notes: tuple[str, ...] = ()
+    ) -> None:
         # The turn itself goes one way only: into the spans. What the
         # lifecycle keeps is the count, which is a fact about the whole
         # simulation rather than about any turn — so it is tallied here, as
         # the turns are observed, and rides the terminal transition.
-        self._spans.turn(speaker, text)
+        self._spans.turn(speaker, text, platform_notes)
         self._reporter.turn_count += 1
         loop = asyncio.get_running_loop()
         if speaker == "human" and self._first_human_at is None:

--- a/apps/simulator/src/egma_simulator/spans.py
+++ b/apps/simulator/src/egma_simulator/spans.py
@@ -51,6 +51,7 @@ simulation goes through it.
 
 from __future__ import annotations
 
+import json
 import time
 from collections.abc import Callable
 from contextvars import Token
@@ -88,6 +89,18 @@ TURN_SPAN_OF = {"human": "human_turn", "agent": "agent_turn"}
 so there is no second field free to disagree with it."""
 
 TURN_TEXT_ATTRIBUTE = "egma.turn.text"
+TURN_PLATFORM_NOTES_ATTRIBUTE = "egma.turn.platform_notes"
+"""What the platform said about one turn that nobody said in it.
+
+A node transition announced mid-answer, a message in a role egma has never
+seen. It is agent-side content and it is not speech, so it rides beside
+the words instead of inside them: the persona is handed the words back,
+and one scenario's chat and voice transcripts are only comparable while
+neither carries something nobody spoke.
+
+Carried as a JSON array of strings, in the order the platform said them.
+Absent for every turn that has none, which is nearly all of them.
+"""
 TOOL_NAME_ATTRIBUTE = "egma.tool.name"
 TOOL_ARGUMENTS_ATTRIBUTE = "egma.tool.arguments"
 TOOL_RESULT_ATTRIBUTE = "egma.tool.result"
@@ -203,24 +216,38 @@ class SpanEmitter:
             self._active_token = None
             raise
 
-    def turn(self, speaker: str, text: str) -> None:
+    def turn(
+        self, speaker: str, text: str, platform_notes: tuple[str, ...] = ()
+    ) -> None:
         """One transcript turn, by whichever of the two speakers took it.
 
         One instant, which is the whole truth about a message: chat is
         where this is used and a message has no duration. A turn that was
         *spoken* has two ends read off the audio, and it comes through
         :meth:`spoken_turn` instead.
+
+        ``platform_notes`` is what the platform said about the turn that
+        nobody said in it, and it rides its own attribute rather than the
+        words for the reason :data:`TURN_PLATFORM_NOTES_ATTRIBUTE` gives.
         """
         name = TURN_SPAN_OF.get(speaker)
         if name is None:
             raise ValueError(f"a turn was taken by {speaker!r}, who is not a speaker")
 
+        attributes: dict[str, str | bool] = {TURN_TEXT_ATTRIBUTE: text}
+        if platform_notes:
+            # Only ever when there is something to say. An empty list on
+            # every other turn would be a field a reader learns nothing
+            # from finding.
+            attributes[TURN_PLATFORM_NOTES_ATTRIBUTE] = json.dumps(
+                list(platform_notes), separators=(",", ":"), ensure_ascii=False
+            )
         now = self._clock()
         self._author(
             name,
             started_unix_nano=now,
             ended_unix_nano=now,
-            attributes={TURN_TEXT_ATTRIBUTE: text},
+            attributes=attributes,
         )
 
     def spoken_turn(

--- a/apps/simulator/src/egma_simulator/walk.py
+++ b/apps/simulator/src/egma_simulator/walk.py
@@ -228,11 +228,18 @@ async def conduct(
         opened = await controls.guard(plug.open())
         # Two shapes, because most platforms open with words and nothing
         # else, and one that says more about its opening should not have to
-        # hold it back until the second turn to say it. `ended` is not read
-        # here: opening is not where an exchange ends, and a platform that
-        # ends on its own greeting is the plug's to remember.
+        # hold it back until the second turn to say it.
         if isinstance(opened, AgentReply):
             await record_answer(opened)
+            if opened.ended:
+                # An agent that ends the exchange with its own greeting:
+                # "we are closed today" and a goodbye. Rare, and real. The
+                # exchange is over before the persona has said anything,
+                # so the walk stops here — asking the persona for a turn
+                # would put a line on the record that nobody heard, and
+                # whatever ended the walk afterwards would be reported as
+                # the ending instead of the agent's own doing.
+                return ended(AGENT_ENDED)
         elif opened is not None:
             await record("agent", opened)
         await answered()

--- a/apps/simulator/src/egma_simulator/walk.py
+++ b/apps/simulator/src/egma_simulator/walk.py
@@ -24,11 +24,17 @@ from dataclasses import dataclass
 from typing import Any
 
 from .persona import Persona, Turn
-from .plugs import ConnectionPlug
+from .plugs import AgentReply, ConnectionPlug
 
 logger = logging.getLogger(__name__)
 
-OnTurn = Callable[[str, str], Awaitable[None]]
+OnTurn = Callable[[str, str, tuple[str, ...]], Awaitable[None]]
+"""One transcript turn: who took it, what was said, and whatever the
+platform said *about* it that nobody said. The third is empty for almost
+every turn there has ever been, and it is a separate argument rather than
+part of the words for the reason the words are the transcript: the persona
+is handed those words back, and a transition read as speech is a
+conversation the agent never had."""
 OnTiming = Callable[[str, float], Awaitable[None]]
 OnToolCall = Callable[[str, str | None], Awaitable[None]]
 
@@ -175,9 +181,25 @@ async def conduct(
     loop = asyncio.get_running_loop()
     history: list[Turn] = []
 
-    async def record(speaker: str, text: str) -> None:
+    async def record(
+        speaker: str, text: str, notes: tuple[str, ...] = ()
+    ) -> None:
+        # The history is what the persona is handed, so it carries the
+        # words and nothing else. The notes go to the record only.
         history.append(Turn(speaker, text))
-        await on_turn(speaker, text)
+        await on_turn(speaker, text, notes)
+
+    async def record_answer(answer: AgentReply) -> None:
+        """One agent answer on the record, where there is anything to put.
+
+        An answer that carried no words is not a turn — except when the
+        platform said something about it, which is still the agent's side
+        of the conversation and still has to land somewhere. Then it is a
+        turn with no words, which is exactly what happened.
+        """
+        if answer.text is None and not answer.platform_notes:
+            return
+        await record("agent", answer.text or "", answer.platform_notes)
 
     async def answered() -> None:
         if on_answered is not None:
@@ -203,9 +225,16 @@ async def conduct(
         name=f"{name}:watchdog",
     )
     try:
-        greeting = await controls.guard(plug.open())
-        if greeting is not None:
-            await record("agent", greeting)
+        opened = await controls.guard(plug.open())
+        # Two shapes, because most platforms open with words and nothing
+        # else, and one that says more about its opening should not have to
+        # hold it back until the second turn to say it. `ended` is not read
+        # here: opening is not where an exchange ends, and a platform that
+        # ends on its own greeting is the plug's to remember.
+        if isinstance(opened, AgentReply):
+            await record_answer(opened)
+        elif opened is not None:
+            await record("agent", opened)
         await answered()
 
         while True:
@@ -234,8 +263,7 @@ async def conduct(
             if on_tool_call is not None:
                 for call in answer.tool_calls:
                     await on_tool_call(call.name, call.arguments)
-            if answer.text is not None:
-                await record("agent", answer.text)
+            await record_answer(answer)
             if answer.ended:
                 return ended(AGENT_ENDED)
             # The answer is whole, whatever it turned out to carry. Said

--- a/apps/simulator/tests/conftest.py
+++ b/apps/simulator/tests/conftest.py
@@ -810,6 +810,50 @@ def retell_spec(
     )
 
 
+def playground_spec(
+    simulation_id: str,
+    *,
+    base_url: str,
+    api_key: str,
+    agent_id: str = "agent_stubbed_voice_0001",
+    scenario: str = A_SCENARIO,
+    personality: str = A_PERSONALITY,
+    max_turns: int = 60,
+    max_duration_seconds: int = 600,
+    agent_version: object = None,
+    dynamic_variables: dict[str, str] | None = None,
+    mock_tools: list[dict] | None = None,
+) -> dict:
+    """One spec against a Retell playground connection, pointed wherever asked.
+
+    The connection block is exactly what the control plane stores for a
+    ``retell_playground`` connection — the voice agent's id in the config,
+    the key in the credentials — plus the base URL, which is what lets the
+    exchange land on a playground-shaped stub instead of the platform
+    itself. The version and the run's resolved answers ride the spec the
+    way a real run over this lane carries them: the version because it is
+    resolved once and named on every request, the answers because this is
+    the lane whose mock tools ride the request natively.
+    """
+    return a_spec(
+        simulation_id,
+        connection={
+            "agent_platform": "retell",
+            "connection_type": "retell_playground",
+            "access_variant": "retell_playground.api_key",
+            "config": {"retellAgentId": agent_id, "baseUrl": base_url},
+            "credentials": {"apiKey": api_key},
+        },
+        scenario=scenario,
+        personality=personality,
+        max_turns=max_turns,
+        max_duration_seconds=max_duration_seconds,
+        agent_version=agent_version,
+        dynamic_variables=dynamic_variables,
+        mock_tools=mock_tools,
+    )
+
+
 def assert_kept_secret(
     secret: str, *, records: list[dict], simulator: SimulatorProcess
 ) -> None:

--- a/apps/simulator/tests/conftest.py
+++ b/apps/simulator/tests/conftest.py
@@ -27,6 +27,9 @@ from pathlib import Path
 import aiohttp
 import pytest
 from aiohttp import web
+from playground_stub import PlaygroundStub
+from playground_stub import RunningStub as RunningPlayground
+from playground_stub import serving as serving_playground
 from retell_stub import RetellStub, RunningStub, serving
 
 from egma_simulator.config import DEFAULT_S3_BUCKET, DEFAULT_S3_REGION
@@ -539,6 +542,39 @@ async def start_retell_stub() -> AsyncIterator[Callable[..., Awaitable[RunningSt
             return await stack.enter_async_context(serving(RetellStub(**script)))
 
         yield start
+
+
+@pytest.fixture
+async def start_playground_stub() -> (
+    AsyncIterator[Callable[..., Awaitable[RunningPlayground]]]
+):
+    """Start playground-shaped stubs on loopback; each stops with the test.
+
+    The keyword arguments are :class:`PlaygroundStub`'s script — the key it
+    honors, the exchanges it plays, the statuses it refuses the leading
+    requests with.
+    """
+    async with contextlib.AsyncExitStack() as stack:
+
+        async def start(**script: object) -> RunningPlayground:
+            return await stack.enter_async_context(
+                serving_playground(PlaygroundStub(**script))
+            )
+
+        yield start
+
+
+@pytest.fixture
+def quick_playground_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Collapse the playground's rate-limit backoff to milliseconds.
+
+    Only the waiting is shortened. How many times a throttled request is
+    tried again, and what happens when they run out, are exactly the
+    production ones.
+    """
+    from egma_simulator.plugs import retell_playground
+
+    monkeypatch.setattr(retell_playground, "FIRST_BACKOFF_SECONDS", 0.001)
 
 
 @pytest.fixture

--- a/apps/simulator/tests/playground_stub.py
+++ b/apps/simulator/tests/playground_stub.py
@@ -1,0 +1,318 @@
+"""CI's Retell playground: a local HTTP server shaped like the completion API.
+
+The one endpoint the playground plug speaks — Retell's agent-playground
+completion — answering with Retell's own field names, status codes and
+bearer-key auth, from a script. Real HTTP on a loopback port, because a
+plug's whole job is speaking a platform's wire protocol and a mock of that
+protocol would prove the mock instead.
+
+It is a **stateless** counterpart, exactly as the API it stands in for is:
+it keeps no conversation. Every request carries the whole history, the
+mocks to serve, and where the engine had got to; every reply carries only
+what is new. So this server holds a script and a log, and nothing that
+would let the plug get away with sending less than it must.
+
+Two behaviours here are the platform's rather than the script's, and they
+are what the plug is really proved against:
+
+- **The mocks are matched and served here.** A scripted tool call is
+  answered with the request's own mock for that name where one rode along,
+  and with the script's real return value where none did. A plug that
+  forgot to send the mocks would therefore see real answers come back, and
+  the record would say so.
+- **The version is never defaulted.** The request's ``agent_version`` is
+  logged verbatim, absent included, so a test can say what the plug asked
+  for and — just as much — what it did not.
+
+Its refusals are the platform's too: a request without the exact bearer key
+is refused 401, a request naming no agent is refused 422, and the scripted
+``refusals`` play a throttle or a billing wall in front of a working
+account. Those are what the plug's failure paths are tested against.
+
+**Every field name here is a guess where Retell's documentation was not in
+reach**, marked in :mod:`egma_simulator.plugs.retell_playground` where the
+plug names the same field. The two are wrong together or right together,
+which is the point: one live run against the real platform corrects both.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from urllib.parse import unquote
+
+from aiohttp import web
+
+COMPLETION_ROUTE = "/agent-playground-completion/{agent_id}"
+"""Where the completion answers, in aiohttp's own routing spelling."""
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+@dataclass(frozen=True)
+class ToolTurn:
+    """One tool the scripted agent calls while producing an answer."""
+
+    name: str
+    arguments: str | None = None
+    real_result: str = '{"ok":true,"from":"the real backend"}'
+    """What comes back when **no** mock rode the request for this name —
+    the customer's own implementation running, which is what an uncovered
+    tool does on this lane."""
+
+
+@dataclass(frozen=True)
+class Reply:
+    """One scripted exchange: what the agent does with one request."""
+
+    words: str | Sequence[str] | None = None
+    """What it says. A list is several messages in one reply, the way an
+    agent that sends two bubbles for one turn does."""
+
+    tools: Sequence[ToolTurn] = ()
+    """The tools it calls while producing the words."""
+
+    node: str | None = None
+    """The conversation-flow node it moved to, if it moved."""
+
+    component: str | None = None
+    """The flow component it moved into, where the flow names one."""
+
+    state: str | None = None
+    """The Retell-LLM state it moved to, if it moved."""
+
+    variables: dict | None = None
+    """The dynamic variables as they stand after this exchange."""
+
+    ends: bool = False
+    """Whether the agent ended the exchange with this answer."""
+
+    extra: Sequence[dict] = ()
+    """Messages in roles nobody here has to understand — a transition
+    announcement, an SMS leg, whatever a newer platform grows. They ride
+    the reply verbatim, which is what the plug's preservation rule is
+    proved against."""
+
+    seconds: float = 0.0
+    """How long this exchange takes, the way a real agent takes time."""
+
+
+@dataclass
+class PlaygroundStub:
+    """One scripted Retell account: an agent, a key, and what it does."""
+
+    api_key: str = "stub-key-not-a-real-secret"
+
+    replies: Sequence[Reply] = ()
+    """The agent's exchanges, in order. The first is the **opening** — the
+    request that carries an empty history — so a script whose first reply
+    says nothing is an agent that lets the persona open."""
+
+    refusals: Sequence[int] = ()
+    """A status per leading request, consumed in order: 429 for a throttle,
+    402 for a billing wall. A request past the end of this list is answered
+    from the script, which is how "retries and then succeeds" is written."""
+
+    echo_key_in_refusal: bool = False
+    """When true, a refused request comes back quoting the key it was given.
+
+    Careless platforms do this, and a plug quoting a platform's own words
+    into a failure reason is how a secret reaches a log it was never meant
+    to reach. Nothing here can stop a platform doing it; the plug is what
+    has to survive it."""
+
+    answers_without_messages: bool = False
+    """A 2xx reply with no message list at all — the shape a plug must
+    refuse rather than read as an agent that said nothing."""
+
+    requests: list[dict] = field(default_factory=list)
+    """Every request served, in order, with its whole body — the exchange
+    from the platform's own side."""
+
+    _answered: int = 0
+    """How many exchanges the script has really played, which is what walks
+    it — a request this server refused is one the agent never saw."""
+
+    def histories(self) -> list[list[dict]]:
+        """The message history each request carried, in order."""
+        return [request["body"].get("messages", []) for request in self.requests]
+
+    def mocks(self) -> list[list[dict]]:
+        """The native mocks each request carried, in order."""
+        return [request["body"].get("tool_mocks", []) for request in self.requests]
+
+    def delivered(self) -> list[str]:
+        """What the persona said, read off the histories the way the
+        platform sees it: the last message of each request that ends with
+        one from the user."""
+        spoken = []
+        for history in self.histories():
+            if history and history[-1].get("role") == "user":
+                spoken.append(history[-1].get("content"))
+        return spoken
+
+    def _authorized(self, request: web.Request) -> None:
+        offered = request.headers.get("Authorization", "")
+        if offered != f"Bearer {self.api_key}":
+            told = offered if self.echo_key_in_refusal else ""
+            raise web.HTTPUnauthorized(
+                text=json.dumps({"error_message": f"invalid api key {told}".strip()}),
+                content_type="application/json",
+            )
+
+    def _message(self, role: str, content: str, index: int) -> dict:
+        return {
+            "message_id": f"msg_{len(self.requests)}_{index}_{role}",
+            "role": role,
+            "content": content,
+            "created_timestamp": _now_ms(),
+        }
+
+    async def _completion(self, request: web.Request) -> web.Response:
+        self._authorized(request)
+        agent_id = unquote(request.match_info["agent_id"])
+        body = await request.json()
+        if not agent_id:
+            raise web.HTTPUnprocessableEntity(text="agent_id is required")
+
+        served = len(self.requests)
+        # Recorded before any refusal, not after it: a request a platform
+        # turned down is still a request it was asked, and a test that wants
+        # to know whether egma really asked again has nowhere else to look.
+        self.requests.append(
+            {
+                "agent_id": agent_id,
+                "agent_version": body.get("agent_version"),
+                "body": body,
+            }
+        )
+        if served < len(self.refusals):
+            told = f"key {self.api_key}" if self.echo_key_in_refusal else "no capacity"
+            raise _refusal(self.refusals[served], told)
+
+        if body.get("messages") is None:
+            raise web.HTTPUnprocessableEntity(text="messages is required")
+
+        # The script is walked by the exchanges really conducted, not by the
+        # requests made: a refused request is one the agent never saw, so a
+        # throttle that lets up resumes the conversation rather than skipping
+        # past the part of it nobody had yet.
+        served = self._answered
+        self._answered += 1
+        reply = (
+            self.replies[served]
+            if served < len(self.replies)
+            else Reply(words="Still here.")
+        )
+        if reply.seconds:
+            await asyncio.sleep(reply.seconds)
+        if self.answers_without_messages:
+            return web.json_response({"agent_ended": False}, status=201)
+
+        offered = {
+            mock.get("tool_name"): mock
+            for mock in body.get("tool_mocks") or []
+            if isinstance(mock, dict)
+        }
+        messages: list[dict] = []
+        for index, tool in enumerate(reply.tools):
+            call_id = f"tool_call_{served}_{index}"
+            messages.append(
+                {
+                    "message_id": f"msg_{served}_{index}_invocation",
+                    "role": "tool_call_invocation",
+                    "tool_call_id": call_id,
+                    "name": tool.name,
+                    "arguments": tool.arguments,
+                    "created_timestamp": _now_ms(),
+                }
+            )
+            # The whole point of the lane: a mock that rode the request is
+            # matched by name and served, and anything else runs for real.
+            mock = offered.get(tool.name)
+            messages.append(
+                {
+                    "message_id": f"msg_{served}_{index}_result",
+                    "role": "tool_call_result",
+                    "tool_call_id": call_id,
+                    "content": (
+                        tool.real_result if mock is None else mock.get("output")
+                    ),
+                    "created_timestamp": _now_ms(),
+                }
+            )
+        if reply.node or reply.state:
+            moved = reply.node or reply.state
+            messages.append(
+                {
+                    "message_id": f"msg_{served}_transition",
+                    "role": "node_transition",
+                    "content": f"moved to {moved}",
+                    "created_timestamp": _now_ms(),
+                }
+            )
+        messages.extend(reply.extra)
+        if reply.words is not None:
+            bubbles = (
+                [reply.words] if isinstance(reply.words, str) else list(reply.words)
+            )
+            messages.extend(
+                self._message("agent", bubble, index)
+                for index, bubble in enumerate(bubbles)
+            )
+
+        answered: dict = {"messages": messages, "agent_ended": reply.ends}
+        if reply.node is not None:
+            answered["current_node_id"] = reply.node
+        if reply.component is not None:
+            answered["current_component_id"] = reply.component
+        if reply.state is not None:
+            answered["current_state"] = reply.state
+        if reply.variables is not None:
+            answered["retell_llm_dynamic_variables"] = reply.variables
+        return web.json_response(answered, status=201)
+
+    def build_app(self) -> web.Application:
+        app = web.Application()
+        app.router.add_post(COMPLETION_ROUTE, self._completion)
+        return app
+
+
+def _refusal(status: int, told: str) -> web.HTTPException:
+    """The platform saying no, in the status the script asked for."""
+    body = json.dumps({"error_message": f"refused: {told}"})
+    refusals = {
+        402: web.HTTPPaymentRequired,
+        429: web.HTTPTooManyRequests,
+        500: web.HTTPInternalServerError,
+    }
+    return refusals.get(status, web.HTTPBadRequest)(
+        text=body, content_type="application/json"
+    )
+
+
+@dataclass
+class RunningStub:
+    """A stub on a loopback port, and the base URL a spec points at."""
+
+    base_url: str
+    stub: PlaygroundStub
+
+
+@asynccontextmanager
+async def serving(stub: PlaygroundStub) -> AsyncIterator[RunningStub]:
+    """Serve one stub on an ephemeral loopback port for the test's life."""
+    runner = web.AppRunner(stub.build_app())
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    try:
+        yield RunningStub(f"http://127.0.0.1:{runner.addresses[0][1]}", stub)
+    finally:
+        await runner.cleanup()

--- a/apps/simulator/tests/playground_stub.py
+++ b/apps/simulator/tests/playground_stub.py
@@ -88,7 +88,13 @@ class Reply:
     """The Retell-LLM state it moved to, if it moved."""
 
     variables: dict | None = None
-    """The dynamic variables as they stand after this exchange."""
+    """The dynamic variables the reply names. Whether a real reply names
+    all of them or only the ones that changed is not documented anywhere,
+    so a script can play either."""
+
+    variables_key: str = "retell_llm_dynamic_variables"
+    """Which name the reply carries them under. The plug reads two, and
+    this is how the second one is exercised."""
 
     ends: bool = False
     """Whether the agent ended the exchange with this answer."""
@@ -130,6 +136,16 @@ class PlaygroundStub:
     answers_without_messages: bool = False
     """A 2xx reply with no message list at all — the shape a plug must
     refuse rather than read as an agent that said nothing."""
+
+    ignores_tool_mocks: bool = False
+    """The failure the whole native-mock design rests on not happening: a
+    platform that does not know the ``tool_mocks`` field, ignores it the
+    way JSON APIs commonly do, and runs the customer's real tool instead.
+    Nothing on the wire says it happened — the reply looks ordinary — so
+    the only evidence is that the tool was given something else."""
+
+    retry_after: str | None = None
+    """What a throttling reply asks for in its ``Retry-After`` header."""
 
     requests: list[dict] = field(default_factory=list)
     """Every request served, in order, with its whole body — the exchange
@@ -194,7 +210,7 @@ class PlaygroundStub:
         )
         if served < len(self.refusals):
             told = f"key {self.api_key}" if self.echo_key_in_refusal else "no capacity"
-            raise _refusal(self.refusals[served], told)
+            raise _refusal(self.refusals[served], told, self.retry_after)
 
         if body.get("messages") is None:
             raise web.HTTPUnprocessableEntity(text="messages is required")
@@ -215,11 +231,15 @@ class PlaygroundStub:
         if self.answers_without_messages:
             return web.json_response({"agent_ended": False}, status=201)
 
-        offered = {
-            mock.get("tool_name"): mock
-            for mock in body.get("tool_mocks") or []
-            if isinstance(mock, dict)
-        }
+        offered = (
+            {}
+            if self.ignores_tool_mocks
+            else {
+                mock.get("tool_name"): mock
+                for mock in body.get("tool_mocks") or []
+                if isinstance(mock, dict)
+            }
+        )
         messages: list[dict] = []
         for index, tool in enumerate(reply.tools):
             call_id = f"tool_call_{served}_{index}"
@@ -275,7 +295,7 @@ class PlaygroundStub:
         if reply.state is not None:
             answered["current_state"] = reply.state
         if reply.variables is not None:
-            answered["retell_llm_dynamic_variables"] = reply.variables
+            answered[reply.variables_key] = reply.variables
         return web.json_response(answered, status=201)
 
     def build_app(self) -> web.Application:
@@ -284,7 +304,9 @@ class PlaygroundStub:
         return app
 
 
-def _refusal(status: int, told: str) -> web.HTTPException:
+def _refusal(
+    status: int, told: str, retry_after: str | None = None
+) -> web.HTTPException:
     """The platform saying no, in the status the script asked for."""
     body = json.dumps({"error_message": f"refused: {told}"})
     refusals = {
@@ -293,7 +315,9 @@ def _refusal(status: int, told: str) -> web.HTTPException:
         500: web.HTTPInternalServerError,
     }
     return refusals.get(status, web.HTTPBadRequest)(
-        text=body, content_type="application/json"
+        text=body,
+        content_type="application/json",
+        headers=None if retry_after is None else {"Retry-After": retry_after},
     )
 
 

--- a/apps/simulator/tests/test_acceptance.py
+++ b/apps/simulator/tests/test_acceptance.py
@@ -36,6 +36,7 @@ from conftest import (
     measures_for,
     milliseconds_of,
     phone_spec,
+    playground_spec,
     retell_spec,
     scripted_spec,
     span_attribute,
@@ -44,6 +45,7 @@ from conftest import (
     terminal_event_for,
     turns_for,
 )
+from playground_stub import Reply, ToolTurn
 
 from egma_simulator.model import GOODBYE
 from egma_simulator.recording import channels_of
@@ -740,6 +742,160 @@ async def test_a_retell_endpoint_that_answers_nowhere_fails_honestly(
     assert terminal["facts"]["ending"] == "error"
     assert "unreachable" in terminal["reason"], terminal["reason"]
     assert "127.0.0.1:1" in terminal["reason"], terminal["reason"]
+
+    simulator.stop()
+    assert_kept_secret(sentinel, records=records, simulator=simulator)
+
+
+async def test_a_retell_voice_agent_is_conducted_in_text_and_reads_back(
+    workbench, start_simulator, start_playground_stub
+):
+    """The chat door for a Retell **voice** agent, black-box.
+
+    A spec carrying a playground connection block goes in, and what comes
+    back is a record with everything this lane promises on it: the turns,
+    the transition the platform announced, one tool call marked ``mocked``
+    because the run's snapshot covered its name and one carrying no stamp
+    at all because it ran for real, a coverage stamp saying which was
+    which, no audio, and no provider reference — because the playground
+    keeps no record of its own and an id only egma has seen is not a join.
+    """
+    sentinel = "SENTINEL-playground-key-0d4f8b3e6a12"
+    running = await start_playground_stub(
+        api_key=sentinel,
+        replies=[
+            Reply(words="Lakeside Dental, how can I help?", node="greet"),
+            Reply(
+                words="Thursday at half past two, then.",
+                node="offer_slot",
+                tools=[
+                    ToolTurn(
+                        name="get_availability", arguments='{"day":"thursday"}'
+                    ),
+                    ToolTurn(
+                        name="lookup_customer",
+                        arguments='{"phone":"+15551234567"}',
+                        real_result='{"customer_id":"cus_9931"}',
+                    ),
+                ],
+                ends=True,
+            ),
+        ],
+    )
+    spec = playground_spec(
+        "sim-playground-001",
+        base_url=running.base_url,
+        api_key=sentinel,
+        agent_id="agent_lakeside_voice",
+        agent_version=106,
+        dynamic_variables={"egma_simulation": "sim-playground-001"},
+        scenario="I need to move my Tuesday cleaning to Thursday.",
+        mock_tools=[
+            {
+                "tool_name": "get_availability",
+                "answer": {"answer": {"slots": ["thu-1430"]}},
+                "delay_milliseconds": 30000,
+            }
+        ],
+    )
+    await workbench.offer(spec)
+    simulator = start_simulator(workbench, log_level="DEBUG")
+
+    records = await workbench.wait_for(has_terminal("sim-playground-001"))
+
+    # The transcript, the transition included: a node transition arrives in
+    # a role the record does not know, and the rule for those is that they
+    # are preserved verbatim as the agent's own content rather than lost.
+    assert turns_for(records, "sim-playground-001") == [
+        ("agent", "moved to greet\nLakeside Dental, how can I help?"),
+        ("human", "I need to move my Tuesday cleaning to Thursday."),
+        ("agent", "moved to offer_slot\nThursday at half past two, then."),
+    ]
+
+    terminal = terminal_event_for(records, "sim-playground-001")
+    assert terminal["status"] == "completed"
+    assert terminal["facts"]["ending"] == "agent_ended"
+    # No audio exists anywhere on this lane, and the record says so.
+    assert terminal["facts"]["audio"] is None
+    # No provider reference exists either, and the record says that too,
+    # rather than carrying an id egma invented for itself.
+    assert terminal["facts"]["provider_reference"] is None
+    assert terminal["facts"]["mock_tool_coverage"] == {
+        "discovered": ["get_availability", "lookup_customer"],
+        "covered": ["get_availability"],
+        "uncovered": ["lookup_customer"],
+    }
+
+    # The tool facts, at the grain the honesty claim is made at: the
+    # covered call carries what Egma answered with and the stamp that says
+    # Egma authored it; the uncovered one carries neither, which is the
+    # record's own way of saying a real backend did the work.
+    spans = [record["span"] for record in spans_for(records, "sim-playground-001")]
+    calls = [span for span in spans if span["name"] == "tool_call"]
+    assert [span_attribute(span, "egma.tool.name") for span in calls] == [
+        "get_availability",
+        "lookup_customer",
+    ]
+    mocked, real = calls
+    assert span_attribute(mocked, "egma.tool.arguments") == '{"day":"thursday"}'
+    assert span_attribute(mocked, "egma.tool.result") == '{"slots":["thu-1430"]}'
+    assert span_attribute(mocked, "egma.tool.provenance") == "mocked"
+    assert span_attribute(mocked, "egma.tool.mock_tool") == "get_availability"
+    assert span_attribute(real, "egma.tool.arguments") == '{"phone":"+15551234567"}'
+    assert span_attribute(real, "egma.tool.result") is None
+    assert span_attribute(real, "egma.tool.provenance") is None
+
+    # And the platform's side of the same story: every request named the
+    # version the spec resolved — never Retell's own moving default — and
+    # carried Egma's answers for it to serve.
+    stub = running.stub
+    assert [request["agent_version"] for request in stub.requests] == [106, 106]
+    assert [mock["tool_name"] for mock in stub.mocks()[0]] == ["get_availability"]
+    assert stub.mocks()[0][0]["input_match_rule"] == "any"
+    assert stub.delivered() == ["I need to move my Tuesday cleaning to Thursday."]
+
+    simulator.stop()
+    assert_kept_secret(sentinel, records=records, simulator=simulator)
+
+
+async def test_a_playground_billing_wall_fails_loudly_and_says_nothing(
+    workbench, start_simulator, start_playground_stub
+):
+    """The failing conduct, with the key the platform really accepted.
+
+    The request is authorized and then refused for billing, and the
+    platform is careless enough to say the key back in its own error body.
+    The simulation fails with a reason a person can act on — the status,
+    where it came from, and that it is about billing rather than about the
+    agent under test — and the key appears in none of the three places it
+    could surface.
+    """
+    sentinel = "SENTINEL-playground-key-billing-7c1a"
+    running = await start_playground_stub(
+        api_key=sentinel, refusals=(402,), echo_key_in_refusal=True
+    )
+    spec = playground_spec(
+        "sim-playground-billing", base_url=running.base_url, api_key=sentinel
+    )
+    await workbench.offer(spec)
+    simulator = start_simulator(workbench, log_level="DEBUG")
+
+    records = await workbench.wait_for(has_terminal("sim-playground-billing"))
+
+    assert status_events_for(records, "sim-playground-billing") == [
+        "running",
+        "failed",
+    ]
+    terminal = terminal_event_for(records, "sim-playground-billing")
+    assert terminal["facts"]["ending"] == "error"
+    assert terminal["facts"]["turn_count"] == 0
+    assert "402" in terminal["reason"], terminal["reason"]
+    assert "billing" in terminal["reason"], terminal["reason"]
+    # Nothing was conducted: no exchange happened off the record.
+    assert turns_for(records, "sim-playground-billing") == []
+    # And Egma never stood in this agent's tool path, so it claims nothing
+    # about its tools.
+    assert terminal["facts"].get("mock_tool_coverage") is None
 
     simulator.stop()
     assert_kept_secret(sentinel, records=records, simulator=simulator)

--- a/apps/simulator/tests/test_acceptance.py
+++ b/apps/simulator/tests/test_acceptance.py
@@ -803,14 +803,28 @@ async def test_a_retell_voice_agent_is_conducted_in_text_and_reads_back(
 
     records = await workbench.wait_for(has_terminal("sim-playground-001"))
 
-    # The transcript, the transition included: a node transition arrives in
-    # a role the record does not know, and the rule for those is that they
-    # are preserved verbatim as the agent's own content rather than lost.
+    # The transcript is what was said and only that — which is what makes
+    # this record comparable with a voice record of the same scenario, and
+    # what keeps the persona from answering a node transition.
     assert turns_for(records, "sim-playground-001") == [
-        ("agent", "moved to greet\nLakeside Dental, how can I help?"),
+        ("agent", "Lakeside Dental, how can I help?"),
         ("human", "I need to move my Tuesday cleaning to Thursday."),
-        ("agent", "moved to offer_slot\nThursday at half past two, then."),
+        ("agent", "Thursday at half past two, then."),
     ]
+
+    # The transitions are on the record all the same, beside the turns they
+    # happened in: a node transition arrives in a role the record does not
+    # know, and the rule for those is that they are preserved verbatim as
+    # agent-side content rather than lost or spoken.
+    spans = [record["span"] for record in spans_for(records, "sim-playground-001")]
+    agent_turns = [span for span in spans if span["name"] == "agent_turn"]
+    assert [
+        span_attribute(span, "egma.turn.platform_notes") for span in agent_turns
+    ] == ['["moved to greet"]', '["moved to offer_slot"]']
+    human_turns = [span for span in spans if span["name"] == "human_turn"]
+    assert [
+        span_attribute(span, "egma.turn.platform_notes") for span in human_turns
+    ] == [None]
 
     terminal = terminal_event_for(records, "sim-playground-001")
     assert terminal["status"] == "completed"
@@ -830,7 +844,6 @@ async def test_a_retell_voice_agent_is_conducted_in_text_and_reads_back(
     # covered call carries what Egma answered with and the stamp that says
     # Egma authored it; the uncovered one carries neither, which is the
     # record's own way of saying a real backend did the work.
-    spans = [record["span"] for record in spans_for(records, "sim-playground-001")]
     calls = [span for span in spans if span["name"] == "tool_call"]
     assert [span_attribute(span, "egma.tool.name") for span in calls] == [
         "get_availability",

--- a/apps/simulator/tests/test_acceptance.py
+++ b/apps/simulator/tests/test_acceptance.py
@@ -858,6 +858,57 @@ async def test_a_retell_voice_agent_is_conducted_in_text_and_reads_back(
     assert_kept_secret(sentinel, records=records, simulator=simulator)
 
 
+async def test_a_playground_exchange_the_agent_never_ends_hits_the_turn_limit(
+    workbench, start_simulator, start_playground_stub
+):
+    """The limits keep their job on this lane, unchanged.
+
+    Nothing in the plug ends an exchange the agent did not end, so an agent
+    that would answer forever runs out of turns instead — reported as the
+    limit it was and never as the agent failing. The coverage stamp is
+    still made, because Egma's answers were in the platform's hands from
+    the first request whether or not the agent ever called a tool.
+    """
+    sentinel = "SENTINEL-playground-key-limits-2f9b"
+    running = await start_playground_stub(
+        api_key=sentinel,
+        replies=[Reply(words="Lakeside Dental."), Reply(words="Go on.")],
+    )
+    spec = playground_spec(
+        "sim-playground-limit",
+        base_url=running.base_url,
+        api_key=sentinel,
+        max_turns=3,
+        scenario="I want to move my cleaning. I can do any Thursday.",
+        mock_tools=[
+            {
+                "tool_name": "get_availability",
+                "answer": {"answer": {"slots": []}},
+                "delay_milliseconds": 0,
+            }
+        ],
+    )
+    await workbench.offer(spec)
+    simulator = start_simulator(workbench, log_level="DEBUG")
+
+    records = await workbench.wait_for(has_terminal("sim-playground-limit"))
+
+    terminal = terminal_event_for(records, "sim-playground-limit")
+    assert terminal["status"] == "completed"
+    assert terminal["facts"]["ending"] == "limit_reached"
+    assert "turn limit" in terminal["reason"], terminal["reason"]
+    assert terminal["facts"]["turn_count"] == 3
+    assert terminal["facts"]["provider_reference"] is None
+    assert terminal["facts"]["mock_tool_coverage"] == {
+        "discovered": [],
+        "covered": ["get_availability"],
+        "uncovered": [],
+    }
+
+    simulator.stop()
+    assert_kept_secret(sentinel, records=records, simulator=simulator)
+
+
 async def test_a_playground_billing_wall_fails_loudly_and_says_nothing(
     workbench, start_simulator, start_playground_stub
 ):

--- a/apps/simulator/tests/test_acceptance.py
+++ b/apps/simulator/tests/test_acceptance.py
@@ -871,6 +871,50 @@ async def test_a_retell_voice_agent_is_conducted_in_text_and_reads_back(
     assert_kept_secret(sentinel, records=records, simulator=simulator)
 
 
+async def test_a_playground_agent_that_ends_on_its_greeting_reads_back_that_way(
+    workbench, start_simulator, start_playground_stub
+):
+    """The agent closing the exchange with its own opening line.
+
+    "We are closed today" and a goodbye, before the persona has said
+    anything. The record shows the greeting and nothing after it: no
+    persona turn, because there was nobody left to say it to, and the
+    ending is the agent's own doing rather than whichever limit would have
+    tripped later.
+    """
+    sentinel = "SENTINEL-playground-key-closed-4a8d"
+    running = await start_playground_stub(
+        api_key=sentinel,
+        replies=[
+            Reply(words="We are closed today. Please call back tomorrow.", ends=True)
+        ],
+    )
+    spec = playground_spec(
+        "sim-playground-closed",
+        base_url=running.base_url,
+        api_key=sentinel,
+        scenario="I need to move my Tuesday cleaning to Thursday.",
+    )
+    await workbench.offer(spec)
+    simulator = start_simulator(workbench, log_level="DEBUG")
+
+    records = await workbench.wait_for(has_terminal("sim-playground-closed"))
+
+    assert turns_for(records, "sim-playground-closed") == [
+        ("agent", "We are closed today. Please call back tomorrow."),
+    ]
+    terminal = terminal_event_for(records, "sim-playground-closed")
+    assert terminal["status"] == "completed"
+    assert terminal["facts"]["ending"] == "agent_ended"
+    assert terminal["facts"]["turn_count"] == 1
+    # One request and no more: nothing was delivered into an exchange that
+    # was already over.
+    assert len(running.stub.requests) == 1
+
+    simulator.stop()
+    assert_kept_secret(sentinel, records=records, simulator=simulator)
+
+
 async def test_a_playground_exchange_the_agent_never_ends_hits_the_turn_limit(
     workbench, start_simulator, start_playground_stub
 ):

--- a/apps/simulator/tests/test_contract_fixtures.py
+++ b/apps/simulator/tests/test_contract_fixtures.py
@@ -260,6 +260,53 @@ def test_a_spec_carries_a_named_version_and_this_simulations_variables():
     assert spec.dynamic_variables["caller_name"] == ""
 
 
+def test_the_playground_lane_reads_back_with_and_without_the_optional_fields():
+    """The chat lane for a Retell *voice* agent, both ways round.
+
+    A real playground run always names the version it conducts — the run
+    resolves it once so a concurrent edit cannot move the agent under test
+    mid-suite — and it is the lane whose mock tools ride the request, so
+    the fixture that carries everything carries all three. The plain one is
+    the same connection with none of it: no version means the platform's
+    own default, and a project that mocks nothing sends no answers, and
+    neither is a shape the contract may refuse.
+
+    The connection type is new here and the schema is untouched, which is
+    the point: this vocabulary is open, so a lane arrives as a fixture and
+    a plug rather than as a contract change.
+    """
+    carried = read_json(
+        contract_dir() / "fixtures" / "spec" / "valid" / "chat-retell-playground.json"
+    )
+    spec = SimulationSpec.from_document(carried)
+    assert spec.connection_type == "retell_playground"
+    assert spec.access_variant == "retell_playground.api_key"
+    assert spec.modality == "chat"
+    assert spec.agent_version == 106
+    assert spec.dynamic_variables["egma_simulation"] == carried["simulation_id"]
+    assert spec.dynamic_variables["caller_name"] == ""
+    assert [mock.tool_name for mock in spec.mock_tools] == [
+        "get_availability",
+        "book_appointment",
+    ]
+    assert spec.mock_tools[1].fails
+
+    plain = read_json(
+        contract_dir()
+        / "fixtures"
+        / "spec"
+        / "valid"
+        / "chat-retell-playground-plain.json"
+    )
+    assert "agent_version" not in plain
+    assert "dynamic_variables" not in plain
+    spec = SimulationSpec.from_document(plain)
+    assert spec.connection_type == "retell_playground"
+    assert spec.agent_version is None
+    assert spec.dynamic_variables == {}
+    assert spec.mock_tools == ()
+
+
 def test_phone_connection_stays_phone_while_models_select_voice_legs():
     document = read_json(
         contract_dir()

--- a/apps/simulator/tests/test_plug_retell_playground.py
+++ b/apps/simulator/tests/test_plug_retell_playground.py
@@ -127,7 +127,7 @@ async def test_the_agent_opens_and_the_plug_conducts_the_whole_exchange(
         mock_tools=seam(),
     )
 
-    assert await plug.open() == "Lakeside Dental, how can I help?"
+    assert (await plug.open()).text == "Lakeside Dental, how can I help?"
     assert await plug.deliver("I need to move my cleaning.") == AgentReply(
         text="Of course — could I take your name?", ended=False
     )
@@ -165,7 +165,7 @@ async def test_an_agent_with_nothing_to_say_first_lets_the_persona_open(
         mock_tools=seam(),
     )
 
-    assert await plug.open() is None
+    assert (await plug.open()).text is None
     assert (await plug.deliver("Hello?")).text == "Yes?"
     await plug.close()
 
@@ -255,7 +255,7 @@ async def test_an_agent_that_ended_on_its_opening_is_not_argued_with(
         {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
     )
 
-    assert await plug.open() == "We are closed today."
+    assert (await plug.open()).text == "We are closed today."
     assert await plug.deliver("Oh — can I book for tomorrow?") == AgentReply(
         text=None, ended=True
     )
@@ -323,16 +323,33 @@ async def test_a_spec_carrying_no_version_asks_for_none(start_playground_stub):
     assert "agent_version" not in running.stub.requests[0]["body"]
 
 
-async def test_this_simulations_variables_reach_retell_and_the_reply_replaces_them(
-    start_playground_stub,
+@pytest.mark.parametrize(
+    "variables_key", ["retell_llm_dynamic_variables", "dynamic_variables"]
+)
+async def test_a_reply_updates_this_simulations_variables_without_dropping_them(
+    start_playground_stub, variables_key
 ):
-    """Out byte for byte, and back the same way: a variable the agent set on
-    turn two is set on turn three, because the platform keeps nothing."""
+    """Out byte for byte, and back **over** what was already held.
+
+    A variable the agent set on turn two is set on turn three, because the
+    platform keeps nothing. And a variable it did not mention is still
+    set: whether a reply names every variable or only the ones that
+    changed is not documented anywhere, so a reply that names one is read
+    as naming one — which is what keeps egma's own attribution variable on
+    every request instead of vanishing after the first change.
+
+    Both names a reply might carry them under are exercised, because which
+    one a real reply uses is a guess until the developer's live run.
+    """
     running = await start_playground_stub(
         api_key=SENTINEL_KEY,
         replies=[
             Reply(),
-            Reply(words="Found you.", variables={"caller_name": "Margaret"}),
+            Reply(
+                words="Found you.",
+                variables={"caller_name": "Margaret"},
+                variables_key=variables_key,
+            ),
             Reply(words="Booked."),
         ],
     )
@@ -353,7 +370,12 @@ async def test_this_simulations_variables_reach_retell_and_the_reply_replaces_th
     ]
     assert carried[0] == {"egma_simulation": "sim_01", "caller_name": ""}
     assert carried[1] == {"egma_simulation": "sim_01", "caller_name": ""}
-    assert carried[2] == {"caller_name": "Margaret"}
+    assert carried[2] == {"egma_simulation": "sim_01", "caller_name": "Margaret"}
+    # The one that must never fall off: it is what a tool call the platform
+    # makes rides back to this simulation on.
+    assert all(
+        variables["egma_simulation"] == "sim_01" for variables in carried
+    ), carried
 
 
 async def test_a_spec_carrying_no_variables_sends_no_variable_block(
@@ -437,7 +459,10 @@ async def test_a_transition_the_platform_announces_lands_on_the_turn(
     answered = await plug.deliver("It's Margaret.")
     await plug.close()
 
-    assert answered.text == "moved to lookup_caller\nOne moment."
+    # Beside the turn, never in it: the persona is handed the words back,
+    # and a transition read as speech is a conversation nobody had.
+    assert answered.text == "One moment."
+    assert answered.platform_notes == ("moved to lookup_caller",)
 
 
 async def test_a_role_the_record_does_not_know_reads_back_verbatim(
@@ -463,7 +488,8 @@ async def test_a_role_the_record_does_not_know_reads_back_verbatim(
     answered = await plug.deliver("Text it to me.")
     await plug.close()
 
-    assert answered.text == "Your booking: Thu 14:30\nSent."
+    assert answered.text == "Sent."
+    assert answered.platform_notes == ("Your booking: Thu 14:30",)
 
 
 async def test_a_platform_that_echoes_the_persona_does_not_make_it_speak_twice(
@@ -523,7 +549,8 @@ async def test_a_message_with_nothing_a_record_can_read_is_still_kept(
     answered = await plug.deliver("Press one.")
     await plug.close()
 
-    assert answered.text == '{"role":"beeped","digits":"1"}'
+    assert answered.text is None
+    assert answered.platform_notes == ('{"role":"beeped","digits":"1"}',)
 
 
 # -- Mock tools ride the request ---------------------------------------------
@@ -656,6 +683,127 @@ async def test_a_mocked_failure_reads_back_as_a_failure_not_a_string(
     assert call.mock_tool == "book_appointment"
 
 
+async def test_a_platform_that_ignored_the_mocks_fails_instead_of_being_stamped(
+    start_playground_stub,
+):
+    """The one guess on this lane that could cost a customer their isolation.
+
+    That the playground honours a field egma sends it is unverified until
+    the developer's live run, and a JSON API that does not know
+    ``tool_mocks`` commonly ignores it — in which case the real backend
+    runs and nothing on the wire says so. The only evidence is that the
+    tool was given something other than what egma sent, so that is checked
+    before any call is stamped, and a mismatch stops the simulation rather
+    than reporting it as isolated.
+    """
+    answers = seam(answering("check_calendar", {"slots": ["thu-1430"]}))
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        ignores_tool_mocks=True,
+        replies=[
+            Reply(),
+            Reply(
+                words="Nothing free, sorry.",
+                tools=[ToolTurn(name="check_calendar", real_result='{"slots":[]}')],
+            ),
+        ],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=answers
+    )
+
+    await plug.open()
+    with pytest.raises(PlugError) as refusal:
+        await plug.deliver("Anything Thursday?")
+    await plug.close()
+
+    told = str(refusal.value)
+    assert "check_calendar" in told
+    assert "real implementation ran" in told, told
+    # The refusal names the tool and neither answer: one is the customer's
+    # authored data and the other their backend's.
+    assert "thu-1430" not in told and "slots" not in told
+    # And nothing was stamped: a call Egma cannot vouch for is not on the
+    # record as one Egma answered.
+    assert [call.mock_tool for call in answers.exchanged()] == []
+
+
+async def test_a_covered_call_the_platform_says_nothing_about_is_not_stamped(
+    start_playground_stub,
+):
+    """The same rule where the evidence is missing rather than wrong: Egma
+    cannot confirm its answer was served, so it will not claim it was."""
+    answers = seam(answering("check_calendar", {"slots": []}))
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        replies=[
+            Reply(),
+            Reply(
+                words="Checked.",
+                extra=[
+                    {
+                        "role": "tool_call_invocation",
+                        "tool_call_id": "call_with_no_result",
+                        "name": "check_calendar",
+                        "arguments": "{}",
+                    }
+                ],
+            ),
+        ],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=answers
+    )
+
+    await plug.open()
+    with pytest.raises(PlugError, match="cannot confirm"):
+        await plug.deliver("Anything Thursday?")
+    await plug.close()
+
+
+async def test_an_answer_spelled_differently_by_the_platform_still_counts(
+    start_playground_stub,
+):
+    """Two equivalent JSON documents are one answer. A platform that
+    re-serializes egma's answer with spaces in it, or its keys the other
+    way round, has still served it — and failing a working simulation over
+    whitespace would be the check doing more harm than the hole it
+    closes."""
+    answers = seam(answering("check_calendar", {"slots": [], "open": True}))
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        replies=[
+            Reply(),
+            Reply(
+                words="Checked.",
+                extra=[
+                    {
+                        "role": "tool_call_invocation",
+                        "tool_call_id": "respelled",
+                        "name": "check_calendar",
+                        "arguments": "{}",
+                    },
+                    {
+                        "role": "tool_call_result",
+                        "tool_call_id": "respelled",
+                        "content": '{"open": true,  "slots": []}',
+                    },
+                ],
+            ),
+        ],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=answers
+    )
+
+    await plug.open()
+    await plug.deliver("Anything Thursday?")
+    await plug.close()
+
+    (call,) = answers.exchanged()
+    assert call.mock_tool == "check_calendar"
+
+
 async def test_a_declared_delay_is_not_spent_on_this_lane(start_playground_stub):
     """Delays are speech-world fidelity — the layer chat deliberately
     excludes — and the answer is served inside Retell's own execution
@@ -736,10 +884,65 @@ async def test_a_throttle_that_lets_up_is_conducted_through(
         {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
     )
 
-    assert await plug.open() == "Lakeside Dental."
+    assert (await plug.open()).text == "Lakeside Dental."
     await plug.close()
 
     assert len(running.stub.requests) == 3
+
+
+async def test_a_throttle_that_says_how_long_to_wait_is_waited_out_that_long(
+    start_playground_stub, monkeypatch
+):
+    """A throttled platform saying how long it wants is worth more than any
+    number egma could pick — bounded, because a header is not a promise
+    this process has to keep for minutes."""
+    from egma_simulator.plugs import retell_playground
+
+    monkeypatch.setattr(retell_playground, "FIRST_BACKOFF_SECONDS", 0.001)
+    monkeypatch.setattr(retell_playground, "LONGEST_BACKOFF_SECONDS", 0.05)
+    slept: list[float] = []
+
+    async def remember(seconds: float) -> None:
+        slept.append(seconds)
+
+    monkeypatch.setattr(retell_playground.asyncio, "sleep", remember)
+
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        refusals=(429, 429),
+        retry_after="600",
+        replies=[Reply(words="Lakeside Dental.")],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    assert (await plug.open()).text == "Lakeside Dental."
+    await plug.close()
+
+    # Asked for ten minutes, capped: the wait is the platform's wish held
+    # to what a simulation can afford.
+    assert slept == [0.05, 0.05]
+
+
+@pytest.mark.parametrize("retry_after", ["not-a-number", "0", "-5"])
+async def test_a_retry_after_egma_cannot_use_falls_back_to_the_backoff(
+    start_playground_stub, quick_playground_backoff, retry_after
+):
+    """An HTTP date, a nonsense value, a zero: egma's own doubling backoff
+    is a perfectly good answer without any of them."""
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        refusals=(429,),
+        retry_after=retry_after,
+        replies=[Reply(words="Lakeside Dental.")],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    assert (await plug.open()).text == "Lakeside Dental."
+    await plug.close()
 
 
 async def test_a_billing_wall_fails_naming_the_billing(start_playground_stub):

--- a/apps/simulator/tests/test_plug_retell_playground.py
+++ b/apps/simulator/tests/test_plug_retell_playground.py
@@ -1,0 +1,928 @@
+"""The Retell playground plug against a playground-shaped server.
+
+The plug is the one component that speaks a platform's wire protocol, so
+what is pinned here is the wire: the whole history on every request because
+the platform keeps none of it, the version named every time because its
+default moves, egma's own answers riding along as native mocks, and the
+resume state threaded turn by turn. The counterpart is a real HTTP server
+shaped like the completion API, on loopback — no account, no key, no
+network.
+
+What the plug **saw** is pinned beside it, at the seam that writes it down:
+every tool call the platform reported reaches the mock-tool seam, marked
+``mocked`` exactly where the run's snapshot covers the name. The record
+those become is proved end to end in the acceptance suite; here the
+question is what the plug hands over.
+
+The failure paths get the same treatment, because they are where a
+credential leaks if it ever does: a throttle, a billing wall, a key the
+platform refuses, and a platform careless enough to say the key back all
+end in a refusal a person can act on, and none of them says the key.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from playground_stub import Reply, ToolTurn
+
+from egma_simulator.mock_tools import MockToolSeam
+from egma_simulator.plugs import AgentReply, PlugError, plug_for
+from egma_simulator.plugs.retell import DEFAULT_BASE_URL
+from egma_simulator.plugs.retell_playground import (
+    MATCH_ANYTHING,
+    RATE_LIMIT_RETRIES,
+    RetellPlayground,
+)
+from egma_simulator.redaction import REDACTED
+from egma_simulator.spec import MockTool
+
+SENTINEL_KEY = "SENTINEL-playground-key-4b7e1c9a2f6d"
+
+UNSET = object()
+"""What "the spec carried nothing here" looks like to the builder below,
+told apart from an explicit ``None`` that a test means to hand over."""
+
+
+def seam(*mocks: MockTool) -> MockToolSeam:
+    """One run's resolved answers, as the claimed spec would carry them."""
+    return MockToolSeam(mocks)
+
+
+def answering(name: str, value: object, *, delay_milliseconds: int = 0) -> MockTool:
+    return MockTool(
+        tool_name=name,
+        answer={"answer": value},
+        delay_milliseconds=delay_milliseconds,
+    )
+
+
+def failing(name: str, value: object) -> MockTool:
+    return MockTool(tool_name=name, answer={"error": value}, delay_milliseconds=0)
+
+
+def playground(
+    config: dict,
+    *,
+    modality: str = "chat",
+    access_variant: str = "retell_playground.api_key",
+    key: str | None = SENTINEL_KEY,
+    agent_version: object = UNSET,
+    dynamic_variables: object = UNSET,
+    mock_tools: object = UNSET,
+) -> RetellPlayground:
+    credentials = None if key is None else {"apiKey": key}
+    carried: dict = {}
+    if agent_version is not UNSET:
+        carried["agent_version"] = agent_version
+    if dynamic_variables is not UNSET:
+        carried["dynamic_variables"] = dynamic_variables
+    if mock_tools is not UNSET:
+        carried["mock_tools"] = mock_tools
+    return RetellPlayground(
+        modality=modality,
+        access_variant=access_variant,
+        config=config,
+        credentials=credentials,
+        **carried,
+    )
+
+
+def test_the_registry_knows_the_playground_plug():
+    assert plug_for("retell_playground") is RetellPlayground
+
+
+def test_a_connection_saying_nothing_about_where_reaches_retell_itself():
+    """The base URL is the plug's own optional key; absent, it is the
+    platform, which is what every real connection block will mean."""
+    plug = playground({"retellAgentId": "agent_1"})
+    assert plug.base_url == DEFAULT_BASE_URL == "https://api.retellai.com"
+
+
+def test_the_agent_is_named_in_the_path_and_escaped_there():
+    """The agent's id is somebody else's string, and it goes in a URL."""
+    plug = playground({"retellAgentId": "agent one/two"})
+    assert plug.completion_path == "/agent-playground-completion/agent%20one%2Ftwo"
+
+
+# -- The exchange ------------------------------------------------------------
+
+
+async def test_the_agent_opens_and_the_plug_conducts_the_whole_exchange(
+    start_playground_stub,
+):
+    """A full conduct: the opening line, two delivered turns, and the whole
+    history on every request because the platform keeps none of it."""
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        replies=[
+            Reply(words="Lakeside Dental, how can I help?"),
+            Reply(words="Of course — could I take your name?"),
+            Reply(words="Booked for Thursday."),
+        ],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_lakeside", "baseUrl": running.base_url},
+        mock_tools=seam(),
+    )
+
+    assert await plug.open() == "Lakeside Dental, how can I help?"
+    assert await plug.deliver("I need to move my cleaning.") == AgentReply(
+        text="Of course — could I take your name?", ended=False
+    )
+    assert await plug.deliver("Margaret Hale.") == AgentReply(
+        text="Booked for Thursday.", ended=False
+    )
+    await plug.close()
+
+    stub = running.stub
+    assert [request["agent_id"] for request in stub.requests] == ["agent_lakeside"] * 3
+    # The open carries nothing said yet; every request after it carries the
+    # whole conversation, the agent's own messages included and verbatim.
+    histories = stub.histories()
+    assert histories[0] == []
+    assert [message["role"] for message in histories[1]] == ["agent", "user"]
+    assert [message["role"] for message in histories[2]] == [
+        "agent",
+        "user",
+        "agent",
+        "user",
+    ]
+    assert stub.delivered() == ["I need to move my cleaning.", "Margaret Hale."]
+
+
+async def test_an_agent_with_nothing_to_say_first_lets_the_persona_open(
+    start_playground_stub,
+):
+    """The silent open: the request is still made — an agent that speaks
+    first has to be given the chance — and nothing comes back."""
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY, replies=[Reply(), Reply(words="Yes?")]
+    )
+    plug = playground(
+        {"retellAgentId": "agent_quiet", "baseUrl": running.base_url},
+        mock_tools=seam(),
+    )
+
+    assert await plug.open() is None
+    assert (await plug.deliver("Hello?")).text == "Yes?"
+    await plug.close()
+
+    assert running.stub.histories()[0] == []
+
+
+async def test_several_bubbles_in_one_reply_stay_one_turn(start_playground_stub):
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        replies=[Reply(), Reply(words=["Let me look.", "Thursday works."])],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    await plug.open()
+    assert (await plug.deliver("Anything Thursday?")).text == (
+        "Let me look.\nThursday works."
+    )
+    await plug.close()
+
+
+async def test_a_reply_that_carried_no_words_is_an_answer_without_words(
+    start_playground_stub,
+):
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        replies=[Reply(), Reply(tools=[ToolTurn(name="check_calendar")])],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    await plug.open()
+    assert await plug.deliver("Anything Thursday?") == AgentReply(text=None)
+    await plug.close()
+
+
+# -- How it ends -------------------------------------------------------------
+
+
+async def test_the_agent_ending_the_exchange_is_read_from_the_flag(
+    start_playground_stub,
+):
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        replies=[Reply(), Reply(words="Goodbye then.", ends=True)],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    await plug.open()
+    assert await plug.deliver("That is all.") == AgentReply(
+        text="Goodbye then.", ended=True
+    )
+    await plug.close()
+
+
+async def test_an_end_tool_ends_the_exchange_even_without_the_flag(
+    start_playground_stub,
+):
+    """The same fact said the other way: a Retell agent ends any exchange by
+    invoking its end tool, and a reply carrying one has ended."""
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        replies=[Reply(), Reply(words="Bye.", tools=[ToolTurn(name="end_call")])],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    await plug.open()
+    assert (await plug.deliver("That is all.")).ended is True
+    await plug.close()
+
+
+async def test_an_agent_that_ended_on_its_opening_is_not_argued_with(
+    start_playground_stub,
+):
+    """Rare and real — "we are closed today" and a goodbye. The ending is
+    reported rather than a request being sent into an exchange that is over."""
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY, replies=[Reply(words="We are closed today.", ends=True)]
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    assert await plug.open() == "We are closed today."
+    assert await plug.deliver("Oh — can I book for tomorrow?") == AgentReply(
+        text=None, ended=True
+    )
+    await plug.close()
+
+    assert len(running.stub.requests) == 1, "no request continues an ended exchange"
+
+
+async def test_the_walk_keeps_its_own_limits(start_playground_stub):
+    """Nothing here ends an exchange that the agent did not end: a plug that
+    keeps answering is a walk that runs out of turns instead, which is the
+    walk's job and never the agent failing."""
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY, replies=[Reply(), Reply(words="Still here.")]
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    await plug.open()
+    for _ in range(4):
+        assert (await plug.deliver("And?")).ended is False
+    await plug.close()
+
+
+# -- The version, the variables, and the resume state ------------------------
+
+
+@pytest.mark.parametrize("version", [106, "latest", "  latest  ", "prod"])
+async def test_every_request_names_the_version_the_spec_named(
+    start_playground_stub, version
+):
+    """Named every time, never once: Retell's default is the newest version,
+    and a version created between two turns would move the agent under test
+    mid-conversation."""
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY, replies=[Reply(), Reply(words="Yes.")]
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url},
+        agent_version=version,
+        mock_tools=seam(),
+    )
+
+    await plug.open()
+    await plug.deliver("Hello?")
+    await plug.close()
+
+    wanted = version.strip() if isinstance(version, str) else version
+    assert [request["agent_version"] for request in running.stub.requests] == [
+        wanted,
+        wanted,
+    ]
+
+
+async def test_a_spec_carrying_no_version_asks_for_none(start_playground_stub):
+    running = await start_playground_stub(api_key=SENTINEL_KEY, replies=[Reply()])
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    await plug.open()
+    await plug.close()
+
+    assert "agent_version" not in running.stub.requests[0]["body"]
+
+
+async def test_this_simulations_variables_reach_retell_and_the_reply_replaces_them(
+    start_playground_stub,
+):
+    """Out byte for byte, and back the same way: a variable the agent set on
+    turn two is set on turn three, because the platform keeps nothing."""
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        replies=[
+            Reply(),
+            Reply(words="Found you.", variables={"caller_name": "Margaret"}),
+            Reply(words="Booked."),
+        ],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url},
+        dynamic_variables={"egma_simulation": "sim_01", "caller_name": ""},
+        mock_tools=seam(),
+    )
+
+    await plug.open()
+    await plug.deliver("It's Margaret.")
+    await plug.deliver("Thursday please.")
+    await plug.close()
+
+    carried = [
+        request["body"].get("retell_llm_dynamic_variables")
+        for request in running.stub.requests
+    ]
+    assert carried[0] == {"egma_simulation": "sim_01", "caller_name": ""}
+    assert carried[1] == {"egma_simulation": "sim_01", "caller_name": ""}
+    assert carried[2] == {"caller_name": "Margaret"}
+
+
+async def test_a_spec_carrying_no_variables_sends_no_variable_block(
+    start_playground_stub,
+):
+    """Absent stays absent: an empty block is a value Retell would render."""
+    running = await start_playground_stub(api_key=SENTINEL_KEY, replies=[Reply()])
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url},
+        dynamic_variables={},
+        mock_tools=seam(),
+    )
+
+    await plug.open()
+    await plug.close()
+
+    assert "retell_llm_dynamic_variables" not in running.stub.requests[0]["body"]
+
+
+async def test_the_resume_state_is_threaded_across_turns(start_playground_stub):
+    """A flow that moved node, and moved again into a component: each reply's
+    state rides the next request under the platform's own names."""
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        replies=[
+            Reply(words="Hello.", node="greet"),
+            Reply(words="Checking.", node="lookup", component="verify_caller"),
+            Reply(words="Done."),
+        ],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_flow", "baseUrl": running.base_url},
+        mock_tools=seam(),
+    )
+
+    await plug.open()
+    await plug.deliver("It's Margaret.")
+    await plug.deliver("Thursday please.")
+    await plug.close()
+
+    bodies = [request["body"] for request in running.stub.requests]
+    assert "current_node_id" not in bodies[0], "nothing is resumed before anything ran"
+    assert bodies[1]["current_node_id"] == "greet"
+    assert "current_component_id" not in bodies[1]
+    assert bodies[2]["current_node_id"] == "lookup"
+    assert bodies[2]["current_component_id"] == "verify_caller"
+
+
+async def test_a_retell_llm_threads_its_state_the_same_way(start_playground_stub):
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        replies=[Reply(words="Hi.", state="collect_details"), Reply(words="Done.")],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_llm", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    await plug.open()
+    await plug.deliver("Margaret here.")
+    await plug.close()
+
+    assert running.stub.requests[1]["body"]["current_state"] == "collect_details"
+
+
+async def test_a_transition_the_platform_announces_lands_on_the_turn(
+    start_playground_stub,
+):
+    """A node transition is a message in a role the record does not know, so
+    it is preserved verbatim as agent-side content — which is how a
+    transition gets onto the record at all."""
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        replies=[Reply(), Reply(words="One moment.", node="lookup_caller")],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_flow", "baseUrl": running.base_url},
+        mock_tools=seam(),
+    )
+
+    await plug.open()
+    answered = await plug.deliver("It's Margaret.")
+    await plug.close()
+
+    assert answered.text == "moved to lookup_caller\nOne moment."
+
+
+async def test_a_role_the_record_does_not_know_reads_back_verbatim(
+    start_playground_stub,
+):
+    """Never dropped silently: a platform growing a fifth role must not cost
+    this simulation part of its transcript."""
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        replies=[
+            Reply(),
+            Reply(
+                words="Sent.",
+                extra=[{"role": "sms", "content": "Your booking: Thu 14:30"}],
+            ),
+        ],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    await plug.open()
+    answered = await plug.deliver("Text it to me.")
+    await plug.close()
+
+    assert answered.text == "Your booking: Thu 14:30\nSent."
+
+
+async def test_a_message_with_nothing_a_record_can_read_is_still_kept(
+    start_playground_stub,
+):
+    """The whole message where it carries no words of its own: the
+    alternative is throwing away something the platform meant to say."""
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        replies=[Reply(), Reply(extra=[{"role": "beeped", "digits": "1"}])],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    await plug.open()
+    answered = await plug.deliver("Press one.")
+    await plug.close()
+
+    assert answered.text == '{"role":"beeped","digits":"1"}'
+
+
+# -- Mock tools ride the request ---------------------------------------------
+
+
+async def test_egmas_answers_ride_every_request_as_native_mocks(
+    start_playground_stub,
+):
+    """One answer per tool, matched by name with the match-anything rule —
+    the arguments are never read, here as everywhere."""
+    running = await start_playground_stub(api_key=SENTINEL_KEY, replies=[Reply()])
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url},
+        mock_tools=seam(
+            answering("check_calendar", {"slots": []}),
+            failing("book_appointment", "the booking service is down"),
+        ),
+    )
+
+    await plug.open()
+    await plug.close()
+
+    assert running.stub.mocks()[0] == [
+        {
+            "tool_name": "check_calendar",
+            "input_match_rule": MATCH_ANYTHING,
+            "output": '{"slots":[]}',
+            "result": True,
+        },
+        {
+            "tool_name": "book_appointment",
+            "input_match_rule": MATCH_ANYTHING,
+            "output": '"the booking service is down"',
+            "result": False,
+        },
+    ]
+
+
+async def test_a_run_that_mocks_nothing_sends_no_mocks(start_playground_stub):
+    running = await start_playground_stub(api_key=SENTINEL_KEY, replies=[Reply()])
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    await plug.open()
+    await plug.close()
+
+    assert "tool_mocks" not in running.stub.requests[0]["body"]
+
+
+async def test_a_covered_call_is_marked_mocked_and_an_uncovered_one_is_not(
+    start_playground_stub,
+):
+    """The whole honesty claim of this lane, at the tool grain: the platform
+    served egma's answer for the covered name and the customer's own backend
+    for the other, and the record says which was which."""
+    answers = seam(answering("check_calendar", {"slots": ["thu-1430"]}))
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        replies=[
+            Reply(),
+            Reply(
+                words="Thursday at half two?",
+                tools=[
+                    ToolTurn(name="check_calendar", arguments='{"day":"thu"}'),
+                    ToolTurn(
+                        name="lookup_customer",
+                        arguments='{"phone":"+1"}',
+                        real_result='{"customer":"real"}',
+                    ),
+                ],
+            ),
+        ],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=answers
+    )
+
+    await plug.open()
+    answered = await plug.deliver("Anything Thursday?")
+    await plug.close()
+
+    # Nothing rides back on the reply itself: the seam is the one writer
+    # that can stamp a call, and two writers would record each call twice.
+    assert answered.tool_calls == ()
+
+    exchanged = answers.exchanged()
+    assert [(call.name, call.mock_tool) for call in exchanged] == [
+        ("check_calendar", "check_calendar"),
+        ("lookup_customer", None),
+    ]
+    mocked, real = exchanged
+    assert mocked.arguments == '{"day":"thu"}'
+    assert mocked.answer == '{"slots":["thu-1430"]}'
+    assert mocked.refused is False and mocked.late_attached is False
+    # The uncovered call is on the record as the observation it is: what was
+    # called, with what — and no stamp, which is the record's own way of
+    # saying a real backend did the work.
+    assert real.arguments == '{"phone":"+1"}'
+    assert real.answer is None
+
+    assert answers.coverage() == {
+        "discovered": ["check_calendar", "lookup_customer"],
+        "covered": ["check_calendar"],
+        "uncovered": ["lookup_customer"],
+    }
+
+
+async def test_a_mocked_failure_reads_back_as_a_failure_not_a_string(
+    start_playground_stub,
+):
+    """The tag stays on the record for the failure branch, exactly as it
+    does on the room lane, so one authored world reads the same on both."""
+    answers = seam(failing("book_appointment", {"code": 503}))
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        replies=[Reply(), Reply(words="Sorry — I could not book that.",
+                                tools=[ToolTurn(name="book_appointment")])],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=answers
+    )
+
+    await plug.open()
+    await plug.deliver("Book it.")
+    await plug.close()
+
+    (call,) = answers.exchanged()
+    assert call.answer == '{"error":{"code":503}}'
+    assert call.mock_tool == "book_appointment"
+
+
+async def test_a_declared_delay_is_not_spent_on_this_lane(start_playground_stub):
+    """Delays are speech-world fidelity — the layer chat deliberately
+    excludes — and the answer is served inside Retell's own execution
+    anyway, where egma has nothing to hold back."""
+    answers = seam(answering("check_calendar", {}, delay_milliseconds=30_000))
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        replies=[Reply(), Reply(words="Checked.", tools=[ToolTurn("check_calendar")])],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=answers
+    )
+
+    await plug.open()
+    async with asyncio.timeout(10):
+        await plug.deliver("Anything Thursday?")
+    await plug.close()
+
+    (call,) = answers.exchanged()
+    assert call.mock_tool == "check_calendar"
+
+
+async def test_a_simulation_reaching_no_platform_claims_no_coverage(
+    start_playground_stub,
+):
+    """A request that never landed put egma in nobody's tool path, and the
+    stamp is the one thing that must never claim otherwise."""
+    answers = seam(answering("check_calendar", {}))
+    running = await start_playground_stub(
+        api_key="the-only-key-this-stub-honors", replies=[Reply()]
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=answers
+    )
+
+    with pytest.raises(PlugError):
+        await plug.open()
+    await plug.close()
+
+    assert answers.coverage() is None
+
+
+# -- Errors, loud and without the key ----------------------------------------
+
+
+async def test_a_throttle_retries_a_bounded_number_of_times_then_fails_loudly(
+    start_playground_stub, quick_playground_backoff
+):
+    """A run that quietly waited out a throttle would report a shorter
+    exchange than the test asked for, with nothing to say why."""
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY, refusals=(429,) * 10, replies=[Reply()]
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    with pytest.raises(PlugError) as refusal:
+        await plug.open()
+    await plug.close()
+
+    assert len(running.stub.requests) == RATE_LIMIT_RETRIES + 1
+    told = str(refusal.value)
+    assert "429" in told and "throttled" in told
+    assert "rate limit" in told, told
+    assert SENTINEL_KEY not in told
+
+
+async def test_a_throttle_that_lets_up_is_conducted_through(
+    start_playground_stub, quick_playground_backoff
+):
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        refusals=(429, 429),
+        replies=[Reply(words="Lakeside Dental.")],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    assert await plug.open() == "Lakeside Dental."
+    await plug.close()
+
+    assert len(running.stub.requests) == 3
+
+
+async def test_a_billing_wall_fails_naming_the_billing(start_playground_stub):
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY, refusals=(402,), replies=[Reply()]
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    with pytest.raises(PlugError) as refusal:
+        await plug.open()
+    await plug.close()
+
+    told = str(refusal.value)
+    assert "402" in told and "billed" in told and "billing" in told
+    assert len(running.stub.requests) == 1, "a billing wall is not retried"
+    assert SENTINEL_KEY not in told
+
+
+async def test_a_key_the_platform_refuses_fails_without_saying_the_key(
+    start_playground_stub,
+):
+    running = await start_playground_stub(api_key="the-only-key-this-stub-honors")
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    with pytest.raises(PlugError) as refusal:
+        await plug.open()
+    await plug.close()
+
+    told = str(refusal.value)
+    assert "401" in told and running.base_url in told
+    assert SENTINEL_KEY not in told
+
+
+async def test_a_platform_that_says_the_key_back_is_quoted_without_it(
+    start_playground_stub,
+):
+    """A platform careless enough to echo the key would otherwise put it in
+    a failure reason and in the traceback logged beneath it."""
+    running = await start_playground_stub(
+        api_key="the-only-key-this-stub-honors", echo_key_in_refusal=True
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    with pytest.raises(PlugError) as refusal:
+        await plug.open()
+    await plug.close()
+
+    told = str(refusal.value)
+    assert SENTINEL_KEY not in told
+    assert REDACTED in told, told
+
+
+async def test_a_throttle_that_says_the_key_back_is_quoted_without_it(
+    start_playground_stub, quick_playground_backoff
+):
+    """The same discipline on the failing path this lane adds — a throttle is
+    where a busy account meets a careless error body."""
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        refusals=(429,) * 10,
+        echo_key_in_refusal=True,
+        replies=[Reply()],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    with pytest.raises(PlugError) as refusal:
+        await plug.open()
+    await plug.close()
+
+    told = str(refusal.value)
+    assert SENTINEL_KEY not in told
+    assert REDACTED in told, told
+
+
+async def test_a_platform_that_answers_nowhere_fails_without_saying_the_key():
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": "http://127.0.0.1:1"},
+        mock_tools=seam(),
+    )
+
+    with pytest.raises(PlugError) as refusal:
+        await plug.open()
+    await plug.close()
+
+    assert SENTINEL_KEY not in str(refusal.value)
+    assert "unreachable" in str(refusal.value)
+
+
+async def test_a_reply_with_no_messages_is_refused_rather_than_read_as_silence(
+    start_playground_stub,
+):
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY, answers_without_messages=True
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    with pytest.raises(PlugError, match="no messages list"):
+        await plug.open()
+    await plug.close()
+
+
+async def test_a_turn_before_the_exchange_opened_is_refused():
+    plug = playground({"retellAgentId": "agent_1"}, mock_tools=seam())
+
+    with pytest.raises(PlugError, match="before the exchange opened"):
+        await plug.deliver("Hello?")
+
+
+async def test_closing_an_exchange_that_was_never_opened_is_safe():
+    plug = playground({"retellAgentId": "agent_1"}, mock_tools=seam())
+    await plug.close()
+    await plug.close()
+
+
+# -- What the record claims about this lane ----------------------------------
+
+
+async def test_this_lane_offers_no_provider_reference_ever(start_playground_stub):
+    """The playground stores nothing, so there is no id either side could
+    look this exchange up by — and an id only egma has seen is not a join."""
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY, replies=[Reply(words="Hello."), Reply(words="Yes.")]
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    assert plug.provider_reference is None
+    await plug.open()
+    assert plug.provider_reference is None
+    await plug.deliver("Hello?")
+    assert plug.provider_reference is None
+    await plug.close()
+    assert plug.provider_reference is None
+
+
+# -- Config, credentials, and the modality it speaks -------------------------
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {},
+        {"retellAgentId": ""},
+        {"retellAgentId": "   "},
+        {"retellAgentId": 7},
+        {"retellAgentId": "agent_1", "baseUrl": ""},
+        {"retellAgentId": "agent_1", "roomHost": "wss://somewhere"},
+        {"agentId": "agent_1"},
+    ],
+)
+def test_config_the_plug_does_not_understand_is_refused(config: dict):
+    with pytest.raises(PlugError):
+        playground(config)
+
+
+def test_a_config_typo_is_named_in_the_refusal():
+    with pytest.raises(PlugError) as refusal:
+        playground({"retellAgentId": "agent_1", "retellAgentID": "agent_2"})
+    assert "retellAgentID" in str(refusal.value)
+
+
+@pytest.mark.parametrize(
+    "credentials",
+    [None, {}, {"apiKey": ""}, {"apiKey": 7}, {"apiKey": "k", "apiSecret": "s"}],
+)
+def test_credentials_of_the_wrong_shape_are_refused(credentials):
+    with pytest.raises(PlugError):
+        RetellPlayground(
+            modality="chat",
+            access_variant="retell_playground.api_key",
+            config={"retellAgentId": "agent_1"},
+            credentials=credentials,
+        )
+
+
+def test_a_credential_refusal_names_the_key_and_never_its_value():
+    with pytest.raises(PlugError) as refusal:
+        RetellPlayground(
+            modality="chat",
+            access_variant="retell_playground.api_key",
+            config={"retellAgentId": "agent_1"},
+            credentials={"apiKey": SENTINEL_KEY, "apiSecret": "SENTINEL-secret-0001"},
+        )
+    told = str(refusal.value)
+    assert "apiSecret" in told
+    assert SENTINEL_KEY not in told and "SENTINEL-secret-0001" not in told
+
+
+def test_the_plug_speaks_chat_only():
+    with pytest.raises(PlugError, match="chat only"):
+        playground({"retellAgentId": "agent_1"}, modality="voice")
+
+
+def test_the_plug_holds_one_access_variant():
+    with pytest.raises(PlugError, match="access variant"):
+        playground(
+            {"retellAgentId": "agent_1"}, access_variant="retell_chat_api.api_key"
+        )
+
+
+@pytest.mark.parametrize(
+    ("agent_version", "dynamic_variables"),
+    [(" ", UNSET), (-1, UNSET), (UNSET, {"open_slots": 3}), (UNSET, {" ": "x"})],
+)
+def test_a_version_or_a_variable_the_plug_cannot_send_is_refused(
+    agent_version, dynamic_variables
+):
+    """Read through the shared helpers, so two plugs reaching one platform
+    cannot disagree about what either of them is."""
+    with pytest.raises(PlugError):
+        playground(
+            {"retellAgentId": "agent_1"},
+            agent_version=agent_version,
+            dynamic_variables=dynamic_variables,
+        )

--- a/apps/simulator/tests/test_plug_retell_playground.py
+++ b/apps/simulator/tests/test_plug_retell_playground.py
@@ -466,6 +466,46 @@ async def test_a_role_the_record_does_not_know_reads_back_verbatim(
     assert answered.text == "Your booking: Thu 14:30\nSent."
 
 
+async def test_a_platform_that_echoes_the_persona_does_not_make_it_speak_twice(
+    start_playground_stub,
+):
+    """Egma owns the persona's side of the history. A platform that repeats
+    the turn it was just given is repeating what is already written down,
+    and keeping the echo would have the caller say everything twice from
+    the next request onward."""
+    running = await start_playground_stub(
+        api_key=SENTINEL_KEY,
+        replies=[
+            Reply(),
+            Reply(
+                words="Thursday, then.",
+                extra=[{"role": "user", "content": "Anything Thursday?"}],
+            ),
+            Reply(words="Booked."),
+        ],
+    )
+    plug = playground(
+        {"retellAgentId": "agent_1", "baseUrl": running.base_url}, mock_tools=seam()
+    )
+
+    await plug.open()
+    answered = await plug.deliver("Anything Thursday?")
+    await plug.deliver("Yes please.")
+    await plug.close()
+
+    # Not the agent's words either: the record knows this role, so it is
+    # neither spoken nor preserved as something nobody understood.
+    assert answered.text == "Thursday, then."
+    assert [
+        (message["role"], message["content"])
+        for message in running.stub.histories()[2]
+    ] == [
+        ("user", "Anything Thursday?"),
+        ("agent", "Thursday, then."),
+        ("user", "Yes please."),
+    ]
+
+
 async def test_a_message_with_nothing_a_record_can_read_is_still_kept(
     start_playground_stub,
 ):

--- a/apps/simulator/tests/test_walk.py
+++ b/apps/simulator/tests/test_walk.py
@@ -248,6 +248,7 @@ class NotingPlug:
 
     def __init__(self, *, opening: AgentReply, answers: list[AgentReply]) -> None:
         self.provider_reference = None
+        self.delivered = 0
         self._opening = opening
         self._answers = answers
 
@@ -255,6 +256,7 @@ class NotingPlug:
         return self._opening
 
     async def deliver(self, text: str) -> AgentReply:
+        self.delivered += 1
         return self._answers.pop(0) if self._answers else AgentReply(text="Go on.")
 
     async def close(self) -> None:
@@ -291,6 +293,94 @@ async def test_what_the_platform_said_rides_the_record_and_not_the_turn():
     assert turns[0] == ("agent", "Front desk.", ("moved to greet",))
     assert turns[1] == ("human", "First point.", ())
     assert turns[2] == ("agent", "Certainly.", ("moved to lookup",))
+
+
+async def test_an_agent_that_ends_on_its_greeting_ends_the_walk_there():
+    """"We are closed today" and a goodbye — rare, and real.
+
+    The exchange is over before the persona has said anything, so nothing
+    is asked of it: a turn taken after the agent had gone would be a line
+    on the record nobody heard, and whichever ending tripped afterwards —
+    the persona concluding, a limit — would be reported instead of the
+    agent's own doing.
+    """
+    turns, recorder = collect_with_notes()
+    plug = NotingPlug(
+        opening=AgentReply(text="We are closed today. Goodbye.", ended=True),
+        answers=[],
+    )
+
+    conducted = await conduct(
+        persona=persona_for("First point."),
+        plug=plug,
+        max_turns=60,
+        max_duration_seconds=30,
+        on_turn=recorder,
+        on_timing=None,
+        controls=WalkControls(),
+        name="sim:test",
+    )
+
+    assert turns == [("agent", "We are closed today. Goodbye.", ())]
+    assert plug.delivered == 0, "the persona was asked to speak to nobody"
+    assert conducted == Conducted(
+        status="completed",
+        ending="agent_ended",
+        reason="the agent ended the exchange",
+        provider_reference=None,
+    )
+
+
+async def test_an_agent_ending_on_a_greeting_with_no_words_still_ends_the_walk():
+    """The same, from a platform that ends without saying anything: there
+    is no turn to record and the walk is over all the same."""
+    turns, recorder = collect_with_notes()
+    plug = NotingPlug(opening=AgentReply(text=None, ended=True), answers=[])
+
+    conducted = await conduct(
+        persona=persona_for("First point."),
+        plug=plug,
+        max_turns=60,
+        max_duration_seconds=30,
+        on_turn=recorder,
+        on_timing=None,
+        controls=WalkControls(),
+        name="sim:test",
+    )
+
+    assert turns == []
+    assert plug.delivered == 0
+    assert conducted.ending == "agent_ended"
+
+
+async def test_a_greeting_that_did_not_end_anything_walks_on_as_ever():
+    """The guard is on the flag and nothing else: an opening reply that
+    says the exchange continues is the ordinary case, and it does."""
+    turns, recorder = collect_with_notes()
+    plug = NotingPlug(
+        opening=AgentReply(text="Front desk."),
+        answers=[AgentReply(text="Certainly.")],
+    )
+
+    conducted = await conduct(
+        persona=persona_for("First point."),
+        plug=plug,
+        max_turns=60,
+        max_duration_seconds=30,
+        on_turn=recorder,
+        on_timing=None,
+        controls=WalkControls(),
+        name="sim:test",
+    )
+
+    assert [speaker for speaker, _text, _notes in turns] == [
+        "agent",
+        "human",
+        "agent",
+        "human",
+    ]
+    assert plug.delivered == 1
+    assert conducted.ending == "persona_concluded"
 
 
 async def test_an_answer_with_no_words_the_platform_spoke_about_is_still_a_turn():

--- a/apps/simulator/tests/test_walk.py
+++ b/apps/simulator/tests/test_walk.py
@@ -46,8 +46,27 @@ def scripted_plug(config: dict) -> ScriptedCounterpart:
 def collect():
     turns: list[tuple[str, str]] = []
 
-    async def on_turn(speaker: str, text: str) -> None:
+    async def on_turn(
+        speaker: str, text: str, notes: tuple[str, ...] = ()
+    ) -> None:
         turns.append((speaker, text))
+
+    return turns, on_turn
+
+
+def collect_with_notes():
+    """The same, keeping what the platform said about each turn.
+
+    Separate from :func:`collect` because almost every test here is about
+    the conversation and would only be made harder to read by a third
+    element that is empty in all of them.
+    """
+    turns: list[tuple[str, str, tuple[str, ...]]] = []
+
+    async def on_turn(
+        speaker: str, text: str, notes: tuple[str, ...] = ()
+    ) -> None:
+        turns.append((speaker, text, notes))
 
     return turns, on_turn
 
@@ -217,6 +236,86 @@ async def test_a_cancel_after_the_walk_finished_changes_nothing():
     assert conducted.status == "completed"
     assert conducted.ending == "persona_concluded"
     assert len(turns) == 3
+
+
+class NotingPlug:
+    """A plug whose platform says things nobody said.
+
+    The shape a platform takes when it reports more about an answer than
+    the words in it — a flow announcing the node it moved to, a message in
+    a role egma has never seen.
+    """
+
+    def __init__(self, *, opening: AgentReply, answers: list[AgentReply]) -> None:
+        self.provider_reference = None
+        self._opening = opening
+        self._answers = answers
+
+    async def open(self) -> AgentReply:
+        return self._opening
+
+    async def deliver(self, text: str) -> AgentReply:
+        return self._answers.pop(0) if self._answers else AgentReply(text="Go on.")
+
+    async def close(self) -> None:
+        return None
+
+
+async def test_what_the_platform_said_rides_the_record_and_not_the_turn():
+    """The rule the chat-versus-voice diagnostic rests on.
+
+    A transition is agent-side content and it is not speech. It reaches
+    whoever writes the record, beside the turn; it never joins the words,
+    because the words are what the persona is handed back and what a voice
+    transcript of the same scenario is compared against.
+    """
+    turns, recorder = collect_with_notes()
+    plug = NotingPlug(
+        opening=AgentReply(text="Front desk.", platform_notes=("moved to greet",)),
+        answers=[
+            AgentReply(text="Certainly.", platform_notes=("moved to lookup",)),
+        ],
+    )
+
+    await conduct(
+        persona=persona_for("First point."),
+        plug=plug,
+        max_turns=60,
+        max_duration_seconds=30,
+        on_turn=recorder,
+        on_timing=None,
+        controls=WalkControls(),
+        name="sim:test",
+    )
+
+    assert turns[0] == ("agent", "Front desk.", ("moved to greet",))
+    assert turns[1] == ("human", "First point.", ())
+    assert turns[2] == ("agent", "Certainly.", ("moved to lookup",))
+
+
+async def test_an_answer_with_no_words_the_platform_spoke_about_is_still_a_turn():
+    """An answer that carried no words is not a turn — unless the platform
+    said something about it, which is still the agent's side of the
+    conversation and still has to land somewhere."""
+    turns, recorder = collect_with_notes()
+    plug = NotingPlug(
+        opening=AgentReply(text=None),
+        answers=[AgentReply(text=None, platform_notes=("moved to lookup",))],
+    )
+
+    await conduct(
+        persona=persona_for("First point."),
+        plug=plug,
+        max_turns=4,
+        max_duration_seconds=30,
+        on_turn=recorder,
+        on_timing=None,
+        controls=WalkControls(),
+        name="sim:test",
+    )
+
+    assert turns[0] == ("human", "First point.", ())
+    assert turns[1] == ("agent", "", ("moved to lookup",))
 
 
 class ObservantPlug:

--- a/packages/simulation-contract/fixtures/spec/valid/chat-retell-playground-plain.json
+++ b/packages/simulation-contract/fixtures/spec/valid/chat-retell-playground-plain.json
@@ -1,0 +1,48 @@
+{
+  "contract_version": 5,
+  "simulation_id": "sim_01K5T4RB9F0C2XKQNZ7MVD4HTA",
+  "modality": "chat",
+  "connection": {
+    "agent_platform": "retell",
+    "connection_type": "retell_playground",
+    "access_variant": "retell_playground.api_key",
+    "config": {
+      "retellAgentId": "agent_b0e2e9cb267c47e7e7026cd8e8"
+    },
+    "credentials": {
+      "apiKey": "fixture-not-a-real-secret-0000000000000000"
+    }
+  },
+  "persona": {
+    "name": "Eleanor",
+    "personality": "Retired teacher, 68, typing carefully. Polite, thorough, repeats details back to be sure she has them right.",
+    "language": "en-US"
+  },
+  "scenario": {
+    "instructions": "You want to know whether the practice is open on Saturday mornings. Conclude once you have been told."
+  },
+  "limits": {
+    "max_duration_seconds": 600,
+    "max_turns": 60
+  },
+  "models": {
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "adapter": "openai_chat_completions",
+      "key": "fixture-not-a-real-secret-llm"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general",
+      "adapter": "deepgram"
+    },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "adapter": "cartesia",
+      "voice_id": "measured-alto-3",
+      "speed": 0.95
+    }
+  }
+}

--- a/packages/simulation-contract/fixtures/spec/valid/chat-retell-playground.json
+++ b/packages/simulation-contract/fixtures/spec/valid/chat-retell-playground.json
@@ -1,0 +1,66 @@
+{
+  "contract_version": 5,
+  "simulation_id": "sim_01K5T4P2QW7H3NDXB8ZM6VYJRE",
+  "modality": "chat",
+  "connection": {
+    "agent_platform": "retell",
+    "connection_type": "retell_playground",
+    "access_variant": "retell_playground.api_key",
+    "config": {
+      "retellAgentId": "agent_b0e2e9cb267c47e7e7026cd8e8"
+    },
+    "credentials": {
+      "apiKey": "fixture-not-a-real-secret-0000000000000000"
+    }
+  },
+  "agent_version": 106,
+  "dynamic_variables": {
+    "egma_simulation": "sim_01K5T4P2QW7H3NDXB8ZM6VYJRE",
+    "is_existing": "true",
+    "caller_name": ""
+  },
+  "persona": {
+    "name": "Eleanor",
+    "personality": "Retired teacher, 68, typing carefully. Polite, thorough, repeats details back to be sure she has them right.",
+    "language": "en-US"
+  },
+  "scenario": {
+    "instructions": "Your six-month check-up is on Tuesday and you now have to be somewhere else that morning. You want it moved to any Thursday in the next month, and you want the new date read back to you before the exchange ends."
+  },
+  "limits": {
+    "max_duration_seconds": 600,
+    "max_turns": 60
+  },
+  "models": {
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "adapter": "openai_chat_completions",
+      "key": "fixture-not-a-real-secret-llm"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general",
+      "adapter": "deepgram"
+    },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "adapter": "cartesia",
+      "voice_id": "measured-alto-3",
+      "speed": 0.95
+    }
+  },
+  "mock_tools": [
+    {
+      "tool_name": "get_availability",
+      "answer": { "answer": { "slots": ["2026-09-03T14:30:00Z"] } },
+      "delay_milliseconds": 250
+    },
+    {
+      "tool_name": "book_appointment",
+      "answer": { "error": "the booking service is unavailable" },
+      "delay_milliseconds": 0
+    }
+  ]
+}

--- a/packages/simulation-contract/span-vocabulary.md
+++ b/packages/simulation-contract/span-vocabulary.md
@@ -93,6 +93,7 @@ disagree with it.
 | Attribute | On | Value |
 | --- | --- | --- |
 | `egma.turn.text` | `human_turn`, `agent_turn` | What was said, as text — spoken and transcribed on voice, sent verbatim on chat. May be empty for a turn that carried no words. |
+| `egma.turn.platform_notes` | `agent_turn` | What the agent's platform said about the turn that nobody said *in* it — a node transition it announced mid-answer, a message in a role Egma has never seen. A JSON array of strings, in the order the platform said them, and absent for every turn that has none, which is nearly all of them. It rides beside `egma.turn.text` rather than inside it because the turn's text is handed back to the persona as the transcript it answers, and because one scenario's chat and voice records are only comparable while neither carries words nobody spoke. Only a connection whose platform reports such things ever emits it. |
 | `egma.tool.name` | `tool_call` | The tool's name, exactly as the platform reported it. |
 | `egma.tool.arguments` | `tool_call` | The arguments, JSON-encoded, exactly as observed — absent where the platform reports the invocation but not its arguments. A string deliberately: the observed bytes are the fact worth keeping. |
 | `egma.tool.result` | `tool_call` | The answer the call was given, JSON-encoded, exactly as it was served. Present only where Egma itself authored the answer; absent for a call Egma merely watched go past, and absent for one Egma refused. |


### PR DESCRIPTION
Ticket 02 of the retell-playground effort (planning: `.scratch/retell-playground/issues/02-the-simulator-types-to-the-playground.md`). Part of the retell-lanes integration; lands on the integration branch, not main.

## What this carries

- **A new `retell_playground` simulator plug**: the chat walk conducts a Retell VOICE agent in text over Retell's stateless agent-playground-completion API — full history each turn, resume state threaded (Retell-LLM state; flow node + component), updated dynamic variables merged over the held set so egma's attribution variable rides **every** request, the agent-ended flag (and the end tool, as a second path) ending the exchange, no audio fact anywhere, no provider reference and the record saying so honestly.
- **Native per-request tool mocks with a proof, not a guess**: the plug hands the run snapshot's answers over as the playground's native mocks (match-anything by name), and before stamping any call `mocked` it verifies the platform's reported tool result against the answer egma served — a platform that ignored the mocks fails the simulation loudly instead of letting the coverage stamp claim isolation that never happened. Mock delays deliberately never apply on chat.
- **Transitions and unknown roles preserved off the transcript**: platform-side content (node/state transitions, unknown roles) lands verbatim in a new `egma.turn.platform_notes` span attribute — a real record slot the persona never sees — so the chat transcript stays comparable with the voice transcript for the same scenario. The span vocabulary gains the attribute, pinned by the span fixtures.
- **Loud, typed failures**: rate limits retry with bounded backoff (honoring a capped `Retry-After`) then fail naming the throttle; payment-required fails naming billing; credentials appear in no message, log, or report — proven with sentinel keys the fake platform echoes back in error bodies.
- **Every wire-shape guess is named** in the plug's docstring with the fake wrong in the same places, so the developer's live run (ticket 03) corrects cheaply; a wrong guess fails loudly rather than conducting wrong.
- Contract fixtures for the optional `agent_version`/`dynamic_variables` fields on this lane, absent and present, on both contract engines.

## Review

Independently reviewed against the ticket and spec before this PR: 1 blocker (the mock-verification fail-safe above), 3 should-fixes (transitions off the persona-visible text; variable merge; per-lane coverage docstring), and the cheap nits — all applied and proven. Known partial, by design: the conducted version is *named on every request* here, but the simulator's report schema has no version slot — the control-plane ticket stamps the resolved version on the simulation row, closing that clause where the write belongs.

## Tests

Plug suite 69, playground acceptance 3, contract fixtures 12 (+40 TS, +15 span fixtures), walk/seam-adjacent suites 282, `ruff` clean, `pnpm build` exit 0. CI's cheap lane runs here; the full proof runs at the main gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABEAtGrwfsBnCBx2RvsRm6

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABEAtGrwfsBnCBx2RvsRm6)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790508151&installation_model_id=431960&pr_number=258&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F258&signature=985f751ebf7107bc90c0887009d326c3c870ba19e454f7caca9058b85806ebc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a text-based Retell playground plug for conducting voice agents through Retell’s stateless completion API.
- Threads conversation history, resume state, dynamic variables, and native tool mocks through each request.
- Preserves platform-only messages as span notes and records playground tool activity through the shared mock-tool seam.
- Updates the chat walk so an agent-ended opening terminates immediately without requesting a persona turn.
- Adds contract fixtures, stub-backed plug coverage, acceptance tests, and span-vocabulary documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/simulator/src/egma_simulator/plugs/retell_playground.py | Implements the stateless Retell playground lifecycle, request state, mock verification, response parsing, retries, and failure handling. |
| apps/simulator/src/egma_simulator/walk.py | Extends agent replies with platform notes and correctly terminates the walk when the opening greeting ends the exchange. |
| apps/simulator/src/egma_simulator/mock_tools.py | Adds native-platform mock handoff and reported-call recording while retaining shared coverage semantics. |
| apps/simulator/src/egma_simulator/service.py | Integrates answer-boundary and final mock-tool span draining into the simulation lifecycle. |
| apps/simulator/src/egma_simulator/spans.py | Records platform-only notes separately from persona-visible transcript content. |
| apps/simulator/tests/test_plug_retell_playground.py | Exercises playground request state, response handling, tool mocks, retries, endings, and credential-safe failures. |

<sub>Reviews (2): Last reviewed commit: ["fix: an agent that ends on its greeting ..."](https://github.com/egma-ai/egma/commit/6d0212cafd6cb393b72848e5c31a5f7d8698ea3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57875873)</sub>

<!-- /greptile_comment -->