### PR TITLE
Retell playground: the connect flows ask how you test

### DIFF
--- a/apps/api/src/providers/retell.ts
+++ b/apps/api/src/providers/retell.ts
@@ -225,9 +225,15 @@ export async function discoverRetellAgents(
         agent.modality === "chat"
           ? [chatCandidate(agent.id)]
           : [
-              // The web call first: it needs nothing of the customer's to be
-              // routed, it is what a mocked run is conducted over, and it is
-              // the one voice lane every voice agent has.
+              // The chat door a voice agent otherwise has none of: the
+              // playground conducts a chat simulation of it in text. Offered
+              // for every voice agent, because whether its engine is one the
+              // playground can reach is a question answered when the connection
+              // is confirmed, not one discovery can answer from a listing.
+              playgroundCandidate(agent.id),
+              // The web call: it needs nothing of the customer's to be routed,
+              // it is what a mocked run is conducted over, and it is the one
+              // voice lane every voice agent has.
               webCallCandidate(agent.id),
               ...numbersAnswering(numbers, agent.id).map(({ number }) =>
                 phoneCandidate(number),

--- a/apps/api/test/agents.test.ts
+++ b/apps/api/test/agents.test.ts
@@ -148,7 +148,7 @@ describe("discovering simulation agents", () => {
     expect(response.statusCode).toBe(404);
   });
 
-  it("returns normalized chat and phone candidates, never provider data or the key", async () => {
+  it("returns normalized playground, web-call, chat and phone candidates, never provider data or the key", async () => {
     api = await createApi("retell_agent_discovery");
     const ada = await signUp(api.app, "ada@acme.example", "Acme");
     const retellKey = "retell-secret-never-returned-WXYZ";
@@ -219,10 +219,21 @@ describe("discovering simulation agents", () => {
           name: "Front desk",
           modality: "voice",
           connectionCandidates: [
-            // The web call comes first, and it is offered whether or not the
-            // agent has a number: Egma places this call itself, so there is
-            // nothing to route. It is also the lane a mocked run is conducted
-            // over.
+            // The playground first: the chat door a voice agent otherwise has
+            // none of. It is offered for every voice agent — whether its engine
+            // is one the playground can reach is answered when the connection is
+            // confirmed, not from a listing.
+            {
+              agentPlatform: "retell",
+              connectionType: "retell_playground",
+              accessVariant: "retell_playground.api_key",
+              modality: "chat",
+              productLabel: "Retell playground",
+              config: { retellAgentId: "agent_voice_1" },
+            },
+            // The web call is offered whether or not the agent has a number:
+            // Egma places this call itself, so there is nothing to route. It is
+            // also the lane a mocked run is conducted over.
             {
               agentPlatform: "retell",
               connectionType: "retell_web_call",
@@ -261,8 +272,16 @@ describe("discovering simulation agents", () => {
           name: "Not routed",
           modality: "voice",
           // A voice agent nobody has routed a number to is still reachable:
-          // Egma opens a web call against it.
+          // over the playground in text, and over a web call Egma opens.
           connectionCandidates: [
+            {
+              agentPlatform: "retell",
+              connectionType: "retell_playground",
+              accessVariant: "retell_playground.api_key",
+              modality: "chat",
+              productLabel: "Retell playground",
+              config: { retellAgentId: "agent_voice_without_number" },
+            },
             {
               agentPlatform: "retell",
               connectionType: "retell_web_call",

--- a/apps/api/test/retell-playground-lane.test.ts
+++ b/apps/api/test/retell-playground-lane.test.ts
@@ -61,6 +61,16 @@ const RETELL_CHAT = {
   credentials: { apiKey: SENTINEL_KEY },
 } as const;
 
+/** The voice door beside the playground: a web call against the same agent. */
+const WEB_CALL = {
+  agentPlatform: "retell",
+  connectionType: "retell_web_call",
+  accessVariant: "retell_web_call.api_key",
+  modality: "voice",
+  config: { retellAgentId: PLATFORM_AGENT },
+  credentials: { apiKey: SENTINEL_KEY },
+} as const;
+
 /**
  * A conversation flow with one tool of each class: one Egma stands in front
  * of, one that executes inside Retell, and one Egma does not intercept yet.
@@ -343,6 +353,60 @@ describe("registering a playground connection against a named Retell agent", () 
     });
     expect(refused.statusCode, JSON.stringify(refused.body)).toBe(422);
     expect(String(refused.body.message)).toContain("Chat API");
+  });
+});
+
+describe("one Retell agent through both a text and a voice door, on the web's fresh flow", () => {
+  /**
+   * The web connect flow registers a fresh agent by POSTing a plain
+   * registration — it has no name-clash fallback of its own, unlike the CLI. So
+   * the server is what has to land the other modality on the first door's agent.
+   * Both the playground (chat) and the web call (voice) key on the vendor agent
+   * id, so it does: a connection added, never a twin, in either order.
+   */
+  async function bothDoors(
+    label: string,
+    firstDoor: typeof PLAYGROUND | typeof WEB_CALL,
+    secondDoor: typeof PLAYGROUND | typeof WEB_CALL,
+  ): Promise<void> {
+    const { fetchImpl } = retell({ channel: "voice" });
+    api = await createApi(label, { retellFetch: fetchImpl });
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+
+    const post = (door: typeof PLAYGROUND | typeof WEB_CALL) =>
+      ask(api.app, "POST", "/v1/agents", key, {
+        agentPlatform: "retell",
+        name: "Front desk",
+        connection: { ...door, platformAgentId: PLATFORM_AGENT },
+      });
+
+    const first = await post(firstDoor);
+    expect(first.statusCode, JSON.stringify(first.body)).toBe(201);
+    expect(first.body.result).toBe("created");
+
+    const second = await post(secondDoor);
+    expect(second.statusCode, JSON.stringify(second.body)).toBe(201);
+    // Attached to the first door's agent, not a second identity.
+    expect(second.body.result).toBe("connection_added");
+    expect((second.body.agent as { id: string }).id).toBe(
+      (first.body.agent as { id: string }).id,
+    );
+
+    // One Egma agent, two connections; the sentinel key never surfaced.
+    const { rows } = await api.database.sql<{ count: string }>(
+      "select count(*)::text as count from agent",
+    );
+    expect(rows[0]?.count).toBe("1");
+    expect(JSON.stringify(second.body)).not.toContain(SENTINEL_KEY);
+  }
+
+  it("attaches the web call after the playground, on one egma agent", async () => {
+    await bothDoors("web_playground_then_webcall", PLAYGROUND, WEB_CALL);
+  });
+
+  it("attaches the playground after the web call, on one egma agent", async () => {
+    await bothDoors("web_webcall_then_playground", WEB_CALL, PLAYGROUND);
   });
 });
 

--- a/apps/cli/src/retell/connect.ts
+++ b/apps/cli/src/retell/connect.ts
@@ -39,6 +39,7 @@ import {
 import { ConnectionCredentials } from "../platform/connection-credentials.ts";
 import {
   confirmNumber,
+  CUSTOM_LLM_HAS_NO_CONFIGURATION,
   listAgents,
   listNumbers,
   numbersAnswering,
@@ -81,10 +82,12 @@ export const DEFAULT_AGENT_NAME = "voice-agent";
 /**
  * How egma reaches the agent, chosen by the developer and never by egma.
  *
- * A Retell voice agent is reached by phone. A genuine Retell chat agent is
- * reached by text. Voice-over-text stays unavailable until Egma implements
- * Retell Agent Playground Completion; the shipped chat adapter cannot safely
- * conduct that path.
+ * A Retell voice agent is reached either way: by phone, dialling one of its
+ * numbers, or by text, conducting a chat simulation over the Retell playground.
+ * A genuine Retell chat agent is reached by text alone, over the chat API. So
+ * text means two different connections depending on the agent it is chosen for
+ * — the playground for a voice agent, the chat API for a chat one — which is
+ * `selectionFor`'s whole job below.
  */
 export type Reach = "text" | "phone";
 
@@ -99,15 +102,25 @@ export const REACH_LINES: Readonly<Record<Reach, string>> = {
     "telephone network, the way the people who call it do.",
 };
 
-/** What a developer can do after asking Retell for the wrong connection type. */
-export const VOICE_REQUIRES_PHONE_LINE =
-  "Retell says this is a voice agent. Voice agents require a Phone connection. " +
-  "Choose --reach phone and try again. Nothing was written.";
-
 /** What a developer can do after asking Retell for a phone connection to chat. */
 export const CHAT_REQUIRES_TEXT_LINE =
   "Retell says this is a chat agent. Chat agents require a Chat connection. " +
   "Choose --reach text and try again. Nothing was written.";
+
+/**
+ * Why text cannot reach a voice agent whose engine is a custom LLM.
+ *
+ * The playground is the door text would open for a voice agent, and it reaches
+ * an agent's words and tools through Retell — which holds neither for a custom
+ * LLM. So the refusal is Retell's own absence, said in the package's one place
+ * for it, and then the one door that does reach such an agent: its phone line,
+ * where the agent answers the way its callers reach it. It is the same reason
+ * the run-start read and the web flow give, at the moment the engine is read.
+ */
+export const PLAYGROUND_REFUSES_CUSTOM_LLM =
+  `${CUSTOM_LLM_HAS_NO_CONFIGURATION} Choose --reach phone and test this agent ` +
+  "over its phone line instead, which reaches it the way its callers do. " +
+  "Nothing was written.";
 
 /** What the developer is asked when the phone was chosen. */
 export const NUMBER_ASK_LINE =
@@ -216,7 +229,15 @@ export type ConnectOutcome =
   | { readonly kind: "unchosen"; readonly agents: readonly RetellAgent[] }
   /** Nobody chose one of the provider-safe ways offered for this agent. */
   | { readonly kind: "unchosen-reach"; readonly offered: readonly Reach[] }
-  /** The requested reach does not match the selected Retell agent's channel. */
+  /**
+   * The requested reach cannot reach this agent, and the reason says why.
+   *
+   * Two shapes, one outcome: a chat agent asked for by phone, which has no
+   * number to dial, and a voice agent asked for by text whose engine is a
+   * custom LLM, which the playground cannot reach. Each names the reach that
+   * does work — text for the first, phone for the second — and the reason a
+   * developer reads.
+   */
   | {
       readonly kind: "incompatible-reach";
       readonly requested: Reach;
@@ -379,13 +400,16 @@ type Selected = {
 /**
  * The one connection the chosen reach means.
  *
- * **Text is only a direct connection to a genuine Retell chat agent.** A voice
- * agent cannot take this branch until the Agent Playground Completion adapter
- * exists. **Phone carries the destination number and no durable connection
- * credential.** Its request-only platform selection carries the Retell key so
- * the API can confirm the routing during the write, then discard the key. The
- * separate agent-platform field records that this onboarding flow found the
- * agent in Retell.
+ * **Text means two different connections, and the agent decides which.** A
+ * genuine Retell chat agent is reached over the chat API; a Retell voice agent
+ * is reached over the playground, which conducts a chat simulation of it in
+ * text. Both carry the vendor's own agent id and the Retell key, because both
+ * conduct every simulation through Retell — and they differ only in the two
+ * technical axes that name which door egma knocks on. **Phone carries the
+ * destination number and no durable connection credential.** Its request-only
+ * platform selection carries the Retell key so the API can confirm the routing
+ * during the write, then discard the key. The separate agent-platform field
+ * records that this onboarding flow found the agent in Retell.
  */
 function selectionFor(
   reach: Reach,
@@ -412,14 +436,21 @@ function selectionFor(
       number,
     };
   }
+  // A voice agent tested in text is conducted over the playground; a chat agent
+  // over the chat API. The engine that cannot take the playground — a custom
+  // LLM — has already been refused before this is reached, so a voice agent
+  // here is one the playground can conduct.
+  const playground = config.modality === "voice";
   return {
     reach,
     connection: {
       agentPlatform: "retell",
-      connectionType: "retell_chat_api",
-      accessVariant: "retell_chat_api.api_key",
-      // Only Retell chat agents reach this branch. Their vendor identity is the
-      // connection target, and no phone number is read or stored.
+      connectionType: playground ? "retell_playground" : "retell_chat_api",
+      accessVariant: playground
+        ? "retell_playground.api_key"
+        : "retell_chat_api.api_key",
+      // The one modality both text doors speak: a chat simulation, whether of a
+      // voice agent over the playground or a chat agent over the chat API.
       modality: "chat",
       config: { retellAgentId: config.agentId },
       credentials: ConnectionCredentials.defer(() => ({ apiKey: key.reveal() })),
@@ -441,11 +472,27 @@ function isTheSameReach(held: RegisteredConnection, wanted: NewConnection): bool
   return Object.entries(wanted.config).every(([key, value]) => held.config[key] === value);
 }
 
-/** The Retell agent a connection already on the platform reaches, if it names one. */
+/**
+ * The Retell agent a connection already on the platform reaches, if it names
+ * one.
+ *
+ * Every Retell connection that carries the vendor's own agent id answers here —
+ * the chat API, the playground, and the web call alike — because the whole
+ * point is telling a name clash apart: a living connection naming this vendor
+ * agent means the row that holds it is this agent, whichever modality it was
+ * reached by. Only a phone connection names no vendor id, and that is the one
+ * case the numbers below have to settle instead.
+ */
+const RETELL_AGENT_ID_KINDS: readonly string[] = [
+  "retell_chat_api",
+  "retell_playground",
+  "retell_web_call",
+];
+
 function retellAgentOf(held: RegisteredConnection): string | null {
   if (
     held.agentPlatform !== "retell" ||
-    held.connectionType !== "retell_chat_api"
+    !RETELL_AGENT_ID_KINDS.includes(held.connectionType)
   ) {
     return null;
   }
@@ -834,28 +881,40 @@ export async function connect(options: ConnectOptions): Promise<ConnectOutcome> 
 
   const config = pulled.config;
 
-  // The agent is settled, so what egma may offer is settled with it. Asking
-  // before this point would be offering a phone the agent may have no number
-  // for.
-  const compatibleReach: Reach = config.modality === "voice" ? "phone" : "text";
-  const offered: readonly Reach[] = [compatibleReach];
+  // The agent is settled, so what egma may offer is settled with it. This is
+  // the modality question, and it leads: for a voice agent the developer says
+  // chat or voice — text over the playground, or phone down a line — before
+  // any number is read. A chat agent has one door, text over the chat API, so
+  // there is nothing to ask it and text is all that is offered.
+  const offered: readonly Reach[] =
+    config.modality === "voice" ? ["text", "phone"] : ["text"];
   const reach = await options.chooseReach(offered);
   if (options.signal.aborted) return { kind: "interrupted" };
   if (reach === null) return { kind: "unchosen-reach", offered };
-  if (config.modality === "voice" && reach !== "phone") {
-    return {
-      kind: "incompatible-reach",
-      requested: reach,
-      compatible: compatibleReach,
-      reason: VOICE_REQUIRES_PHONE_LINE,
-    };
-  }
+  // A chat agent has no number to dial, so phone is the wrong door for it.
   if (config.modality === "chat" && reach !== "text") {
     return {
       kind: "incompatible-reach",
       requested: reach,
-      compatible: compatibleReach,
+      compatible: "text",
       reason: CHAT_REQUIRES_TEXT_LINE,
+    };
+  }
+  // A voice agent tested in text is conducted over the playground, which
+  // reaches an agent's words and tools through Retell — and a custom LLM keeps
+  // both on its own socket server, out of that reach. So the engine, already
+  // read when the agent was pulled, is refused here, at the door, with its
+  // reason and the phone line as the way that does reach it.
+  if (
+    config.modality === "voice" &&
+    reach === "text" &&
+    config.engine === "custom-llm"
+  ) {
+    return {
+      kind: "incompatible-reach",
+      requested: reach,
+      compatible: "phone",
+      reason: PLAYGROUND_REFUSES_CUSTOM_LLM,
     };
   }
 

--- a/apps/cli/test/connect-command.test.ts
+++ b/apps/cli/test/connect-command.test.ts
@@ -61,6 +61,23 @@ const VOICE_AGENT: FakeRetellScript = {
   agents: ONE_AGENT.agents.map((agent) => ({ ...agent, channel: "voice" as const })),
 };
 
+/** A voice agent whose brain is a custom LLM, out of the playground's reach. */
+const CUSTOM_LLM_VOICE_AGENT: FakeRetellScript = {
+  keys: [KEY],
+  agents: [
+    {
+      agent_id: "agent_0001",
+      agent_name: "order-line",
+      channel: "voice",
+      voice_id: "11labs-Adrian",
+      response_engine: {
+        type: "custom-llm",
+        llm_websocket_url: "wss://example.invalid/llm",
+      },
+    },
+  ],
+};
+
 const TWO_AGENTS: FakeRetellScript = {
   keys: [KEY],
   agents: [
@@ -402,17 +419,21 @@ describe("egma connect", () => {
  * dial somebody's telephone.
  */
 describe("which connection egma creates", () => {
-  it("refuses an explicit reach that the Retell agent does not support before writing", async () => {
-    retell = await startFakeRetell(VOICE_AGENT);
+  it("refuses an explicit reach the Retell agent does not support before writing", async () => {
+    // A chat agent has no phone line to dial, so phone is the wrong door. The
+    // voice-over-text refusal that used to sit here retired: text now mints a
+    // playground for a voice agent, so the remaining mismatch is a chat agent
+    // asked for by phone.
+    retell = await startFakeRetell(ONE_AGENT);
 
-    const result = await egma(["connect", "--reach", "text"], { stdin: KEY });
+    const result = await egma(["connect", "--reach", "phone"], { stdin: KEY });
 
     expect(result.code).toBe(CONNECT_EXIT.unchosen);
     expect(facts(result.stdout).status).toBe("incompatible-reach");
-    expect(result.stdout).toContain("reach_option: phone");
-    expect(result.stdout).not.toContain("reach_option: text");
+    expect(result.stdout).toContain("reach_option: text");
+    expect(result.stdout).not.toContain("reach_option: phone");
     expect(result.stderr).toContain(
-      "Voice agents require a Phone connection. Choose --reach phone and try again.",
+      "Chat agents require a Chat connection. Choose --reach text and try again.",
     );
     expect(platform.registered.agents).toHaveLength(0);
     expect(platform.registered.connections).toHaveLength(0);
@@ -459,8 +480,9 @@ describe("which connection egma creates", () => {
 
     expect(result.code).toBe(CONNECT_EXIT.unchosen);
     expect(facts(result.stdout).status).toBe("unchosen-reach");
-    // Only the compatible way was put on the screen, and it was not taken.
-    expect(result.stdout).not.toContain("reach_option: text");
+    // Both ways a voice agent supports were put on the screen, and neither was
+    // taken.
+    expect(result.stdout).toContain("reach_option: text");
     expect(result.stdout).toContain("reach_option: phone");
     expect(platform.registered.agents).toHaveLength(0);
     expect(platform.registered.connections).toHaveLength(0);
@@ -535,8 +557,12 @@ describe("which connection egma creates", () => {
 });
 
 describe("the whole walk, headless", () => {
-  it("prints the compatible Retell reach and stops before writing on a mismatch", async () => {
-    retell = await startFakeRetell(VOICE_AGENT);
+  it("prints the compatible Retell reach and stops before writing on a custom-LLM mismatch", async () => {
+    // The playground reaches a voice agent's words and tools through Retell, and
+    // a custom LLM keeps both on its own socket. So text is offered — every
+    // voice agent has it — but the engine is refused at the door, with phone
+    // named as the way that does reach it.
+    retell = await startFakeRetell(CUSTOM_LLM_VOICE_AGENT);
     const script = await workspace.script({
       steps: [
         { kind: "say", text: "egma:found framework retell-sdk\n" },
@@ -560,13 +586,13 @@ describe("the whole walk, headless", () => {
     );
 
     expect(result.code).toBe(1);
+    // A voice agent offers both ways; the engine, not the reach, is what fails.
+    expect(result.stdout).toContain("reach_option: text");
     expect(result.stdout).toContain("reach_option: phone");
-    expect(result.stdout).not.toContain("reach_option: text");
-    expect(result.stdout).toContain(
-      "Egma could not finish: Retell says this is a voice agent. " +
-        "Voice agents require a Phone connection. Choose --reach phone and try again. " +
-        "Nothing was written.",
-    );
+    expect(result.stdout).toContain("Egma could not finish: ");
+    expect(result.stdout).toContain("custom LLM");
+    expect(result.stdout).toContain("Choose --reach phone");
+    expect(result.stdout).toContain("Nothing was written.");
     expect(platform.registered.agents).toHaveLength(0);
     expect(platform.registered.connections).toHaveLength(0);
     await expect(readConfig(folderPathsIn(workspace.dir).config)).rejects.toMatchObject({

--- a/apps/cli/test/connect-screen.test.ts
+++ b/apps/cli/test/connect-screen.test.ts
@@ -385,14 +385,16 @@ describe("the choice between text and phone", () => {
     const offered = await showing(
       run,
       "How should Egma reach this agent?",
+      "Chat — Egma exchanges messages with the agent",
       "Phone — Egma dials one of the agent's numbers",
       "Egma creates this connection only after you confirm it.",
     );
-    // Retell voice agents support only phone. It is the only row, and the
-    // developer must still confirm before Egma can dial it.
-    expect(offered).toContain("\u203a Phone");
-    expect(offered).not.toContain("Chat —");
-
+    // A voice agent supports both ways: chat over the playground and voice down
+    // a line. Text is the row the cursor rests on first because it dials
+    // nothing; the developer moves to phone and confirms it before Egma dials.
+    expect(offered).toContain("\u203a Chat");
+    run.write("\u001B[B");
+    await showing(run, "› Phone");
     run.write("\r");
 
     await chooseNoExistingTests(run);
@@ -435,6 +437,9 @@ describe("the choice between text and phone", () => {
     await showing(run, "Paste your Retell API key");
     run.write(`${KEY}\n`);
     await showing(run, "How should Egma reach this agent?");
+    // A voice agent offers text first; move to phone, the lane that dials.
+    run.write("\u001B[B");
+    await showing(run, "› Phone");
     run.write("\r");
 
     // Two numbers reach this agent, so there is a real choice and the wizard
@@ -481,7 +486,9 @@ describe("the choice between text and phone", () => {
     run.write("\u001B");
 
     expect(await run.exited).toBe(1);
-    expect(run.scrollback()).toContain("nobody chose phone, so nothing was created");
+    expect(run.scrollback()).toContain(
+      "nobody chose text or phone, so nothing was created",
+    );
     expect(platform.registered.agents).toHaveLength(0);
     expect(platform.registered.connections).toHaveLength(0);
   });

--- a/apps/cli/test/connect.test.ts
+++ b/apps/cli/test/connect.test.ts
@@ -21,7 +21,7 @@ import {
   KEY_ASK_LINE,
   CUSTODY_LINE,
   NO_AGENTS_LINE,
-  VOICE_REQUIRES_PHONE_LINE,
+  PLAYGROUND_REFUSES_CUSTOM_LLM,
 } from "../src/retell/connect.ts";
 import { DRIFT_LINE } from "../src/retell/prompt-drift.ts";
 import { HeadlessUI } from "../src/ui/headless-ui.ts";
@@ -77,6 +77,24 @@ const ONE_VOICE_AGENT: FakeRetellScript = {
     },
   ],
   ...(ONE_CHAT_AGENT.llms === undefined ? {} : { llms: ONE_CHAT_AGENT.llms }),
+  numbers: NUMBERS,
+};
+
+/** A voice agent whose brain is a custom LLM, so Retell holds no words for it. */
+const ONE_VOICE_CUSTOM_LLM_AGENT: FakeRetellScript = {
+  keys: [KEY],
+  agents: [
+    {
+      agent_id: "agent_0001",
+      agent_name: "order-line",
+      channel: "voice",
+      voice_id: "11labs-Adrian",
+      response_engine: {
+        type: "custom-llm",
+        llm_websocket_url: "wss://example.invalid/llm",
+      },
+    },
+  ],
   numbers: NUMBERS,
 };
 
@@ -328,14 +346,59 @@ describe("one agent, and several", () => {
     expect(connected?.config.prompt).toBeNull();
   });
 
-  it("refuses text for a Retell voice agent before it writes anything", async () => {
+  it("makes a text connection a playground one for a Retell voice agent", async () => {
+    // agent_0002 is a voice agent on a Retell LLM, so text is a chat simulation
+    // over the playground rather than the phone. The refusal that used to stand
+    // here retired with this lane.
     retell = await startFakeRetell(THREE_AGENTS);
 
-    const voice = await run({ keys: [KEY], agent: "agent_0002" });
-    expect(voice.connected).toBeNull();
-    expect(voice.report).toEqual({ kind: "failed", reason: VOICE_REQUIRES_PHONE_LINE });
+    const { connected } = await run({ keys: [KEY], agent: "agent_0002" });
+
+    expect(connected?.reach).toBe("text");
+    expect(connected?.config.modality).toBe("voice");
+    const [connection] = platform.registered.connections;
+    expect(connection?.connectionType).toBe("retell_playground");
+    expect(connection?.accessVariant).toBe("retell_playground.api_key");
+    // A chat simulation of a voice agent: the connection speaks chat, and it
+    // names the voice agent it conducts against.
+    expect(connection?.modality).toBe("chat");
+    expect(connection?.config).toEqual({ retellAgentId: "agent_0002" });
+    expect(connection?.productLabel).toBe("Retell playground");
+    // The key conducts every playground exchange, so it is sealed on the
+    // connection exactly as the chat API's is.
+    expect(connection?.credentialsHint).toBe(KEY.slice(-4));
+  });
+
+  it("refuses text for a voice agent whose engine is a custom LLM, at the door", async () => {
+    // The playground reaches an agent's words and tools through Retell, and a
+    // custom LLM keeps both on the customer's own socket. So the choice is
+    // refused with its reason, before anything is written, and phone is named
+    // as the door that does reach it.
+    retell = await startFakeRetell(ONE_VOICE_CUSTOM_LLM_AGENT);
+
+    const refused = await run({ keys: [KEY], reach: "text" });
+
+    expect(refused.connected).toBeNull();
+    expect(refused.report).toEqual({
+      kind: "failed",
+      reason: PLAYGROUND_REFUSES_CUSTOM_LLM,
+    });
+    expect(PLAYGROUND_REFUSES_CUSTOM_LLM).toContain("custom LLM");
+    expect(PLAYGROUND_REFUSES_CUSTOM_LLM).toContain("--reach phone");
     expect(platform.registered.agents).toHaveLength(0);
     expect(platform.registered.connections).toHaveLength(0);
+  });
+
+  it("still conducts a custom-LLM voice agent over the phone, which reaches it", async () => {
+    // The refusal is the playground's alone: a phone connection dials the
+    // agent the way its callers do, whatever engine answers behind the line.
+    retell = await startFakeRetell(ONE_VOICE_CUSTOM_LLM_AGENT);
+
+    const { connected, report } = await run({ keys: [KEY], reach: "phone" });
+
+    expect(report.kind).toBe("connected");
+    expect(connected?.reach).toBe("phone");
+    expect(platform.registered.connections[0]?.connectionType).toBe("phone_number");
   });
 
   it("reads a chat agent at the address Retell keeps chat agents at", async () => {
@@ -539,6 +602,74 @@ describe("what lands on the platform", () => {
       agent: "created",
       connection: "created",
     });
+  });
+});
+
+describe("one agent, two connections", () => {
+  /**
+   * The chat-versus-voice diagnostic the model promises needs both histories
+   * under one identity. So registering the same Retell agent again with the
+   * other modality attaches to the agent the first walk wrote, never a twin —
+   * in either order, because a developer sets one up today and the other
+   * tomorrow and cannot be made to remember which came first.
+   */
+  it("attaches text after phone to the one agent, never a twin", async () => {
+    retell = await startFakeRetell(ONE_VOICE_AGENT);
+
+    const phone = await run({ keys: [KEY], reach: "phone" });
+    const text = await run({ keys: [KEY], reach: "text" });
+
+    expect(phone.connected?.reach).toBe("phone");
+    expect(text.connected?.reach).toBe("text");
+
+    // One egma agent holds both ways of reaching the one Retell agent.
+    expect(platform.registered.agents.map((agent) => agent.name)).toEqual(["order-line"]);
+    expect(text.connected?.registered.agent.id).toBe(phone.connected?.registered.agent.id);
+
+    // The phone was written first; the playground was added to the same agent.
+    expect(phone.connected?.registration).toEqual({ agent: "created", connection: "created" });
+    expect(text.connected?.registration).toEqual({ agent: "reused", connection: "created" });
+    expect(text.connected?.registered.result).toBe("connection_added");
+
+    const kinds = platform.registered.connections.map((one) => one.connectionType).sort();
+    expect(kinds).toEqual(["phone_number", "retell_playground"]);
+  });
+
+  it("attaches phone after text to the one agent, never a twin", async () => {
+    retell = await startFakeRetell(ONE_VOICE_AGENT);
+
+    const text = await run({ keys: [KEY], reach: "text" });
+    const phone = await run({ keys: [KEY], reach: "phone" });
+
+    expect(text.connected?.reach).toBe("text");
+    expect(phone.connected?.reach).toBe("phone");
+
+    expect(platform.registered.agents.map((agent) => agent.name)).toEqual(["order-line"]);
+    expect(phone.connected?.registered.agent.id).toBe(text.connected?.registered.agent.id);
+
+    // The playground was written first; the phone was added to the same agent.
+    expect(text.connected?.registration).toEqual({ agent: "created", connection: "created" });
+    expect(phone.connected?.registration).toEqual({ agent: "reused", connection: "created" });
+    expect(phone.connected?.registered.result).toBe("connection_added");
+
+    const kinds = platform.registered.connections.map((one) => one.connectionType).sort();
+    expect(kinds).toEqual(["phone_number", "retell_playground"]);
+  });
+
+  it("reuses the playground connection when the same modality is registered twice", async () => {
+    // Registering text twice is one connection, rotated: the within-type reuse
+    // rule the platform already keeps, now for the playground too.
+    retell = await startFakeRetell({ ...ONE_VOICE_AGENT, keys: [KEY, OTHER_KEY] });
+
+    const first = await run({ keys: [KEY], reach: "text" });
+    const second = await run({ keys: [OTHER_KEY], reach: "text" });
+
+    expect(first.connected?.registered.result).toBe("created");
+    expect(second.connected?.registered.result).toBe("reused");
+    expect(platform.registered.connections).toHaveLength(1);
+    expect(platform.registered.connections[0]?.connectionType).toBe("retell_playground");
+    // The key it was just given replaces the old one whole.
+    expect(platform.registered.connections[0]?.credentialsHint).toBe(OTHER_KEY.slice(-4));
   });
 });
 

--- a/apps/cli/test/reach-choice.test.ts
+++ b/apps/cli/test/reach-choice.test.ts
@@ -288,21 +288,29 @@ describe("choosing the phone", () => {
 });
 
 describe("choosing text", () => {
-  it("refuses text for a Retell voice agent before it writes anything", async () => {
+  it("creates one Retell playground connection for a Retell voice agent", async () => {
+    // A voice agent tested in text is conducted over the playground. The
+    // refusal that used to stand here retired with this lane, the agent being
+    // on a Retell LLM the playground can reach.
     retell = await startFakeRetell(ACCOUNT);
 
     const { report, connected } = await run({ reach: "text" });
 
-    expect(connected).toBeNull();
-    expect(report).toEqual({
-      kind: "failed",
-      reason:
-        "Retell says this is a voice agent. Voice agents require a Phone connection. " +
-        "Choose --reach phone and try again. Nothing was written.",
-    });
-    expect(platform.registered.agents).toHaveLength(0);
-    expect(platform.registered.connections).toHaveLength(0);
-    expect(await wroteAnEgmaFolder()).toBe(false);
+    expect(connected?.reach).toBe("text");
+    expect(connected?.number).toBeNull();
+    expect(report.kind).toBe("connected");
+
+    expect(platform.registered.connections).toHaveLength(1);
+    const [connection] = platform.registered.connections;
+    expect(connection?.agentPlatform).toBe("retell");
+    expect(connection?.connectionType).toBe("retell_playground");
+    expect(connection?.accessVariant).toBe("retell_playground.api_key");
+    // A chat simulation of a voice agent: the connection speaks chat and names
+    // the voice agent it conducts against.
+    expect(connection?.modality).toBe("chat");
+    expect(connection?.config).toEqual({ retellAgentId: "agent_0001" });
+    expect(connection?.credentialsHint).toBe(KEY.slice(-4));
+    expect(platform.registered.sealed).toEqual([KEY]);
   });
 
   it("creates one Retell chat connection for the selected chat agent", async () => {
@@ -337,13 +345,15 @@ describe("choosing text", () => {
 });
 
 describe("choosing neither", () => {
-  it("offers only phone for a Retell voice agent", async () => {
+  it("offers both text and phone for a Retell voice agent", async () => {
+    // The modality question leads for a voice agent: chat over the playground,
+    // or voice down a line. Both are offered, and neither is chosen here.
     retell = await startFakeRetell(ACCOUNT);
 
     const { lines } = await run({ reach: null });
 
+    expect(lines).toContainEqual(expect.stringContaining("reach_option: text"));
     expect(lines).toContainEqual(expect.stringContaining("reach_option: phone"));
-    expect(lines).not.toContainEqual(expect.stringContaining("reach_option: text"));
   });
 
   it("offers only text for a Retell chat agent", async () => {
@@ -363,7 +373,7 @@ describe("choosing neither", () => {
     expect(ui.record.reachOffered).toBe(true);
     expect(report).toEqual({
       kind: "failed",
-      reason: "nobody chose phone, so nothing was created.",
+      reason: "nobody chose text or phone, so nothing was created.",
     });
     expect(platform.registered.agents).toHaveLength(0);
     expect(platform.registered.connections).toHaveLength(0);

--- a/apps/cli/test/support/fixture-platform/agents.ts
+++ b/apps/cli/test/support/fixture-platform/agents.ts
@@ -308,6 +308,34 @@ const REGISTRY: Readonly<Record<string, Descriptor>> = {
     reuseKey: "retellAgentId",
     simulatorAdapter: true,
   },
+  retell_playground: {
+    // Chat, and a chat with a voice agent: the playground door a Retell voice
+    // agent otherwise has none of. Voice is never admitted here — a playground
+    // exchange synthesizes nothing — so a voice simulation of the same agent is
+    // a phone or web-call connection beside this one, on one Egma agent.
+    modalities: ["chat"],
+    // Retell brokers the exchange exactly as it brokers a chat session.
+    topology: "hosted-broker",
+    accessVariants: [
+      {
+        id: "retell_playground.api_key",
+        named: "a Retell playground connection",
+        // Only the vendor agent id here: the CLI never sends the optional
+        // baseUrl the real registry admits for a proxied deployment, so the
+        // fixture does not need to model a URL gate it would never exercise.
+        config: { retellAgentId: nonEmptyString },
+        credentials: {
+          required: true,
+          fields: ["apiKey"],
+          hint: lastFourOf("apiKey"),
+        },
+      },
+    ],
+    // The same vendor agent as the voice connection beside it: chat and voice
+    // land as two connections on one Egma agent, never a twin.
+    reuseKey: "retellAgentId",
+    simulatorAdapter: true,
+  },
   phone_number: {
     modalities: ["voice"],
     topology: "egma-dials-in",
@@ -408,6 +436,13 @@ const CONNECTION_OPTIONS = [
     accessVariant: "retell_chat_api.api_key",
     modality: "chat",
     productLabel: "Retell chat",
+  },
+  {
+    agentPlatform: "retell",
+    connectionType: "retell_playground",
+    accessVariant: "retell_playground.api_key",
+    modality: "chat",
+    productLabel: "Retell playground",
   },
   {
     agentPlatform: "retell",

--- a/apps/simulator/.gitignore
+++ b/apps/simulator/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 .ruff_cache/
 # The default write-ahead-log location when run from this directory.
 .egma-simulator/
+# Proof artifacts the live playground suite banks when a developer runs it.
+tests/.live-proof/

--- a/apps/simulator/tests/test_live_playground.py
+++ b/apps/simulator/tests/test_live_playground.py
@@ -1,0 +1,383 @@
+"""One real chat simulation of a real Retell voice agent — opt-in.
+
+Everything else on this lane converses with a playground-shaped stub, which
+proves the plug speaks the documented protocol and nothing at all about the
+platform behind it. This file is the other half, and the founder's one live
+proof: a genuine chat simulation against a real Retell **voice** agent, over
+the agent-playground-completion API, with a mocked tool answer and a node or
+state transition on the record — and no audio anywhere, because the playground
+synthesizes nothing and hears nothing.
+
+It is written here and **run by the developer**, never by an agent and never
+by CI: agents test against fakes only, and the live account is the developer's
+to touch (ruling 2026-08-28). With its environment missing it skips — visibly,
+never failing, never waiting on anybody, and never reaching a network.
+
+## The one command
+
+    TEST_RETELL_API_KEY=key_... \\
+    TEST_RETELL_AGENT_ID=agent_... \\
+    TEST_MODEL_API_KEY=sk-... \\
+    uv run pytest tests/test_live_playground.py -v -s
+
+## What it needs, and why each
+
+- **TEST_RETELL_API_KEY** and **TEST_RETELL_AGENT_ID** — a real Retell key and
+  a real **voice** agent on that account, conducted on a conversation flow or a
+  Retell LLM (a custom-LLM agent is refused by construction and is the wrong
+  agent for this proof). The agent should have at least one tool and a prompt
+  that a booking-style scenario leads it to call, so a mocked answer lands.
+- **TEST_MODEL_API_KEY** — a funded model key for the persona's own brain, so
+  the caller reasons for real rather than reading a script. It is the OpenAI
+  key `direct_models` gives the persona; each name also falls back to the
+  provider's own plain variable, so one environment drives the whole thing.
+- **TEST_RETELL_SCENARIO** — optional, the situation the persona calls about;
+  tune it to what exercises your agent's tools. A booking-style default is
+  used when it is unset.
+
+It **banks its proof**: the whole record it read is written to a JSON file
+under `tests/.live-proof/` (git-ignored) and its path is printed, and the
+transcript, the coverage stamp, every mocked tool call and every transition
+are printed to stdout — which is what the `-s` above is for. Watch it work.
+
+## What only a live run can say
+
+The exchange really was text — the record carries no audio and no provider
+reference, because the playground stores nothing on Retell's side. The version
+egma resolved was named on every request. Egma's mock answers reached the real
+agent, marked `mocked` on the record with the tool that served them. And the
+platform's own node or state transitions rode back beside the turns, verbatim,
+which is what makes a chat record of a voice agent comparable with a voice one.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import aiohttp
+import pytest
+from conftest import (
+    a_spec,
+    assert_kept_secret,
+    credential,
+    direct_models,
+    has_terminal,
+    span_attribute,
+    spans_for,
+    terminal_event_for,
+    turns_for,
+)
+
+from egma_simulator.plugs.retell import DEFAULT_BASE_URL
+
+API_KEY = credential("TEST_RETELL_API_KEY", "RETELL_API_KEY")
+AGENT_ID = credential("TEST_RETELL_AGENT_ID", "EGMA_RETELL_AGENT_ID")
+MODEL_API_KEY = credential("TEST_MODEL_API_KEY", "OPENAI_API_KEY")
+BASE_URL = credential("TEST_RETELL_BASE_URL", "") or DEFAULT_BASE_URL
+
+REQUIRED = {
+    "TEST_RETELL_API_KEY": API_KEY,
+    "TEST_RETELL_AGENT_ID": AGENT_ID,
+    "TEST_MODEL_API_KEY": MODEL_API_KEY,
+}
+MISSING = sorted(name for name, value in REQUIRED.items() if not value)
+
+pytestmark = pytest.mark.skipif(
+    bool(MISSING),
+    reason=(
+        "no live Retell playground environment: set "
+        + ", ".join(MISSING)
+        + " to conduct one real chat simulation of a real Retell voice agent, "
+        "with a mocked tool answer and a transition on the record"
+    ),
+)
+
+SIMULATION = "sim-playground-live-001"
+
+DEFAULT_SCENARIO = (
+    "You are calling to move a booked appointment. Ask what times are free "
+    "later this week, accept whatever the agent offers, and confirm the new "
+    "time back before finishing."
+)
+SCENARIO = credential("TEST_RETELL_SCENARIO", "") or DEFAULT_SCENARIO
+
+PERSONALITY = (
+    "Polite and warm; explains yourself in two or three full sentences at a "
+    "time rather than clipped answers."
+)
+
+# A chat exchange pays a real second per turn and Retell's per-request cost, so
+# the walls are short: this proves the path works, not that an agent can talk
+# all day.
+MAX_TURNS = 12
+MAX_DURATION_SECONDS = 90
+WITHIN_SECONDS = MAX_DURATION_SECONDS + 60
+
+# What every discovered tool is answered with. Its only job is to reach the
+# agent so the record can show it did: a small, unmistakably-Egma answer, the
+# same one whatever the tool, because what is being proved is interception and
+# not a chain-consistent world.
+MOCK_ANSWER: dict[str, object] = {
+    "ok": True,
+    "note": "answered by an Egma mock tool during a chat simulation",
+    "slots": ["Thursday 2:30pm", "Friday 10:00am"],
+}
+
+# Where a proof is banked, so a hand-run leaves something to keep and read.
+PROOF_DIR = Path(__file__).with_name(".live-proof")
+
+
+async def _read_json(
+    session: aiohttp.ClientSession, url: str
+) -> dict[str, object]:
+    async with session.get(
+        url,
+        headers={"Authorization": f"Bearer {API_KEY}"},
+        timeout=aiohttp.ClientTimeout(total=30),
+    ) as response:
+        assert response.status == 200, (
+            f"{url} → {response.status}: {await response.text()}"
+        )
+        body = await response.json()
+    assert isinstance(body, dict)
+    return body
+
+
+async def _mockable_tools() -> tuple[list[str], object]:
+    """The names of the tools Egma can stand in front of, and the serving version.
+
+    Read the way the run-start read reads it — resolve the serving version once
+    by name, then read that version's engine document — so what is mocked is
+    what the agent actually runs. A custom LLM holds nothing here and is the
+    wrong agent for this proof; the read says so rather than guessing.
+    """
+    async with aiohttp.ClientSession() as session:
+        agent = await _read_json(
+            session, f"{BASE_URL}/get-agent/{AGENT_ID}?version=latest"
+        )
+        version = agent.get("version")
+        engine = agent.get("response_engine")
+        assert isinstance(engine, dict), f"no response engine on {AGENT_ID}: {agent}"
+        engine_type = engine.get("type")
+        if engine_type == "custom-llm":
+            pytest.fail(
+                f"agent {AGENT_ID} is a custom LLM: Retell holds none of its "
+                "tools, and this lane refuses it by construction. Point "
+                "TEST_RETELL_AGENT_ID at a conversation-flow or Retell-LLM "
+                "voice agent for this proof."
+            )
+
+        engine_version = engine.get("version")
+        query = (
+            f"?version={engine_version}"
+            if isinstance(engine_version, int)
+            else ""
+        )
+        if engine_type == "conversation-flow":
+            flow_id = engine.get("conversation_flow_id")
+            document = await _read_json(
+                session, f"{BASE_URL}/get-conversation-flow/{flow_id}{query}"
+            )
+            raw = document.get("tools")
+        else:
+            llm_id = engine.get("llm_id")
+            document = await _read_json(
+                session, f"{BASE_URL}/get-retell-llm/{llm_id}{query}"
+            )
+            raw = document.get("general_tools")
+
+        tools = raw if isinstance(raw, list) else []
+        names: list[str] = []
+        for tool in tools:
+            # Only the tool type Egma stands in front of by name; the platform's
+            # own kinds — transfer, end call, SMS — run inside Retell.
+            if isinstance(tool, dict) and tool.get("type") == "custom":
+                name = tool.get("name")
+                if isinstance(name, str) and name and name not in names:
+                    names.append(name)
+        return names, version
+
+
+def _live_spec(mock_tools: list[dict], version: object) -> dict:
+    """A playground spec against real Retell: no baseUrl, so the plug reaches
+    Retell itself, and the persona's own funded brain."""
+    spec = a_spec(
+        SIMULATION,
+        modality="chat",
+        connection={
+            "agent_platform": "retell",
+            "connection_type": "retell_playground",
+            "access_variant": "retell_playground.api_key",
+            # No baseUrl: the plug reaches Retell's own address.
+            "config": {"retellAgentId": AGENT_ID},
+            "credentials": {"apiKey": API_KEY},
+        },
+        scenario=SCENARIO,
+        personality=PERSONALITY,
+        max_turns=MAX_TURNS,
+        max_duration_seconds=MAX_DURATION_SECONDS,
+        dynamic_variables={"egma_simulation": SIMULATION},
+        mock_tools=mock_tools or None,
+        models=direct_models(modality="chat", llm_key=MODEL_API_KEY),
+    )
+    if isinstance(version, int):
+        spec["agent_version"] = version
+    return spec
+
+
+def _bank(records: list[dict]) -> Path:
+    """Write the whole record read to a git-ignored file, and answer its path."""
+    PROOF_DIR.mkdir(exist_ok=True)
+    path = PROOF_DIR / f"playground-{int(time.time())}.json"
+    path.write_text(json.dumps(records, indent=2), encoding="utf-8")
+    return path
+
+
+def _tool_calls(records: list[dict]) -> list[dict]:
+    return [
+        record["span"]
+        for record in spans_for(records, SIMULATION)
+        if record["span"]["name"] == "tool_call"
+    ]
+
+
+def _transitions(records: list[dict]) -> list[str]:
+    """Every platform note the record carries beside an agent turn.
+
+    A node or state transition Retell announces arrives in a role the record
+    does not know and is preserved verbatim as that turn's platform notes,
+    beside the words rather than among them. Those notes are where a transition
+    lands on the record.
+    """
+    notes: list[str] = []
+    for record in spans_for(records, SIMULATION):
+        span = record["span"]
+        if span["name"] != "agent_turn":
+            continue
+        note = span_attribute(span, "egma.turn.platform_notes")
+        if note:
+            notes.append(note)
+    return notes
+
+
+def _hand_back(records: list[dict], banked: Path) -> None:
+    """Show the founder the promise working: the transcript, the mocked calls,
+    the transitions, and where the whole record was banked."""
+    print(f"\n--- banked proof ---\n{banked}")
+    print("\n--- the transcript ---")
+    for speaker, text in turns_for(records, SIMULATION):
+        print(f"{speaker:>6}: {text}")
+
+    terminal = terminal_event_for(records, SIMULATION) or {}
+    coverage = (terminal.get("facts") or {}).get("mock_tool_coverage")
+    print(f"\n--- the coverage stamp ---\n{json.dumps(coverage, indent=2)}")
+
+    print("\n--- the mocked tool calls, on the record ---")
+    for call in _tool_calls(records):
+        provenance = span_attribute(call, "egma.tool.provenance")
+        print(
+            f"{span_attribute(call, 'egma.tool.name')}: "
+            f"provenance={provenance}, "
+            f"mock_tool={span_attribute(call, 'egma.tool.mock_tool')}, "
+            f"result={span_attribute(call, 'egma.tool.result')}"
+        )
+
+    print("\n--- the transitions, on the record ---")
+    for note in _transitions(records):
+        print(note)
+
+
+@pytest.mark.timeout(WITHIN_SECONDS + 60)
+async def test_a_real_retell_voice_agent_is_conducted_in_text(
+    workbench, start_simulator
+):
+    tool_names, version = await _mockable_tools()
+    mock_tools = [
+        {"tool_name": name, "answer": {"answer": MOCK_ANSWER}} for name in tool_names
+    ]
+
+    await workbench.offer(_live_spec(mock_tools, version))
+    # A real persona brain, no speech: chat synthesizes and hears nothing.
+    simulator = start_simulator(workbench, direct_model=True)
+
+    records = await workbench.wait_for(
+        has_terminal(SIMULATION), within_seconds=WITHIN_SECONDS
+    )
+
+    # The scan comes first, before anything about the conversation is asserted:
+    # the likeliest place a credential reaches a log is a refusal, so a scan
+    # written below a status assertion would never run on the run that failed.
+    simulator.stop()
+    assert_kept_secret(API_KEY, records=records, simulator=simulator)
+    assert_kept_secret(MODEL_API_KEY, records=records, simulator=simulator)
+
+    banked = _bank(records)
+    _hand_back(records, banked)
+
+    terminal = terminal_event_for(records, SIMULATION)
+    assert terminal is not None
+    assert terminal["status"] == "completed", terminal.get("reason")
+    facts = terminal["facts"]
+
+    # No audio and no provider reference: the two facts that say this really was
+    # a text exchange the playground kept nothing of.
+    assert facts["audio"] is None, "a chat simulation carried audio"
+    assert facts["provider_reference"] is None, (
+        "the playground answered a provider reference it is not supposed to keep"
+    )
+
+    # The coverage stamp is present with its three classes: the run read the
+    # agent's tools before the first turn.
+    coverage = facts["mock_tool_coverage"]
+    assert coverage is not None, "no coverage stamp: the world was never read"
+    assert set(coverage) >= {"discovered", "covered", "uncovered"}, coverage
+
+    # A genuine exchange happened: the persona reasoned and the agent answered.
+    spoken = turns_for(records, SIMULATION)
+    agent_turns = [text for speaker, text in spoken if speaker == "agent"]
+    human_turns = [text for speaker, text in spoken if speaker == "human"]
+    assert agent_turns, f"the agent never said anything: {spoken}"
+    assert human_turns, f"the persona never said anything: {spoken}"
+
+    # A transition on the record: a node or state the platform announced,
+    # preserved beside a turn. This is half of what the proof exists to show.
+    transitions = _transitions(records)
+    assert transitions, (
+        "no node or state transition on the record: use an agent and a scenario "
+        "whose conversation moves through its flow or its states"
+    )
+
+    # A mocked tool answer on the record: the other half. Every tool call the
+    # agent made that the run covered is marked mocked, never run for real.
+    calls = _tool_calls(records)
+    assert calls, (
+        "the agent called no tool, so no mocked answer could land: set "
+        "TEST_RETELL_SCENARIO to something that leads your agent to a tool"
+    )
+    covered = set(tool_names)
+    mocked = [
+        call
+        for call in calls
+        if span_attribute(call, "egma.tool.name") in covered
+    ]
+    assert mocked, (
+        "the agent called only tools no mock covered; the ones this run mocked "
+        f"were {sorted(covered)} and it called "
+        f"{[span_attribute(call, 'egma.tool.name') for call in calls]}"
+    )
+    for call in mocked:
+        assert span_attribute(call, "egma.tool.provenance") == "mocked", (
+            "a covered tool call was not marked mocked: an authored answer did "
+            "not reach the agent"
+        )
+        assert span_attribute(call, "egma.tool.mock_tool"), (
+            "a mocked call carries no mock-tool name"
+        )
+
+    # Nothing the simulator sent was refused on its way in. A throttled account
+    # would have failed the run loudly rather than degrading into a shorter
+    # exchange, so a completed run with no refusal is also the rate-limit's
+    # answer — what the actual limit is stays informational, read off this run.
+    assert [record for record in records if record["kind"] == "refusal"] == []

--- a/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
@@ -161,6 +161,10 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
   >(null);
   const [retellAgentId, setRetellAgentId] = useState("");
   const [retellRoute, setRetellRoute] = useState("");
+  // How the developer wants to test a voice agent: chat over the playground, or
+  // voice down a call. The modality question the flow leads with for a voice
+  // agent whose goal is a simulation.
+  const [testModality, setTestModality] = useState<"" | "chat" | "voice">("");
   const [discovering, setDiscovering] = useState(false);
 
   const [livekitAccess, setLivekitAccess] = useState(PROJECT_CREDENTIALS);
@@ -185,6 +189,7 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
     setRetellAgents(null);
     setRetellAgentId("");
     setRetellRoute("");
+    setTestModality("");
     setLivekitAccess(PROJECT_CREDENTIALS);
     setLivekitAgentName("");
     setLivekitConfig({});
@@ -339,6 +344,7 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
     setRetellAgents(null);
     setRetellAgentId("");
     setRetellRoute("");
+    setTestModality("");
     setLivekitAccess(PROJECT_CREDENTIALS);
     setLivekitAgentName("");
     setLivekitConfig({});
@@ -402,6 +408,7 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
     setRetellAgents(answer.value.agents);
     setRetellAgentId("");
     setRetellRoute("");
+    setTestModality("");
     transition("retell-agent");
   }
 
@@ -618,13 +625,30 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
       case "retell-key":
         await findRetellAgents();
         return;
-      case "retell-agent":
-        if (selectedModality === null) return;
-        if (selectedModality === "voice") {
+      case "retell-agent": {
+        if (selectedModality === null || goal === "") return;
+        const next = stepAfterRetellAgent(selectedModality, goal);
+        // A voice agent going straight to the phone step (Monitoring or Both)
+        // needs its first voice route chosen for it; a voice agent going to the
+        // modality question waits for chat-or-voice first.
+        if (next === "retell-phone") {
           const first = voiceRoutes[0];
           setRetellRoute(first === undefined ? "" : retellCandidateValue(first));
         }
-        transition(stepAfterRetellAgent(selectedModality));
+        transition(next);
+        return;
+      }
+      case "retell-modality":
+        if (testModality === "") return;
+        if (testModality === "chat") {
+          // Chat over the playground: minted from the one chat route a voice
+          // agent carries, the same finish the chat-agent path uses.
+          await finishRetellChat();
+        } else {
+          const first = voiceRoutes[0];
+          setRetellRoute(first === undefined ? "" : retellCandidateValue(first));
+          transition("retell-phone");
+        }
         return;
       case "retell-phone":
         await finishRetellVoice();
@@ -680,6 +704,9 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
     const needsCatalog =
       step === "livekit-simulation" ||
       step === "retell-phone" ||
+      // The modality step can mint the playground connection on Continue, and
+      // that needs the option catalog to name the row it writes.
+      step === "retell-modality" ||
       (step === "retell-chat" && goal !== "monitoring");
     if (needsCatalog && catalogRefused !== null) {
       return (
@@ -807,6 +834,7 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
                 onValueChange={(value) => {
                   setRetellAgentId(value);
                   setRetellRoute("");
+                  setTestModality("");
                 }}
               >
                 {visibleRetellAgents.map((one) => {
@@ -841,6 +869,42 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
             <InfoBox>
               Voice agents use a phone number. Chat agents connect through the
               Retell Chat API.
+            </InfoBox>
+          </div>
+        );
+      case "retell-modality":
+        return (
+          <div className="flex flex-col gap-5">
+            <StepIntro
+              title="How do you want to test this agent?"
+              description={
+                "Egma can test " +
+                String(selectedRetellAgent?.name ?? "this voice agent") +
+                " two ways. Choose the one you want to start with."
+              }
+            />
+            <RadioGroup
+              className="gap-4"
+              aria-label="How to test"
+              value={testModality}
+              onValueChange={(value) =>
+                setTestModality(value as "chat" | "voice")
+              }
+            >
+              <ChoiceCard
+                value="chat"
+                title="Chat"
+                description="Egma tests the agent in text over Retell's playground. No call is placed and nothing is dialled, so a whole suite runs in seconds."
+              />
+              <ChoiceCard
+                value="voice"
+                title="Voice"
+                description="Egma places a call and talks to the agent over the wire, the way its callers do."
+              />
+            </RadioGroup>
+            <InfoBox>
+              Chat and voice land as two connections on one agent, so you can
+              add the other later and compare the same tests across both.
             </InfoBox>
           </div>
         );
@@ -980,11 +1044,18 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
   const primaryLabel =
     step === "goal" || step === "platform" || step === "retell-agent"
       ? "Continue"
-      : step === "retell-key"
-        ? discovering
-          ? "Finding agents…"
-          : "Find agents"
-        : step === "retell-phone"
+      : step === "retell-modality"
+        ? // Chat mints here; voice carries on to choose a number.
+          testModality === "chat"
+          ? saving
+            ? "Setting up…"
+            : "Set up simulation"
+          : "Continue"
+        : step === "retell-key"
+          ? discovering
+            ? "Finding agents…"
+            : "Find agents"
+          : step === "retell-phone"
           ? saving
             ? "Finishing…"
             : goal === "simulation"
@@ -1013,6 +1084,11 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
     (step === "platform" && platform === "") ||
     (step === "retell-key" && !keyReady) ||
     (step === "retell-agent" && selectedModality === null) ||
+    // Nothing chosen yet, or chat chosen before the catalog it mints from
+    // arrived.
+    (step === "retell-modality" &&
+      (testModality === "" ||
+        (testModality === "chat" && catalog === null))) ||
     (step === "retell-phone" &&
       (selectedVoiceRoute === undefined || catalog === null)) ||
     (step === "retell-chat" && goal !== "monitoring" && catalog === null) ||

--- a/apps/web/lib/agent-setup-flow.ts
+++ b/apps/web/lib/agent-setup-flow.ts
@@ -141,6 +141,7 @@ export type AgentSetupStep =
   | "platform"
   | "retell-key"
   | "retell-agent"
+  | "retell-modality"
   | "retell-phone"
   | "retell-chat"
   | "livekit-simulation"
@@ -155,11 +156,21 @@ export function stepAfterPlatform(
   return goal === "monitoring" ? "livekit-monitoring" : "livekit-simulation";
 }
 
-/** Retell reports modality. The person chooses the agent, not the modality. */
+/**
+ * Where a chosen Retell agent leads.
+ *
+ * A chat agent has one door and goes straight to it. A voice agent has two —
+ * chat over the playground, voice over a call — so when the goal is a
+ * simulation the flow asks which before any plumbing: that is the modality
+ * question, and it leads. Monitoring and Both need the voice connection for
+ * production pull, so they keep going to the voice route without the question.
+ */
 export function stepAfterRetellAgent(
   modality: "chat" | "voice",
+  goal: AgentSetupGoal,
 ): AgentSetupStep {
-  return modality === "voice" ? "retell-phone" : "retell-chat";
+  if (modality === "chat") return "retell-chat";
+  return goal === "simulation" ? "retell-modality" : "retell-phone";
 }
 
 /** The single Back graph shared by every rendering of the setup flow. */
@@ -180,7 +191,12 @@ export function previousAgentSetupStep({
       return "platform";
     case "retell-agent":
       return "retell-key";
+    case "retell-modality":
+      return "retell-agent";
     case "retell-phone":
+      // A voice agent reaches the phone step through the modality question when
+      // the goal is a simulation, and straight from the agent otherwise.
+      return goal === "simulation" ? "retell-modality" : "retell-agent";
     case "retell-chat":
       return "retell-agent";
     case "livekit-monitoring":

--- a/apps/web/test/agent-setup-flow.test.ts
+++ b/apps/web/test/agent-setup-flow.test.ts
@@ -8,6 +8,7 @@ import {
   retellCandidatesForPlan,
   stepAfterPlatform,
   stepAfterRetellAgent,
+  type RetellDiscoveredAgent,
 } from "../lib/agent-setup-flow.ts";
 
 const CHAT = {
@@ -55,6 +56,40 @@ const UNROUTED_VOICE = {
   name: "Voice without a number",
   modality: "voice" as const,
   connectionCandidates: [],
+};
+
+/** A voice agent as discovery now describes one: the playground chat door, the
+ * web call, and one routed number — the choice the modality question spans. */
+const VOICE_WITH_ROUTES: RetellDiscoveredAgent = {
+  platformAgentId: "voice_3",
+  name: "Front desk",
+  modality: "voice" as const,
+  connectionCandidates: [
+    {
+      agentPlatform: "retell" as const,
+      connectionType: "retell_playground" as const,
+      accessVariant: "retell_playground.api_key" as const,
+      modality: "chat" as const,
+      productLabel: "Retell playground",
+      config: { retellAgentId: "voice_3" },
+    },
+    {
+      agentPlatform: "retell" as const,
+      connectionType: "retell_web_call" as const,
+      accessVariant: "retell_web_call.api_key" as const,
+      modality: "voice" as const,
+      productLabel: "Retell web call",
+      config: { retellAgentId: "voice_3" },
+    },
+    {
+      agentPlatform: "retell" as const,
+      connectionType: "phone_number" as const,
+      accessVariant: "phone_number.public_e164" as const,
+      modality: "voice" as const,
+      productLabel: "Retell phone",
+      config: { phoneNumber: "+14155550109" },
+    },
+  ],
 };
 
 describe("the goal-first agent setup plan", () => {
@@ -115,6 +150,28 @@ describe("the goal-first agent setup plan", () => {
     );
   });
 
+  it("buckets a voice agent's routes so the modality question spans chat and voice", () => {
+    const simulation = agentSetupPlan("simulation", "retell");
+    const routes = retellCandidatesForPlan(simulation, VOICE_WITH_ROUTES);
+
+    // Every route the plan can save is present: the plan admits both modalities,
+    // so the playground rides through beside the two voice ways.
+    expect(routes.map((one) => one.connectionType)).toEqual([
+      "retell_playground",
+      "retell_web_call",
+      "phone_number",
+    ]);
+    // The chat door is the one chat route; the voice routes are the rest. This
+    // is exactly the split the modality step and the phone step read.
+    const chatRoute = routes.find((one) => one.modality === "chat");
+    const voiceRoutes = routes.filter((one) => one.modality === "voice");
+    expect(chatRoute?.connectionType).toBe("retell_playground");
+    expect(voiceRoutes.map((one) => one.connectionType)).toEqual([
+      "retell_web_call",
+      "phone_number",
+    ]);
+  });
+
   it("defines the approved screen graph without putting screen order in provider payloads", () => {
     expect(stepAfterPlatform("simulation", "retell")).toBe("retell-key");
     expect(stepAfterPlatform("monitoring", "retell")).toBe("retell-key");
@@ -125,8 +182,14 @@ describe("the goal-first agent setup plan", () => {
     expect(stepAfterPlatform("monitoring", "livekit")).toBe(
       "livekit-monitoring",
     );
-    expect(stepAfterRetellAgent("chat")).toBe("retell-chat");
-    expect(stepAfterRetellAgent("voice")).toBe("retell-phone");
+    // A chat agent has one door. A voice agent is asked the modality question
+    // first when the goal is a simulation, and goes straight to the voice route
+    // for Monitoring and Both, which need the voice connection for pull.
+    expect(stepAfterRetellAgent("chat", "simulation")).toBe("retell-chat");
+    expect(stepAfterRetellAgent("chat", "both")).toBe("retell-chat");
+    expect(stepAfterRetellAgent("voice", "simulation")).toBe("retell-modality");
+    expect(stepAfterRetellAgent("voice", "monitoring")).toBe("retell-phone");
+    expect(stepAfterRetellAgent("voice", "both")).toBe("retell-phone");
 
     expect(previousAgentSetupStep({ step: "platform", goal: "both" })).toBe(
       "goal",
@@ -134,6 +197,15 @@ describe("the goal-first agent setup plan", () => {
     expect(
       previousAgentSetupStep({ step: "retell-agent", goal: "both" }),
     ).toBe("retell-key");
+    // The modality question goes back to the agent picker.
+    expect(
+      previousAgentSetupStep({ step: "retell-modality", goal: "simulation" }),
+    ).toBe("retell-agent");
+    // The phone step goes back to the modality question for a simulation, and
+    // to the agent picker for the goals that skip it.
+    expect(
+      previousAgentSetupStep({ step: "retell-phone", goal: "simulation" }),
+    ).toBe("retell-modality");
     expect(
       previousAgentSetupStep({ step: "retell-phone", goal: "both" }),
     ).toBe("retell-agent");

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -253,6 +253,38 @@ const TYPES = {
     {
       agentPlatform: "retell",
       agentPlatformLabel: "Retell",
+      connectionType: "retell_playground",
+      accessVariant: "retell_playground.api_key",
+      accessVariantLabel: "Retell API key",
+      modality: "chat",
+      productLabel: "Retell playground",
+      topology: "hosted-broker",
+      simulatorAdapter: true,
+      fields: [
+        {
+          key: "retellAgentId",
+          label: "Retell agent ID",
+          kind: "text",
+          required: true,
+          help: "The voice agent's own identifier in Retell.",
+          afterCredentials: false,
+        },
+      ],
+      credentialRule: "required",
+      credentialHelp: "Egma seals your key and never shows it again.",
+      credentialFields: [
+        {
+          field: "apiKey",
+          label: "Retell API key",
+          kind: "secret",
+          required: true,
+          help: "Copied from your Retell dashboard.",
+        },
+      ],
+    },
+    {
+      agentPlatform: "retell",
+      agentPlatformLabel: "Retell",
       connectionType: "phone_number",
       accessVariant: "phone_number.public_e164",
       accessVariantLabel: "Public E.164 number",
@@ -1552,6 +1584,139 @@ describe("goal-first agent setup", () => {
         credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
       },
     });
+  });
+
+  /** A voice agent as discovery now describes one, playground door and all. */
+  const voiceWithPlayground = {
+    agents: [
+      {
+        platformAgentId: "agent_voice_1",
+        name: "Front desk",
+        modality: "voice",
+        connectionCandidates: [
+          {
+            agentPlatform: "retell",
+            connectionType: "retell_playground",
+            accessVariant: "retell_playground.api_key",
+            modality: "chat",
+            productLabel: "Retell playground",
+            config: { retellAgentId: "agent_voice_1" },
+          },
+          {
+            agentPlatform: "retell",
+            connectionType: "retell_web_call",
+            accessVariant: "retell_web_call.api_key",
+            modality: "voice",
+            productLabel: "Retell web call",
+            config: { retellAgentId: "agent_voice_1" },
+          },
+          {
+            agentPlatform: "retell",
+            connectionType: "phone_number",
+            accessVariant: "phone_number.public_e164",
+            modality: "voice",
+            productLabel: "Retell phone",
+            config: { phoneNumber: "+14155550100" },
+          },
+        ],
+      },
+    ],
+  };
+
+  it("leads a Simulation voice agent with the modality question, and chat mints the playground", async () => {
+    sheetAnswers({
+      "/v1/agents:discover": { status: 200, body: voiceWithPlayground },
+      "/v1/agents": [
+        { status: 200, body: { agents: [], nextPageToken: null } },
+        {
+          status: 201,
+          body: {
+            result: "created",
+            agent: { ...AGENT, name: "Front desk", platformAgentId: "agent_voice_1" },
+            connection: { ...CONNECTION, connectionType: "retell_playground" },
+          },
+        },
+        { status: 200, body: { agents: [LISTED_AGENT], nextPageToken: null } },
+      ],
+    });
+    render(<RegisterAgentPage />);
+    await choose("Run simulations", "Retell");
+    await findRetellAgents();
+    await pickRetellAgent("Front desk");
+
+    // The modality question leads: chat or voice, before any plumbing. A phone
+    // picker is not on screen yet.
+    expect(
+      await screen.findByRole("heading", {
+        name: "How do you want to test this agent?",
+      }),
+    ).toBeDefined();
+    expect(screen.queryByLabelText("Phone number*")).toBeNull();
+
+    fireEvent.click(screen.getByRole("radio", { name: /^Chat/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Set up simulation" }));
+
+    await waitFor(() => {
+      expect(
+        sent.some((call) => call.url === "/v1/agents?projectId=prj_1"),
+      ).toBe(true);
+    });
+    const registration = sent.find(
+      (call) => call.url === "/v1/agents?projectId=prj_1",
+    );
+    // Choosing text mints the playground with the same key, against the voice
+    // agent it conducts in text.
+    expect(registration?.body).toEqual({
+      name: "Front desk",
+      agentPlatform: "retell",
+      connection: {
+        agentPlatform: "retell",
+        connectionType: "retell_playground",
+        accessVariant: "retell_playground.api_key",
+        modality: "chat",
+        config: { retellAgentId: "agent_voice_1" },
+        platformAgentId: "agent_voice_1",
+        credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+      },
+    });
+  });
+
+  it("takes a Simulation voice agent to the phone picker when voice is chosen", async () => {
+    sheetAnswers({
+      "/v1/agents:discover": { status: 200, body: voiceWithPlayground },
+      "/v1/agents": [
+        { status: 200, body: { agents: [], nextPageToken: null } },
+        {
+          status: 201,
+          body: {
+            result: "created",
+            agent: { ...AGENT, name: "Front desk", platformAgentId: "agent_voice_1" },
+            connection: MEASURED_CONNECTION,
+          },
+        },
+        { status: 200, body: { agents: [LISTED_AGENT], nextPageToken: null } },
+      ],
+    });
+    render(<RegisterAgentPage />);
+    await choose("Run simulations", "Retell");
+    await findRetellAgents();
+    await pickRetellAgent("Front desk");
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "How do you want to test this agent?",
+      }),
+    ).toBeDefined();
+    fireEvent.click(screen.getByRole("radio", { name: /^Voice/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    // The voice route: the phone picker, which the modality question led into.
+    const numbers = (await screen.findByLabelText(
+      "Phone number*",
+    )) as HTMLSelectElement;
+    expect([...numbers.options].map((one) => one.value)).toContain(
+      "phone:+14155550100",
+    );
   });
 
   it("uses one Retell key for Both and stores the selected voice route", async () => {

--- a/packages/db/src/access/agents.ts
+++ b/packages/db/src/access/agents.ts
@@ -27,6 +27,7 @@ import {
 import { monitoringState } from "../schema/production.ts";
 import { sealCredentials } from "../sealing.ts";
 import {
+  connectionTypesSharingReuseKey,
   credentialRedirectingConfigKey,
   credentialRuleOf,
   descriptorOf,
@@ -980,29 +981,42 @@ export type Registration = {
  * failure. Minting a second identity for one vendor agent splits a team's
  * results history in half, which is the one thing that must not happen quietly.
  *
- * So the connection type's reuse key decides (`connection-registry.ts`), and a living
- * connection in the project naming the same vendor agent decides the outcome:
+ * So the connection type's reuse key decides (`connection-registry.ts`), and a
+ * living connection in the project naming the same vendor agent — **through any
+ * door of the same reuse family** — decides the outcome:
  *
- * - **same modality** → that agent and that connection answer, with the
- *   supplied credential replacing the stored one **whole**. Rotation never
- *   asks for the old secret and never merges into it, so plaintext has no
- *   reason to travel back out. `reused`.
- * - **a different modality** → the same agent gains a new connection, because
- *   a chat endpoint and a voice endpoint on one vendor agent are two ways to
- *   reach one thing. `connection_added`.
+ * - **the same door** (same connection type and access variant) → that agent
+ *   and that connection answer, with the supplied credential replacing the
+ *   stored one **whole**. Rotation never asks for the old secret and never
+ *   merges into it, so plaintext has no reason to travel back out. `reused`.
+ * - **a different door on the same vendor agent** → the same agent gains a new
+ *   connection, because a chat lane and a voice lane on one Retell agent are
+ *   two ways to reach one thing. This is the whole of one-agent-two-connections
+ *   on **every** surface: the CLI's `connect`, and the web's fresh connect flow
+ *   which has no name-clash fallback of its own. `connection_added`.
  * - **no match, or a kind with no reuse key at all** → both rows, exactly as
  *   `createAgent` writes them. `created`.
+ *
+ * **The reuse family is the types that share a reuse key**, and today that is
+ * exactly Retell's three vendor-id lanes — the chat API, the playground, and
+ * the web call, all keyed on `retellAgentId`. A phone number and a LiveKit room
+ * carry no reuse key and so are in no family: a phone number is where Egma
+ * dials, not who answers, and two agents may share one. So this widening
+ * touches only the three lanes that already mean "one Retell agent = one Egma
+ * agent", and no other platform's behaviour moves.
  *
  * The reused and extended paths answer the agent as it stands and leave its
  * name alone: the registration named an identity that already
  * exists, and quietly renaming somebody's agent because a second machine typed
  * it differently would be a change nobody asked for.
  *
- * **Racing registrations settle to one agent.** Two identical creates arriving
- * together would both find nothing, both insert, and one would lose to the
- * name index — an error where a retry-safe path must answer. The transaction
- * takes an advisory lock on the vendor agent first, so the second one reads
- * the first one's committed work and reuses it.
+ * **Racing registrations settle to one agent.** Two creates of the same vendor
+ * agent arriving together — even through two different doors of its family —
+ * would both find nothing, both insert, and one would lose to the name index,
+ * an error where a retry-safe path must answer. The transaction takes an
+ * advisory lock on the vendor agent under its reuse key first, so every door of
+ * one agent waits behind one lock and the second reads the first's committed
+ * work.
  */
 export async function registerAgent(
   auth: AuthContext,
@@ -1047,9 +1061,16 @@ export async function registerAgent(
     return db().transaction(bothRows);
   }
 
-  // What the lock is taken on: this one vendor agent, in this one project, of
-  // this one customer. Nothing else waits behind it.
-  const racing = `${auth.organizationId}:${projectId}:${inline.connectionType}:${vendorAgent}`;
+  // Every connection type that reuses on this same key — the vendor-id family
+  // this registration belongs to. A living connection through any of these
+  // doors on the same vendor agent is the same Egma agent.
+  const family = connectionTypesSharingReuseKey(reuseKey);
+
+  // What the lock is taken on: this one vendor agent under its reuse key, in
+  // this one project, of this one customer. Every door of one agent shares it,
+  // so two doors racing on one agent settle to one rather than one losing to
+  // the name index. Nothing else waits behind it.
+  const racing = `${auth.organizationId}:${projectId}:${reuseKey}:${vendorAgent}`;
 
   return db().transaction(async (tx): Promise<Registration> => {
     // Taken before anything is read, and let go when the transaction ends.
@@ -1070,8 +1091,7 @@ export async function registerAgent(
           connection,
           and(
             eq(connection.projectId, projectId),
-            eq(connection.connectionType, inline.connectionType),
-            eq(connection.accessVariant, inline.accessVariant),
+            inArray(connection.connectionType, [...family]),
             sql`${connection.config}->>${reuseKey} = ${vendorAgent}`,
             connectionNotArchived,
             notArchived,
@@ -1080,11 +1100,18 @@ export async function registerAgent(
       )
       .orderBy(asc(connection.id));
 
-    const sameModality = living.find(
-      (row) => row.reached.modality === inline.modality,
+    // The exact same door — same connection type and access variant — is a
+    // re-registration of this connection, and it rotates the key. A door that
+    // only shares the modality is a different lane on the same agent and must
+    // not be rotated onto: a playground and a chat API are both chat, and one
+    // is not the other.
+    const sameDoor = living.find(
+      (row) =>
+        row.reached.connectionType === inline.connectionType &&
+        row.reached.accessVariant === inline.accessVariant,
     );
 
-    if (sameModality !== undefined) {
+    if (sameDoor !== undefined) {
       const [rotated] = await tx
         .update(connection)
         .set({
@@ -1095,7 +1122,7 @@ export async function registerAgent(
           credentialsHint: inline.credentialsHint,
           updatedAt: new Date(),
         })
-        .where(eq(connection.id, sameModality.reached.id))
+        .where(eq(connection.id, sameDoor.reached.id))
         .returning(CONNECTION_COLUMNS);
 
       if (rotated === undefined) {
@@ -1103,16 +1130,16 @@ export async function registerAgent(
       }
       return {
         result: "reused",
-        agent: agentFromRow(sameModality.identity),
+        agent: agentFromRow(sameDoor.identity),
         connection: connectionFromRow(
           rotated,
-          sameModality.identity.agentPlatform as AgentPlatform,
+          sameDoor.identity.agentPlatform as AgentPlatform,
         ),
       };
     }
 
-    // The same vendor agent reached a different way. Oldest first, so which
-    // agent gains the connection is the same answer every time.
+    // The same vendor agent reached through a different door. Oldest first, so
+    // which agent gains the connection is the same answer every time.
     const known = living[0];
     if (known !== undefined) {
       const home = agentFromRow(known.identity);

--- a/packages/db/src/access/connection-registry.ts
+++ b/packages/db/src/access/connection-registry.ts
@@ -1292,6 +1292,31 @@ export function conductableConnectionTypes(): readonly ConnectionType[] {
 }
 
 /**
+ * Every connection type that reuses on the same key as this one — the family
+ * that means one underlying platform agent.
+ *
+ * A reuse key is a config field that names the vendor's own agent, and two
+ * connection types that carry the same-named field for the same value reach the
+ * **same** platform agent: Retell's chat API, its playground, and its web call
+ * all key on `retellAgentId`, so a text lane and a voice lane on one Retell
+ * agent are two ways to reach one thing rather than two agents. Registering a
+ * second one therefore lands on the first's Egma agent, whichever door it came
+ * through. A type with no reuse key — a phone number, a LiveKit room — is in no
+ * family and answers an empty list: a number is where Egma dials, not who
+ * answers, and two agents may share one.
+ *
+ * The set always includes the type asked about when it has a reuse key, so a
+ * caller may treat it as "this connection's whole reuse family".
+ */
+export function connectionTypesSharingReuseKey(
+  reuseKey: string,
+): readonly ConnectionType[] {
+  return CONNECTION_TYPES.filter(
+    (connectionType) => CONNECTION_REGISTRY[connectionType].reuseKey === reuseKey,
+  );
+}
+
+/**
  * Whether this exact stored connection can be handed to a simulator.
  *
  * The modality is checked here as well as at write time. Dispatch trusts only

--- a/packages/db/test/agents-register.test.ts
+++ b/packages/db/test/agents-register.test.ts
@@ -51,14 +51,17 @@ function registration(overrides: {
   readonly modality?: "chat" | "voice";
   readonly retellAgentId?: string;
   readonly apiKey?: string;
+  /** The Retell text lane this registration takes, chat API by default. */
+  readonly lane?: "retell_chat_api" | "retell_playground";
 }): NewAgent {
+  const lane = overrides.lane ?? "retell_chat_api";
   return {
     name: overrides.name ?? "Front desk",
     agentPlatform: "retell",
     connection: {
       agentPlatform: "retell",
-      connectionType: "retell_chat_api",
-      accessVariant: "retell_chat_api.api_key",
+      connectionType: lane,
+      accessVariant: `${lane}.api_key`,
       modality: overrides.modality ?? "chat",
       config: { retellAgentId: overrides.retellAgentId ?? "agent_in_retell_1" },
       credentials: { apiKey: overrides.apiKey ?? "retell-secret-A1B2C3D4WXYZ" },
@@ -108,6 +111,45 @@ describe("two identical registrations arriving together", () => {
       [acme.project, "Racing"],
     );
     expect(rows[0]?.count).toBe("1");
+  });
+
+  it("settle to one for the playground lane too, since it carries the reuse key", async () => {
+    // The playground shares the reuse key the chat API carries — the vendor
+    // agent id — so the same advisory lock and committed read behind it settle
+    // a racing playground registration to one agent, not a twin.
+    const racing = await Promise.all(
+      Array.from({ length: 4 }, () =>
+        registerAgent(
+          actingIn(acme.project),
+          registration({
+            name: "Racing playground",
+            lane: "retell_playground",
+            retellAgentId: "agent_playground_race",
+          }),
+        ),
+      ),
+    );
+
+    expect(new Set(racing.map((one) => one.agent.id)).size).toBe(1);
+    expect(new Set(racing.map((one) => one.connection?.id)).size).toBe(1);
+    const results = racing.map((one) => one.result);
+    expect(results.filter((one) => one === "created")).toHaveLength(1);
+    expect(results.filter((one) => one === "reused")).toHaveLength(3);
+
+    // One agent, and the one connection is the playground.
+    const { rows } = await database.sql<{ count: string }>(
+      "select count(*) as count from agent where project_id = $1 and name = $2",
+      [acme.project, "Racing playground"],
+    );
+    expect(rows[0]?.count).toBe("1");
+    const connections = await listConnections(
+      actingIn(acme.project),
+      racing[0]!.agent.id,
+    );
+    expect(connections).toBeDefined();
+    expect((connections ?? []).map((one) => one.connectionType)).toEqual([
+      "retell_playground",
+    ]);
   });
 });
 

--- a/packages/db/test/agents-register.test.ts
+++ b/packages/db/test/agents-register.test.ts
@@ -51,8 +51,8 @@ function registration(overrides: {
   readonly modality?: "chat" | "voice";
   readonly retellAgentId?: string;
   readonly apiKey?: string;
-  /** The Retell text lane this registration takes, chat API by default. */
-  readonly lane?: "retell_chat_api" | "retell_playground";
+  /** Which Retell vendor-id door this registration takes, chat API by default. */
+  readonly lane?: "retell_chat_api" | "retell_playground" | "retell_web_call";
 }): NewAgent {
   const lane = overrides.lane ?? "retell_chat_api";
   return {
@@ -150,6 +150,108 @@ describe("two identical registrations arriving together", () => {
     expect((connections ?? []).map((one) => one.connectionType)).toEqual([
       "retell_playground",
     ]);
+  });
+});
+
+describe("the same Retell agent through two doors of its reuse family", () => {
+  /**
+   * One Retell agent's playground (chat) and its web call (voice) both key on
+   * the vendor agent id, so registering the second lands on the first's Egma
+   * agent — a connection added, never a twin — whichever order they arrive in.
+   * This is the whole of one-agent-two-connections on the **web's fresh connect
+   * flow**, which submits a plain registration with no name-clash fallback of
+   * its own and so relies entirely on the server settling it here.
+   */
+  async function twoDoors(
+    label: string,
+    vendor: string,
+    firstLane: "retell_playground" | "retell_web_call",
+    secondLane: "retell_playground" | "retell_web_call",
+  ): Promise<void> {
+    const modalityOf = (lane: string) =>
+      lane === "retell_web_call" ? ("voice" as const) : ("chat" as const);
+
+    const first = await registerAgent(
+      actingIn(acme.project),
+      registration({
+        name: label,
+        lane: firstLane,
+        modality: modalityOf(firstLane),
+        retellAgentId: vendor,
+      }),
+    );
+    const second = await registerAgent(
+      actingIn(acme.project),
+      registration({
+        name: label,
+        lane: secondLane,
+        modality: modalityOf(secondLane),
+        retellAgentId: vendor,
+      }),
+    );
+
+    expect(first.result).toBe("created");
+    // The second door is added to the first door's agent, not a new one.
+    expect(second.result).toBe("connection_added");
+    expect(second.agent.id).toBe(first.agent.id);
+
+    const connections = await listConnections(actingIn(acme.project), first.agent.id);
+    expect(connections).toBeDefined();
+    expect((connections ?? []).map((one) => one.connectionType).sort()).toEqual(
+      [firstLane, secondLane].sort(),
+    );
+
+    // Exactly one Egma agent carries this label; there is no twin.
+    const { rows } = await database.sql<{ count: string }>(
+      "select count(*) as count from agent where project_id = $1 and name = $2",
+      [acme.project, label],
+    );
+    expect(rows[0]?.count).toBe("1");
+  }
+
+  it("attaches the web call after the playground, on one agent", async () => {
+    await twoDoors("Two doors A", "vendor_two_doors_a", "retell_playground", "retell_web_call");
+  });
+
+  it("attaches the playground after the web call, on one agent", async () => {
+    await twoDoors("Two doors B", "vendor_two_doors_b", "retell_web_call", "retell_playground");
+  });
+
+  it("settles a race across two doors of one agent to a single agent", async () => {
+    // The lock is on the vendor agent under its reuse key, not on the door, so
+    // a playground and a web call for one agent racing on different doors still
+    // wait behind one lock and settle to one agent — one created, one added.
+    const vendor = "vendor_two_doors_race";
+    const racing = await Promise.all([
+      registerAgent(
+        actingIn(acme.project),
+        registration({
+          name: "Two doors race",
+          lane: "retell_playground",
+          modality: "chat",
+          retellAgentId: vendor,
+        }),
+      ),
+      registerAgent(
+        actingIn(acme.project),
+        registration({
+          name: "Two doors race",
+          lane: "retell_web_call",
+          modality: "voice",
+          retellAgentId: vendor,
+        }),
+      ),
+    ]);
+
+    expect(new Set(racing.map((one) => one.agent.id)).size).toBe(1);
+    const results = racing.map((one) => one.result).sort();
+    expect(results).toEqual(["connection_added", "created"]);
+
+    const { rows } = await database.sql<{ count: string }>(
+      "select count(*) as count from agent where project_id = $1 and name = $2",
+      [acme.project, "Two doors race"],
+    );
+    expect(rows[0]?.count).toBe("1");
   });
 });
 

--- a/packages/platform-api/openapi/platform-api.openapi.json
+++ b/packages/platform-api/openapi/platform-api.openapi.json
@@ -118,6 +118,7 @@
                                   "type": "string",
                                   "enum": [
                                     "retell_chat_api",
+                                    "retell_playground",
                                     "retell_web_call",
                                     "phone_number"
                                   ]
@@ -126,6 +127,7 @@
                                   "type": "string",
                                   "enum": [
                                     "retell_chat_api.api_key",
+                                    "retell_playground.api_key",
                                     "retell_web_call.api_key",
                                     "phone_number.public_e164"
                                   ]

--- a/packages/platform-api/src/contract/operations/agents.ts
+++ b/packages/platform-api/src/contract/operations/agents.ts
@@ -334,6 +334,7 @@ export const agentOperations = {
                       type: "string",
                       enum: [
                         "retell_chat_api",
+                        "retell_playground",
                         "retell_web_call",
                         "phone_number",
                       ],
@@ -342,6 +343,7 @@ export const agentOperations = {
                       type: "string",
                       enum: [
                         "retell_chat_api.api_key",
+                        "retell_playground.api_key",
                         "retell_web_call.api_key",
                         "phone_number.public_e164",
                       ],

--- a/packages/platform-api/src/generated/types.gen.ts
+++ b/packages/platform-api/src/generated/types.gen.ts
@@ -86,8 +86,8 @@ export type DiscoverAgentsResponses = {
             modality: 'chat' | 'voice';
             connectionCandidates: Array<{
                 agentPlatform: 'retell';
-                connectionType: 'retell_chat_api' | 'retell_web_call' | 'phone_number';
-                accessVariant: 'retell_chat_api.api_key' | 'retell_web_call.api_key' | 'phone_number.public_e164';
+                connectionType: 'retell_chat_api' | 'retell_playground' | 'retell_web_call' | 'phone_number';
+                accessVariant: 'retell_chat_api.api_key' | 'retell_playground.api_key' | 'retell_web_call.api_key' | 'phone_number.public_e164';
                 modality: 'chat' | 'voice';
                 productLabel: string;
                 config: {

--- a/packages/retell/src/versions.ts
+++ b/packages/retell/src/versions.ts
@@ -94,7 +94,16 @@ export type WroteEngineTools = { readonly kind: "written" } | RetellFailure;
 /** What a version reference may be: a number, `latest`, or a tag's name. */
 export type VersionReference = number | string;
 
-const CUSTOM_LLM_HAS_NO_CONFIGURATION =
+/**
+ * Why the playground cannot reach a custom-LLM agent, in Retell's own absence.
+ *
+ * Exported to the package because two flows now say it — the run-start read
+ * that refuses a run over a playground connection whose engine turned out to
+ * be a custom LLM, and the connect flows that refuse the same engine at the
+ * door, at the moment they read it. One sentence in one place, so the two
+ * cannot drift into two ideas of why the same agent is out of reach.
+ */
+export const CUSTOM_LLM_HAS_NO_CONFIGURATION =
   "this agent's response engine is a custom LLM, so Retell holds none of its " +
   "words or tools: they run in your own service, behind the websocket URL " +
   "the agent points at.";


### PR DESCRIPTION
Ticket 03 of the retell-playground effort (planning: `.scratch/retell-playground/issues/03-the-flows-ask-how-you-test.md`), the last ticket of the retell-lanes integration. Lands on the integration branch, not main.

## What this carries

- **Both connect flows lead with the modality question** for a Retell voice agent. The CLI widens its existing `chooseReach` step to offer text or voice (placement found in the flow's state machine, not invented); the web adds a `retell-modality` step between the agent step and the phone step, reached for a voice agent. Choosing text mints the `retell_playground` connection with the same Retell API key. The CLI's voice-requires-a-phone-line refusal — the one whose comment named "Retell Agent Playground Completion" as its missing piece — is retired with its tests, and there is no instructions surface (there is nothing to instruct). UI reuses the design system verbatim (StepIntro/RadioGroup/ChoiceCard/InfoBox — 0px radius, Ember-Wash selection, radio semantics).
- **The custom-LLM refusal surfaces in both flows** at the moment the engine is read, from one shared reason constant.
- **One agent, two connections**: registering the same Retell agent again with the other modality attaches to the existing egma agent — either order (text after phone, phone after text), either surface — never a twin. Within a connection type the db reuse key + an advisory lock settle racing registrations to one; across types (text↔phone) the CLI's name-clash fallback lands on the one known agent.
- **The live playground suite** — one documented command that conducts a genuine chat simulation against a real Retell voice agent (a mocked answer and a transition on the record, no audio anywhere), env-gated, zero network when skipped, needs stated where the command is, banks proof to a git-ignored dir. Never executed by agents.

## Review

Independently reviewed: **ship as-is, no blockers.** All five acceptance boxes confirmed with the named tests. One should-fix is a product sign-off, not a code fix — see below. The full `pnpm typecheck` gate passes end to end (it caught a test-only type error that `pnpm build` alone would miss); the platform-api change is two enum values widened inside `discoverAgents` (no new operation, the 77-op guards untouched), regenerated not hand-edited.

**For the developer to confirm (not blocking this ticket):**
1. The web modality question is scoped to `goal === "simulation"` (Monitoring and Both go straight to the voice route, which their production pull needs; a Both developer adds chat later as a second connection). The CLI, which has no goal, always asks. The reviewer judged this correct for Monitoring and defensible for Both — confirm the asymmetry is intended.
2. **Known pre-existing bug, surfaced by this epic, to fix before main** (out of scope for this ticket — it lives on the `retell_web_call` surface): the web "Choose a phone number" step renders the `retell_web_call` discovery candidate as a blank, default-selected `<option>` (it has no `phoneNumber`), so a developer who hits Continue can get a web-call connection unknowingly — a different unit from a phone simulation. Fix options: filter that picker to `phone_number` candidates, or present the web call as its own labelled voice choice. This is a product decision about how `retell_web_call` registers in the web flow.

## Tests

CLI connect 35, web agent-setup-flow 5 + agents-pages 47, api agents + playground-lane 100, db agents-register 6 (racing settles to one), simulator acceptance (chat sim of a voice agent) + live-skip — all green; `pnpm typecheck` exit 0. CI's cheap lane runs here; the full proof runs at the main gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABEAtGrwfsBnCBx2RvsRm6

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABEAtGrwfsBnCBx2RvsRm6)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790522428&installation_model_id=431960&pr_number=262&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F262&signature=00d9d0a86ea7d309ba069ebe761e3f0ab511aa61236e2d23d3007fec57d6bbd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds text-playground and voice choices when connecting Retell agents and centralizes cross-type registration reuse so both connections share one Egma agent.
- Adds Retell playground candidates and modality selection to the web and CLI flows.
- Reuses an existing agent across Retell vendor-ID connection types under a shared advisory lock.
- Adds focused coverage for both registration orders, concurrent registration, custom-LLM refusal, and the live playground path.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported cross-type reuse issue is resolved by project-scoped vendor-agent reuse and shared locking, with both connection orders covered.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/db/src/access/agents.ts | Cross-type Retell registrations now reuse the matching project agent under a vendor-agent advisory lock, resolving the previously reported identity split. |
| packages/db/src/access/connection-registry.ts | Defines the Retell connection family sharing the retellAgentId reuse key while correctly excluding phone-number connections. |
| apps/web/app/projects/[projectId]/agents/connect-sheet.tsx | Adds the Retell modality step and submits the selected candidate with matching platform and candidate agent identities. |
| apps/cli/src/retell/connect.ts | Supports playground text connections for voice agents and recognizes the expanded Retell connection family during name-clash reuse. |
| apps/api/src/providers/retell.ts | Exposes playground candidates for voice agents while preserving provider-side confirmation of agent modality and identity. |
| packages/db/test/agents-register.test.ts | Covers cross-type reuse in both orders and concurrent registration settling on one Egma agent. |

<sub>Reviews (2): Last reviewed commit: ["fix(db): attach the other Retell modalit..."](https://github.com/egma-ai/egma/commit/4aeae8a35eb5d749627070c855f632faf9e744ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57939394)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Retell integration](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/retell-integration.md)
- Knowledge Base — [Database persistence](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/database-persistence.md)
- Knowledge Base — [Web application](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/web-application.md)
- Knowledge Base — [CLI operations](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/cli-operations.md)
</details>


<!-- /greptile_comment -->