### PR TITLE
Revert: back out the gray chrome change (#270)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,7 +6,7 @@ The orange-red palette and the Egma logo are locked. Change them only with expli
 
 The styling architecture changed on 2026-08-19 with that approval. **Styling architecture** below is the current truth.
 
-The product's shape changed on 2026-08-23 with that approval, from the Paper file "Egma — Design system and product UI". Five rules moved, and each is marked where it is written: **one radius, and it is 0px**; Egma identity returned to the signed-in sidebar; the **primary action is the wash button**, not a Deep Ember block; **`system-ui` leads the font stack**; and the **side sheet** is where one record is created, read and edited. On 2026-08-24, the approved Paper refinement replaced the full sidebar wordmark with the Egma mark beside organization context and made the account avatar square. The same session's agents-and-tests rework added three rules and changed one: the `*` and `[optional]` label grammar, the Ember top-line on a segmented control's chosen segment, square status markers, and — the one change — **quiet text-field focus**. On 2026-08-26, the run-flow refinement removed decorative markers from settled run states, reserved a spinner for active work, and moved grader verdict meaning into explicit `Result · Passed` or `Result · Failed` text. On 2026-08-28, the approved Paper page "09 — Gray chrome variations" moved three more, in variation V1b: **gray is the chrome and white is the work**, so the sidebar and the page title bar take the soft gray `--chrome` fill and the content area is pure paper; **a table column header earns its rank from weight and tracking**, not from a fill; and **dark theme separates by surface**, not by a hairline alone. The palette and the logo's own treatment rules did not move.
+The product's shape changed on 2026-08-23 with that approval, from the Paper file "Egma — Design system and product UI". Five rules moved, and each is marked where it is written: **one radius, and it is 0px**; Egma identity returned to the signed-in sidebar; the **primary action is the wash button**, not a Deep Ember block; **`system-ui` leads the font stack**; and the **side sheet** is where one record is created, read and edited. On 2026-08-24, the approved Paper refinement replaced the full sidebar wordmark with the Egma mark beside organization context and made the account avatar square. The same session's agents-and-tests rework added three rules and changed one: the `*` and `[optional]` label grammar, the Ember top-line on a segmented control's chosen segment, square status markers, and — the one change — **quiet text-field focus**. On 2026-08-26, the run-flow refinement removed decorative markers from settled run states, reserved a spinner for active work, and moved grader verdict meaning into explicit `Result · Passed` or `Result · Failed` text. The palette and the logo's own treatment rules did not move.
 
 ## Product context
 
@@ -80,8 +80,8 @@ Egma uses neutral paper surfaces and one orange-red brand family. Routine produc
 
 | Token | Value | Use |
 | --- | --- | --- |
-| Neutral Paper | 6% Graphite mixed with Pure Paper | Application chrome: the sidebar, the page title bar, and the Settings rail |
-| Pure Paper | `#ffffff` | The content area, and the raised surfaces, menus, dialogs, and form groups on it |
+| Neutral Paper | 3% Graphite mixed with Pure Paper | Application canvas |
+| Pure Paper | `#ffffff` | Raised surfaces, menus, dialogs, and form groups |
 | Midnight Ink | `#1f1f1f` | Primary text and dark application surfaces |
 | Carbon | `#000000` | Maximum contrast and rare dark application surfaces |
 | Graphite | `#3c3c3c` | Secondary text and stronger neutral states |
@@ -93,9 +93,9 @@ Egma uses neutral paper surfaces and one orange-red brand family. Routine produc
 
 ### Color rules
 
-- **Gray is the chrome, and white is the work.** The application chrome is Neutral Paper, and the token for that fill is `--chrome`. Chrome is the frame a person moves in: the sidebar, the page title bar, the drawer and top bar those two become on a narrow screen, and the Settings rail beside a page. The content area is Pure Paper. An access page has no sidebar and no title bar to carry the frame, so its whole ground is chrome and the panel centred on it is the work. Going down a page a reader crosses three surfaces and not four: the chrome, the content, and the hairlines that draw structure inside the content. A table panel, a form group and an empty-state card stay Pure Paper on Pure Paper, so each one is drawn by its hairline alone. (Developer decision, 2026-08-28, from the approved Paper page `09 — Gray chrome variations`, variation V1b; the developer named Browserbase as the reference. This replaces the rule that made the canvas the one gray region and the sidebar a quiet paper region.)
+- The application canvas is Neutral Paper.
 - Ordinary borders use a neutral mix of Graphite and Pure Paper.
-- Quiet hover, read-only, progress, and supporting surfaces use a neutral Graphite-and-Paper mix. **On the chrome, that quiet step goes up to Pure Paper instead.** The chrome fill and the quiet mix are the same value in light theme, so a control standing on the chrome moves towards the work surface rather than into the fill it already sits on. The two are still separate facts and they part company in dark theme, where the chrome is `#0f0f0e` and the quiet step is `#262624`. (Developer decision, 2026-08-28, from the approved Paper page `09 — Gray chrome variations`, variation V1b.)
+- Quiet hover, read-only, progress, and supporting surfaces use a neutral Graphite-and-Paper mix.
 - Ember is the main brand signal. Use it for focus, icons, marks, and narrow active edges.
 - Deep Ember is the primary action's text on Ember Wash. Its contrast on that fill is above 7:1. (Developer decision, 2026-08-23: the filled Deep Ember button with white text is retired.)
 - Ember Wash is the primary action's fill, and the surface for selected, current, open, cited, or active-attention states.
@@ -123,8 +123,6 @@ Egma uses neutral paper surfaces and one orange-red brand family. Routine produc
 ### Dark theme
 
 - Dark theme uses neutral dark surfaces and the same Ember focus and action family, lightened where a dark surface needs it. The primary action's text is Ember pulled towards paper rather than Deep Ember: Deep Ember on the dark Ember Wash is 2.69:1 and fails AA, and the lighter step is 5.26:1. (Developer decision, 2026-08-23.)
-- **Dark theme separates by surface, not by hairline alone.** The chrome is `#0f0f0e` and the content surface is `#1e1e1c`: about fifteen steps apart out of 255, in the darkest range where the eye separates best. The hairline lifts with them to `#34342f`, and so do the two quiet text colours — secondary from `#a3a39b` to `#b6b6ae`, and tertiary from `#82827b` to `#94948c` — so a quiet label on the lighter content surface stays legible. The tertiary colour is the one that had to move: it was 4.46:1 on the old surface, which is under AA, and it is 5.47:1 on the new one. The pair before this was `#151514` under `#1b1b1a`, six steps apart at 1.06:1, behind a `#30302d` hairline at about 1.3:1 against the surface it divided, and the whole product read as one flat black. (Developer decision, 2026-08-28, from the approved Paper page `09 — Gray chrome variations`, variation V1b.)
-- **What is raised carries its own fill in dark theme.** A menu, a dialog and a side sheet read `--raised`, which is the content surface with 6% Pure Paper mixed in. In light theme `--raised` is Pure Paper and the shared orange-brown shadow does the separating; on a dark page that shadow resolves lighter than the page it falls on, so it is a faint halo rather than a shadow, and the rule above forbids leaving the hairline to do the work alone. A flush panel — a table, a form group, an ordinary card — does not take this fill. It carries a hairline and nothing else, in both themes. (Read off `tailwind-theme.css`, 2026-08-28. It is the dark half of the surface rule above rather than a rule of its own.)
 - Dense evidence may use a dark contained surface in either theme.
 - Every shared component must support light and dark themes.
 - Verify text, borders, focus, status, overlays, and disabled states in both themes.
@@ -150,8 +148,7 @@ Use `system-ui` first, then Helvetica, Arial, and the system sans-serif fallback
 Rules:
 
 - Hierarchy comes from size, space, and restrained use of weight 500.
-- The micro label is the 12px step, and it stays reserved for the two letter-spaced uppercase labels the sidebar carries — `Project` over the project name, and the role under the account's email. Nothing else uses that size. The scale still starts at 14px.
-- **The 0.08em label tracking is not reserved with it.** A table column header wears the same tracking at the 14px caption step, in sentence case and at weight 500. The size and the tracking are two facts: 12px belongs to those two sidebar labels alone, and the tracking is a way to give a label rank without a fill. (Developer decision, 2026-08-28, from the approved Paper page `09 — Gray chrome variations`, variation V1b. This is the first use of the label tracking outside the sidebar, and it does not move the micro label's own rule above.)
+- The micro label is for the two letter-spaced uppercase labels the sidebar carries — `Project` over the project name, and the role under the account's email. Nothing else uses it. The scale still starts at 14px.
 - Do not use weights 600 or 700.
 - Product tables, forms, and navigation use the 14px and 16px steps.
 - Headings carry no size of their own. Every heading takes its size from a class, because the browser's own heading sizes are not on this scale.
@@ -193,7 +190,6 @@ Most structure comes from contrast and borders.
 - Menus, side sheets, and dialogs use one shared orange-brown shadow: the two-layer stack below. There is no separate shorter menu shadow; the boards draw all three raised surfaces the same way. (Read off the boards, 2026-08-23.)
 - Large showcase panels may use the full orange-brown shadow stack.
 - Tables, sidebars, topbars, inputs, search boxes, and ordinary cards do not float. They carry a hairline and nothing else.
-- The chrome and the content area are told apart by their two surfaces and by the hairline between them. A surface step is contrast, not elevation: the sidebar and the page title bar stay flat and still carry a hairline and no shadow. A table column header takes no fill for the same reason — a filled band inside a panel makes a surface where no new layer starts. What is truly raised keeps the shadow, and in dark theme it also takes the `--raised` fill named under **Dark theme**, because a warm shadow on a dark page does not separate anything. (Developer decision, 2026-08-28, from the approved Paper page `09 — Gray chrome variations`, variation V1b.)
 - Do not use cool gray shadows.
 
 The shared shadow, worn by every menu, sheet, and dialog:
@@ -216,14 +212,14 @@ rgba(122, 49, 23, 0.02) -130px 256px 115px 0
 
 ### Shell
 
-- Neutral Paper is the application chrome: the sidebar, the page title bar across the top of the content, and the drawer and top bar those two become under the layout breakpoint. The content area itself is Pure Paper.
-- The sidebar is a chrome region, separated from the content by a neutral hairline.
+- Neutral Paper is the application canvas.
+- The sidebar is a quiet paper region separated by a neutral hairline.
 - The organization control is the topmost thing in the sidebar. It holds the Egma mark, organization name and paired arrows in a bar of its own.
 - The project selector is a separate control under the organization bar and keeps the word `Project` visible.
 - Navigation uses text and small line icons.
 - The active item uses Ember Wash and a small Ember mark on its leading edge. Its icon follows the row's text colour; the mark is the brand signal and there is only one.
 - The account control stays at the bottom.
-- Every page has a title bar of its own, on the chrome surface, the same height as the sidebar's organization bar, holding the page title alone. A purpose statement, where a form or settings page needs one, is the first quiet line of the page body; list screens carry none (read off the boards, 2026-08-23). Page actions are not in that bar.
+- Every page has a title bar of its own, the same height as the wordmark bar, holding the page title alone. A purpose statement, where a form or settings page needs one, is the first quiet line of the page body; list screens carry none (read off the boards, 2026-08-23). Page actions are not in that bar.
 - A page below a section carries one uniform trail into its record in that bar, and **the trail is one line that ends with the record** — `Tests / Livekit agent suite`. A page passes the real trail, ending with the record's own name; `PageNavigation` draws that final step as the page's only `h1`. Every segment and separator uses the 14px / 400 step, so the current page never jumps in size or weight. Parent steps are muted links, `/` separates every adjacent step, pointer hover reveals an underline, and keyboard focus uses the standard two-pixel Ember indicator. Page changes are immediate and carry no transition. The bar used to draw the trail short of the record and the record beside it as a larger heading, which read as a small underlined link stuck to a big title with no separator between them. (Developer decision, 2026-08-26, from the selected Paper PageHeader refinement. This replaces the never-repeat-the-title rule read off the boards on 2026-08-23. A page with no trail still draws its title alone in the bar.)
 - A page's actions sit in the toolbar row under the title bar, at the right, opposite whatever the page filters by.
 - The toolbar row is 52px, and the last 16px of it is the gap to whatever it stands over. The page body adds no gutter of its own under a toolbar row, so a list's panel begins 132px down the page: the 56px title bar, the 24px gutter, and the 52px row. A page whose header draws no toolbar row keeps the 24px gutter, because then nothing above it carries one. (Read off `71N-0` and `6ZM-0` on `6ZJ-0`, 2026-08-23; the application had been drawing the panel at 156.)
@@ -288,7 +284,7 @@ The measurements, all of them theme values:
 - A table is a Pure Paper panel inside one neutral hairline, with its corners clipped.
 - Table text starts at 14px.
 - Neutral hairlines separate rows. There is no hairline after the last row.
-- **A column header earns its rank from weight and tracking, not from a fill.** The header row carries no fill of its own. It is the 14px caption step in sentence case, weight 500, with the 0.08em label tracking, in the secondary text colour, over one hairline, in a 40px row. A body row is at least 52px. The header was weight 400 in the tertiary colour before this. A soft gray fill was drawn and then removed, and so were the capitals a later variant tried: a fill makes a second surface inside a panel that is already one surface, and capitals slow a word down and buy nothing. The stacked mobile row names its columns with the same recipe, so a column is named one way in both layouts. (Developer decision, 2026-08-28, from the approved Paper page `09 — Gray chrome variations`, variation V1b.)
+- Headers are quiet, regular-weight labels in a 40px row. A body row is at least 52px.
 - Every row ends with the same fixed slot for its row menu, whether or not it has one, so the menus line up in one lane down the table.
 - Selected or active rows use Ember Wash plus a non-color state mark.
 - Mobile may restyle the same DOM as rows. It must not duplicate interactive content.
@@ -307,7 +303,7 @@ The measurements, all of them theme values:
 
 - One record is created, read, and edited in a side sheet anchored to the right edge: agents, connections, personas, and tests. The list stays on screen behind it. (Developer decision, 2026-08-23.)
 - **There are two side-sheet behaviours and one wider production reading variant.** The **modal** sheet is the create, read, and edit surface named above: it is 440px, sits over a scrim, and makes the page behind it inert. The **wide reading** sheet is the evidence surface — a transcript beside its grader results, a persona's version history — it is 640px, has no scrim, and deliberately leaves the page beside it usable. The production trace uses that same reading behaviour but progressively widens from 640px to 760px when the viewport has room, so more of the transcript stays visible. A production transcript closes after a primary pointer press on the page beside it. Simulation transcript-and-audio evidence stays open while its grader results are used for comparison. Every width is a theme value. (Developer decision, 2026-08-23; production-transcript outside dismissal and wider production reading variant added by developer decision, 2026-08-28.)
-- A side sheet is full height, on the raised surface behind a hairline on its left edge. That surface is Pure Paper in light theme and the lifted `--raised` fill in dark theme, because a reading sheet opens over a live page with no scrim and has nothing else to stand on.
+- A side sheet is full height, on Pure Paper behind a hairline on its left edge.
 - Its head is the record's name at the lead step with a close beside it, over a hairline. Its body is the fields and scrolls. Its footer is pinned to the bottom: the answer and the way out at the left, the one destructive action at the right.
 - It travels from the edge it is attached to, on the drawer's durations, and fades in place under reduced motion.
 - It traps focus, makes the page behind it inert, closes with Escape, and restores the exact opener.

--- a/apps/web/app/design-system/proof.tsx
+++ b/apps/web/app/design-system/proof.tsx
@@ -440,7 +440,7 @@ export function DesignSystemProof() {
                   Theme, straight from the tokens
                 </h3>
                 <div className="grid grid-cols-3 gap-2">
-                  <div className="h-10 rounded-input border border-border bg-chrome" title="Neutral Paper" />
+                  <div className="h-10 rounded-input border border-border bg-background" title="Neutral Paper" />
                   <div className="h-10 rounded-input border border-border bg-surface-soft" title="Quiet neutral" />
                   <div className="h-10 rounded-input border border-border bg-selected" title="Ember Wash" />
                   <div className="h-10 rounded-input border border-border bg-primary" title="Deep Ember" />

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -140,7 +140,7 @@
       padding: var(--space-1);
       border: 1px solid var(--border);
       border-radius: var(--radius-lg);
-      background: var(--raised);
+      background: var(--surface);
       box-shadow: var(--shadow-menu);
       color: var(--foreground);
     }

--- a/apps/web/app/projects/[projectId]/runs/[runId]/run-scenario-workbench.tsx
+++ b/apps/web/app/projects/[projectId]/runs/[runId]/run-scenario-workbench.tsx
@@ -6,7 +6,6 @@ import { useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
-  STACKED_HEAD_TYPE,
   Table,
   TableBody,
   TableCell,
@@ -123,17 +122,10 @@ type GraderRow = {
   readonly history: readonly EvidenceGrade[];
 };
 
-/*
- * A narrow results row prints each column's name beside its value, because
- * the header row above is read out and not drawn. The printed name is that
- * header, so it wears the header's own rank — `STACKED_HEAD_TYPE`, the same
- * one every stacked list uses.
- */
 const STACKED_BEHAVIOR_CELL = cn(
   "stacked:flex stacked:h-auto stacked:min-h-0 stacked:items-start",
   "stacked:justify-between stacked:gap-4 stacked:border-0 stacked:p-0",
-  "stacked:before:flex-none stacked:before:text-sm",
-  STACKED_HEAD_TYPE,
+  "stacked:before:flex-none stacked:before:text-sm stacked:before:text-faint",
   "stacked:before:content-[attr(data-label)]",
 );
 

--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -17,7 +17,7 @@ import {
 
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { HEAD_TYPE, LANE_X } from "@/components/ui/table";
+import { LANE_X } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import {
   platformAnswer,
@@ -422,7 +422,7 @@ function PersonaPicker({
 
   return (
     <Arriving
-      className="absolute top-full left-0 z-20 mt-1 w-[300px] origin-top border border-border bg-raised shadow-popover"
+      className="absolute top-full left-0 z-20 mt-1 w-[300px] origin-top border border-border bg-surface shadow-popover"
       role="dialog"
       aria-label="Choose personas"
       data-persona-picker={owner}
@@ -1417,21 +1417,12 @@ export function TestsGrid(props: GridProps) {
           <col style={{ width: "var(--table-action-labelled-width)" }} />
         </colgroup>
         <thead>
-          {/*
-            The header row is unfilled, like every other header row in the
-            product. This grid used to tint it, which was the spreadsheet
-            habit rather than a rule: the approved header is ranked by weight
-            and space, and a tint under it would say the same thing a second
-            time on the one screen that draws it. The vertical rules stay —
-            they are what make this a grid to type in.
-          */}
-          <tr>
+          <tr className="bg-surface-soft">
             {COLUMNS.map((column) => (
               <th
                 className={cn(
                   PAD,
-                  "border-r border-b border-border text-left text-sm last:border-r-0",
-                  HEAD_TYPE,
+                  "border-r border-b border-border text-left text-sm font-normal text-faint last:border-r-0",
                 )}
                 key={column.field}
                 scope="col"
@@ -1448,8 +1439,7 @@ export function TestsGrid(props: GridProps) {
             <th
               className={cn(
                 PAD,
-                "w-(--table-action-labelled-width) border-b border-border text-center text-sm whitespace-nowrap",
-                HEAD_TYPE,
+                "w-(--table-action-labelled-width) border-b border-border text-center text-sm font-normal whitespace-nowrap text-faint",
               )}
               scope="col"
             >

--- a/apps/web/app/ui.tsx
+++ b/apps/web/app/ui.tsx
@@ -231,18 +231,7 @@ export function AuthShell({
   return (
     <main
       className={cn(
-        /*
-         * The ground is chrome, and the panel on it is the work — the same
-         * rule the signed-in product took on 2026-08-28, read onto a page
-         * that has no sidebar and no title bar to carry it. An access page is
-         * all frame and one panel, so the frame is the whole ground.
-         *
-         * It reads `--chrome` rather than `--background` because
-         * `--background` is Pure Paper now and the panel below is Pure Paper
-         * too: the two would be one surface with a hairline between them, and
-         * the panel would stop being a panel.
-         */
-        "relative grid min-h-[100svh] place-items-center bg-chrome",
+        "relative grid min-h-[100svh] place-items-center bg-background",
         "px-6 py-16",
         "max-[620px]:py-12 max-[400px]:px-4",
       )}

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -84,7 +84,7 @@ function DialogContent({
         className={cn(
           "fixed top-1/2 left-1/2 z-30 -translate-x-1/2 -translate-y-1/2",
           "flex w-[min(var(--dialog-width),calc(100vw-var(--space-8)))] flex-col gap-5",
-          "rounded-card border border-border bg-raised p-6 text-foreground shadow-modal",
+          "rounded-card border border-border bg-surface p-6 text-foreground shadow-modal",
           className,
         )}
         {...props}

--- a/apps/web/components/ui/sheet.tsx
+++ b/apps/web/components/ui/sheet.tsx
@@ -173,7 +173,7 @@ function SheetContent({
         className={cn(
           "fixed inset-y-0 right-0 z-30 flex w-[min(var(--sheet-width),100vw)] flex-col gap-5",
           size === "wide" && "w-[min(var(--sheet-width-wide),100vw)]",
-          "border-l border-border bg-raised p-6 text-foreground shadow-modal",
+          "border-l border-border bg-surface p-6 text-foreground shadow-modal",
           "outline-none",
           className,
         )}

--- a/apps/web/components/ui/sidebar.tsx
+++ b/apps/web/components/ui/sidebar.tsx
@@ -328,18 +328,7 @@ function SidebarMenuButton({
         "transition-[color,background-color] duration-(--duration-hover) ease-out",
         "before:absolute before:inset-y-2 before:left-0 before:w-0.5",
         "before:rounded-chip before:bg-transparent before:content-['']",
-        /*
-         * **The quiet hover is paper, because the row stands on the chrome.**
-         * It was `--surface-soft` while the bar was paper, and the bar is
-         * `--chrome` now — one value with `--surface-soft` in light theme, so
-         * the plate would have been drawn in exactly the colour under it and
-         * the busiest hover in the product would have gone silent. A row lifts
-         * towards the work surface instead, which reads in both themes and is
-         * the movement every other control on the chrome makes. `shell.tsx`
-         * states the rule; the drawer wears the chrome fill so this one class
-         * is true in both places the bar is drawn.
-         */
-        "pointer-hover:data-[active=false]:bg-surface pointer-hover:data-[active=false]:text-foreground",
+        "pointer-hover:data-[active=false]:bg-surface-soft pointer-hover:data-[active=false]:text-foreground",
         "data-[active=true]:bg-selected data-[active=true]:text-foreground",
         "data-[active=true]:before:bg-brand",
         /*

--- a/apps/web/components/ui/skeleton.tsx
+++ b/apps/web/components/ui/skeleton.tsx
@@ -15,13 +15,11 @@ import { cn } from "@/lib/utils";
  *
  * 1. **The bar reads `--border`.** shadcn draws it on the quiet accent
  *    surface, which this theme maps to `--surface-soft` — 6% Graphite on
- *    paper. The content area is Pure Paper, so a skeleton drawn there was six
- *    percent of one colour away from the page under it: present in the DOM,
- *    invisible to a person. `--border` is 18%, still "a neutral
- *    Graphite-and-Paper mix" and still quiet, and it is legible on the
- *    content, on the chrome and in dark theme alike. The gap is wider than it
- *    was, not narrower: the canvas used to be 3% Graphite and is now paper,
- *    so this rule is more load-bearing after 2026-08-28, not less.
+ *    paper. The application canvas is 3% Graphite on paper, so a skeleton on
+ *    the canvas was three percent of one colour away from the page it was
+ *    drawn on: present in the DOM, invisible to a person. `--border` is 18%,
+ *    still "a neutral Graphite-and-Paper mix" and still quiet, and it is
+ *    legible on the canvas, on Pure Paper and in dark theme alike.
  * 2. **The radius is named for a component.** shadcn's generic medium step and
  *    `rounded-input` are the same 8px today; only one of them says which of
  *    egma's four radii it means, and only one of them moves if that step ever

--- a/apps/web/components/ui/sonner.tsx
+++ b/apps/web/components/ui/sonner.tsx
@@ -72,19 +72,19 @@ const Toaster = ({ ...props }: ToasterProps) => {
       }}
       style={
         {
-          "--normal-bg": "var(--raised)",
+          "--normal-bg": "var(--surface)",
           "--normal-text": "var(--foreground)",
           "--normal-border": "var(--border)",
-          "--success-bg": "var(--raised)",
+          "--success-bg": "var(--surface)",
           "--success-text": "var(--foreground)",
           "--success-border": "var(--good-border)",
-          "--warning-bg": "var(--raised)",
+          "--warning-bg": "var(--surface)",
           "--warning-text": "var(--foreground)",
           "--warning-border": "var(--warn-border)",
-          "--error-bg": "var(--raised)",
+          "--error-bg": "var(--surface)",
           "--error-text": "var(--foreground)",
           "--error-border": "var(--bad-border)",
-          "--info-bg": "var(--raised)",
+          "--info-bg": "var(--surface)",
           "--info-text": "var(--foreground)",
           "--info-border": "var(--border)",
           /* The card radius, which is what a raised surface this size wears. */

--- a/apps/web/components/ui/table.tsx
+++ b/apps/web/components/ui/table.tsx
@@ -7,9 +7,8 @@ import { cn } from "@/lib/utils";
  *
  * Read off `6ZM-0`, `71F-0` and `710-0` with `get_computed_styles` on
  * 2026-08-23: a Pure Paper panel inside one neutral hairline with the corners
- * clipped and no corner radius; a 40px header row of 14px labels over a
- * hairline, unfilled — see `TableHead` for what ranks them above their column;
- * body rows at least 52px tall with 8px of vertical padding, 16px of
+ * clipped and no corner radius; a 40px header row of quiet 14px labels over a
+ * hairline; body rows at least 52px tall with 8px of vertical padding, 16px of
  * side padding and a hairline between them; and a 48px slot at the trailing
  * edge that every row carries whether or not it holds a menu.
  *
@@ -51,47 +50,6 @@ import { cn } from "@/lib/utils";
  *   rather than a set of columns, so it has no shared edge to keep.
  */
 export const LANE_X = "px-(--row-padding-x)";
-
-/**
- * What ranks a column's name above its column, written once.
- *
- * **A header has to out-rank 14px / 400 values without a fill and without
- * capitals, so weight and space are what it has.** Weight 500 is the ceiling
- * `DESIGN.md` allows and the label tracking opens the word out — about a fifth
- * of its own width on a header of average length — and that air is what the eye
- * reads as a header rather than as a first row of data. The colour is the
- * secondary `--muted` rather than the quieter `--faint`: a label doing more
- * work should not also be the quietest thing in the panel. No fill, and the one
- * hairline under the row is still the only line. (Developer decision,
- * 2026-08-28, from Paper page `09 — Gray chrome variations`, variation V1b.
- * This replaces the quiet regular-weight header read off the boards on
- * 2026-08-23.)
- *
- * The size does not appear here. The header sits at the table's own 14px and
- * has never had a size of its own.
- *
- * It is exported for the same reason `LANE_X` is: the inline-editing suite grid
- * in `tests/tests-grid.tsx` is not built from these parts, and a header's rank
- * declared in two files is a header that drifts.
- */
-export const HEAD_TYPE =
-  "font-medium tracking-(--tracking-label) text-muted-foreground";
-
-/**
- * The same rank, for a narrow layout that has no header row to carry it.
- *
- * A stacked row is a label-and-value list, so each cell prints its own column's
- * name from `data-label` instead. That printed label is the header — said again
- * beside the fact — so it is said the same way, and the two layouts name a
- * column identically. The variants have to be written out rather than composed
- * from `HEAD_TYPE`, because Tailwind finds class names by reading files as
- * text and cannot see a prefix a program adds at runtime.
- */
-export const STACKED_HEAD_TYPE = cn(
-  "stacked:before:font-medium",
-  "stacked:before:tracking-(--tracking-label)",
-  "stacked:before:text-muted-foreground",
-);
 
 /** The bordered surface a table is drawn on. */
 function TablePanel({ className, ...props }: ComponentProps<"div">) {
@@ -140,14 +98,11 @@ function TableRow({ className, ...props }: ComponentProps<"tr">) {
 }
 
 /**
- * A column's name: the same 14px the rows are at, in the header's own rank.
+ * A column's name: quiet, regular weight, and the same 14px the rows are at.
  *
- * The rank is `HEAD_TYPE` above, which is where the reasoning is. The label
- * itself is left in the sentence case it was written in — the treatment is
- * type, not text.
- *
- * The height is fixed rather than a minimum, because a header holds one word
- * and has nothing to grow for.
+ * `DESIGN.md`: "Headers are quiet, regular-weight labels." The height is fixed
+ * rather than a minimum, because a header holds one word and has nothing to
+ * grow for.
  */
 function TableHead({ className, ...props }: ComponentProps<"th">) {
   return (
@@ -156,8 +111,7 @@ function TableHead({ className, ...props }: ComponentProps<"th">) {
       className={cn(
         "h-(--row-height) border-b border-border",
         LANE_X,
-        "text-left whitespace-nowrap",
-        HEAD_TYPE,
+        "text-left font-normal whitespace-nowrap text-faint",
         className,
       )}
       {...props}

--- a/apps/web/test/sidebar-groups.test.tsx
+++ b/apps/web/test/sidebar-groups.test.tsx
@@ -299,14 +299,7 @@ describe("the grouped sidebar", () => {
     // current row's Ember Wash: the hover colours are scoped off the active
     // row rather than fighting it on specificity.
     expect(agents.className).not.toContain("motion-reduce:transition-none");
-    // The plate is paper and not the quiet grey, because the bar under it is
-    // `--chrome` — one value with `--surface-soft` in light theme, so the grey
-    // plate would be drawn in the colour it stands on. A row on the chrome
-    // lifts towards the work surface.
     expect(agents.className).toContain(
-      "pointer-hover:data-[active=false]:bg-surface",
-    );
-    expect(agents.className).not.toContain(
       "pointer-hover:data-[active=false]:bg-surface-soft",
     );
   });

--- a/apps/web/ui/data-table.tsx
+++ b/apps/web/ui/data-table.tsx
@@ -4,7 +4,6 @@ import type { ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
-  STACKED_HEAD_TYPE,
   Table,
   TableBody,
   TableCell,
@@ -32,7 +31,7 @@ import { ROW_HOVER } from "./evidence.tsx";
  * agents should be a list of forty agents rather than four screens of scroll.
  *
  * **The frame is the kit's `Table`, and the numbers are the boards'.** A Pure
- * Paper panel inside one hairline with no corner; a 40px header of unfilled
+ * Paper panel inside one hairline with no corner; a 40px header of quiet
  * labels; rows at least 52px with a hairline between them and none after the
  * last; and a fixed 48px slot at the trailing edge that every row carries, so
  * the ⋮ menus line up in one lane down the table whether or not a given row
@@ -383,29 +382,18 @@ export function DataTable<Row>({
                              * **The lane carries no label, in either layout.**
                              * The header cell is empty by the boards' own
                              * drawing and the control inside names itself, so
-                             * a stacked row that wrote "Actions" above a ⋮
-                             * would be saying the same word twice. What is
-                             * left is the control alone, at the trailing
-                             * edge, which is the lane.
+                             * a stacked row that wrote "ACTIONS" above a ⋮
+                             * would be saying the same word twice — once in
+                             * capitals. What is left is the control alone, at
+                             * the trailing edge, which is the lane.
                              */
                             "stacked:justify-end"
                           : stacks
                             ? [
-                              /*
-                               * The header is the label, said again beside
-                               * the fact — so it is said the same way. This
-                               * is `TableHead`'s recipe on a pseudo-element:
-                               * the 14px step, weight 500, the label tracking
-                               * and the secondary `--muted`. The capitals it
-                               * used to print went with the header they were
-                               * copying; the label is drawn in the sentence
-                               * case the column was written in, so the two
-                               * layouts name a column one way. (Developer
-                               * decision, 2026-08-28, from Paper page `09 —
-                               * Gray chrome variations`, variation V1b.)
-                               */
+                              /* The header is the label, said again beside the fact. */
                               "stacked:before:flex-none stacked:before:text-xs",
-                              STACKED_HEAD_TYPE,
+                              "stacked:before:tracking-(--tracking-label) stacked:before:text-faint",
+                              "stacked:before:uppercase",
                               "stacked:before:content-[attr(data-label)]",
                               ]
                             : undefined,

--- a/apps/web/ui/dialog.tsx
+++ b/apps/web/ui/dialog.tsx
@@ -67,17 +67,6 @@ const PANEL_SHAPE = {
     "top-0 left-0 h-full max-h-none",
     "w-[min(340px,calc(100vw-var(--space-7)))] translate-x-0 translate-y-0",
     "overflow-y-auto border-y-0 border-l-0",
-    /*
-     * **The drawer is the sidebar, so it is chrome and not paper.** It is the
-     * one kind that holds navigation rather than a question or a record, it
-     * draws the shell's own `Navigation`, and those rows read their hover
-     * against the bar they believe they are in — a paper panel would have
-     * given the same component two different grounds and made its hover
-     * invisible on one of them. What makes it a raised surface is what makes
-     * every raised surface one here: the scrim behind it, the hairline on its
-     * edge and the shared shadow. Not the fill.
-     */
-    "bg-chrome",
   ],
   /*
    * **One side sheet look, with reading widths chosen by content.** This is the

--- a/apps/web/ui/feedback.tsx
+++ b/apps/web/ui/feedback.tsx
@@ -162,7 +162,7 @@ export function Toast({
         "w-[min(380px,calc(100vw-(2*var(--space-4))))] min-h-(--tap-target)",
         "grid-cols-[var(--control-sm)_minmax(0,1fr)_var(--control-sm)] gap-3 p-3",
         "rounded-card border border-border border-l-2 border-l-foreground",
-        "bg-raised text-foreground shadow-popover",
+        "bg-surface text-foreground shadow-popover",
         /* The failure colour, for the reason written on `app/ui.tsx`'s notice. */
         "data-[kind=error]:border-l-failure",
         "max-[640px]:right-4 max-[640px]:bottom-4",

--- a/apps/web/ui/project-selector.tsx
+++ b/apps/web/ui/project-selector.tsx
@@ -60,16 +60,7 @@ const TRIGGER_COMPACT = [
   "flex-row items-center gap-2",
   "min-h-(--control-lg) max-w-[220px] rounded-input px-3 py-1",
   "border border-border bg-surface",
-  /*
-   * **The edge answers the pointer; the fill stays where it is.** This form is
-   * drawn on the mobile bar, and that bar is chrome — so the control already
-   * rests a step above what it sits on, and the quiet grey it used to hover to
-   * is the bar's own value in light theme. A control that sank into its bar
-   * the moment somebody pointed at it would be saying the opposite of what a
-   * hover means. The hairline going to ink says it in both themes. The drawer
-   * button beside it in `shell.tsx` is the same control and made the same move.
-   */
-  "pointer-hover:border-border-strong",
+  "pointer-hover:border-border-strong pointer-hover:bg-surface-soft",
   "max-[900px]:min-w-0 max-[900px]:max-w-[min(220px,56vw)]",
 ];
 

--- a/apps/web/ui/settings-nav.tsx
+++ b/apps/web/ui/settings-nav.tsx
@@ -116,16 +116,9 @@ const NAV_ITEM = [
  * disappearing under the pointer. Naming the two sets apart is the fix that
  * needs no rule to outrank another — a row is either current or it is not, and
  * only one of these two lists ever reaches it.
- *
- * **The plate is paper, because the rail under it is chrome.** It was
- * `--surface-soft`, which is the chrome's own value in light theme — the
- * hover would have been drawn in exactly the colour it stands on. A row on the
- * chrome lifts towards the work surface instead. It is the sidebar row's rule
- * and the sidebar row's value, which is the point: these two lists of links
- * are one thing to a person moving between them.
  */
 const NAV_ITEM_QUIET = [
-  "pointer-hover:bg-surface pointer-hover:text-foreground",
+  "pointer-hover:bg-surface-soft pointer-hover:text-foreground",
 ];
 
 const NAV_ITEM_CURRENT = [
@@ -214,24 +207,14 @@ export function SettingsNav({
       className={cn(
         /*
          * **A rail, and a rail is a panel.** The scene board draws the settings
-         * navigation as a bordered card beside the page (`2AO-0`) rather than
-         * as a column hanging off a divider, which is what this was: a hairline
-         * on the right and nothing else made the links read as part of the
-         * page's own left margin. The card says they are a place you are in.
-         * No corner and no shadow — a rail does not float.
-         *
-         * **The card is chrome, and the board's Pure Paper is why it had to
-         * move.** `--background` is Pure Paper now, so a paper rail on a paper
-         * page is a card with nothing but its hairline left to say it is one.
-         * The fill it takes instead is the fill the sidebar takes, and it is
-         * the honest one twice over: this is navigation, drawn beside the work
-         * rather than inside it, and a person crossing from the bar on the left
-         * to the rail in the middle of Settings meets one material for both.
-         * (Developer decision, 2026-08-28, Paper page `09 — Gray chrome
-         * variations`, V1b.)
+         * navigation as a bordered Pure Paper card beside the page (`2AO-0`)
+         * rather than as a column hanging off a divider, which is what this
+         * was: a hairline on the right and nothing else made the links read as
+         * part of the page's own left margin. The card says they are a place
+         * you are in. No corner and no shadow — a rail does not float.
          */
         "flex flex-col items-stretch gap-2",
-        "rounded-card border border-border bg-chrome p-2",
+        "rounded-card border border-border bg-surface p-2",
         /*
          * Narrow, the same card stops being a column beside the page and
          * becomes a card above it — two scopes side by side, still labelled,

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -74,23 +74,6 @@ import { useTheme } from "./theme.tsx";
  * tuning pass at the end of this effort is an edit to the theme rather than an
  * edit to every page.
  *
- * **Gray is the chrome, white is the work.** Three surfaces in this file are
- * the application's own furniture — the sidebar, the page title bar, and the
- * bar that stands in for both under the layout breakpoint — and all three are
- * `--chrome`. Everything between them is `--background`, which is paper now.
- * The product used to be drawn the other way round: a white bar beside a
- * near-white canvas, which made the frame and the work the same material and
- * left a hairline to say which was which. One rule replaces that, and it is
- * legible at a glance from across a desk. (Developer decision, 2026-08-28,
- * from the approved Paper variation.)
- *
- * **On chrome, a quiet state goes up to paper rather than down to grey.** The
- * bar's own fill and `--surface-soft` are one value in light theme, so the
- * neutral hover plate every control here used to wear would land on exactly
- * the colour it sits on and disappear. Hovering a control on the chrome lifts
- * it to `--surface` instead — towards the work surface, away from the frame —
- * which reads in both themes and is the same movement everywhere in the frame.
- *
  * **Where you are comes from the address.** The project is read out of the
  * path, the navigation item is read out of the path, and nothing here keeps a
  * chosen project of its own. Two tabs on two projects are therefore two
@@ -406,17 +389,12 @@ function OrganizationMenu({
           "flex min-h-(--control-lg) w-full min-w-0 items-center gap-1 px-2",
           "cursor-pointer rounded-input border border-transparent bg-transparent text-left",
           "transition-transform duration-(--duration-press) ease-out",
-          /*
-           * Paper, not the quiet grey: this control stands on the chrome, and
-           * the chrome and `--surface-soft` are one value in light theme. The
-           * plate is the account control's, one lane down the same bar.
-           */
-          "pointer-hover:border-border pointer-hover:bg-surface",
+          "pointer-hover:border-border pointer-hover:bg-surface-soft",
           "[&:active:not(:focus-visible)]:scale-97",
           "motion-reduce:transition-none",
           "motion-reduce:[&:active:not(:focus-visible)]:scale-100",
         )}
-        openClassName="border-border bg-surface"
+        openClassName="border-border bg-surface-soft"
         placement="below-start"
         panelRole="dialog"
         panelClassName="w-[280px] p-3"
@@ -561,14 +539,6 @@ function AccountMenu({
           "cursor-pointer rounded-input border border-transparent bg-transparent text-left",
           "transition-transform duration-(--duration-press) ease-out",
           "pointer-coarse:min-h-(--tap-target)",
-          /*
-           * The plate rises to paper, avatar and all, and it is the whole
-           * plate that rises. On the white bar this used to be the border
-           * arriving and nothing else — the fill it asks for was the fill it
-           * already stood on. The bar is chrome now, so the same class is a
-           * visible lift, and the hover a person gets here is the hover the
-           * organization control and every navigation row get.
-           */
           "pointer-hover:border-border pointer-hover:bg-surface",
           "[&:active:not(:focus-visible)]:scale-97",
           "motion-reduce:transition-none",
@@ -582,14 +552,7 @@ function AccountMenu({
             <span
               className={cn(
                 "grid size-(--control-md) flex-none place-items-center",
-                /*
-                 * Paper inside a hairline, because the square stands on the
-                 * chrome and the quiet grey it used to wear is the chrome's
-                 * own value in light theme — a tile the colour of the bar it
-                 * is on. It reads as a tile at rest and keeps its hairline
-                 * once the plate under it has risen to the same paper.
-                 */
-                "rounded-none border border-border bg-surface text-sm",
+                "rounded-none border border-border bg-surface-soft text-sm",
                 compact && "size-(--tap-target)",
               )}
               data-slot="account-avatar"
@@ -816,14 +779,11 @@ function ShellFrame({
        * living beside the breakpoint that reads it. Everything inside it is on
        * the sidebar primitives — the switcher topmost in the header slot, the
        * groups in the content, the account control in the footer slot.
-       *
-       * It is the first of the three chrome surfaces, and it used to be the
-       * paper one. See the note at the top of this file for the rule.
        */}
       <aside
         className={cn(
           "sticky top-0 z-20 flex h-svh flex-col gap-5 overflow-visible pb-4",
-          "border-r border-border bg-chrome",
+          "border-r border-border bg-surface",
           "max-[900px]:hidden",
         )}
       >
@@ -865,19 +825,11 @@ function ShellFrame({
             "sticky top-0 z-20 hidden h-(--topbar-height) items-center gap-3 px-4",
             "border-b border-border backdrop-blur-[12px]",
             /*
-             * Nearly the chrome, so what scrolls under the bar is felt rather
-             * than read. Written here because it is one derived value used in
-             * one place, and the theme holds no key for it.
-             *
-             * **The mix moved from `--surface` to `--chrome` and the effect is
-             * the one it always was**: this bar is the sidebar and the title
-             * bar at once under the layout breakpoint, so it takes their fill,
-             * and 6% of the page shows through it while the page moves. Left
-             * on `--surface` it would have been a paper bar over paper
-             * content — the blur with nothing to blur, and the one chrome
-             * surface a narrow screen has drawn as work.
+             * Nearly the raised surface, so what scrolls under the bar is felt
+             * rather than read. Written here because it is one derived value
+             * used in one place, and the theme holds no key for it.
              */
-            "bg-[color-mix(in_srgb,var(--chrome)_94%,transparent)]",
+            "bg-[color-mix(in_srgb,var(--surface)_94%,transparent)]",
             "max-[900px]:flex",
           )}
         >
@@ -888,16 +840,7 @@ function ShellFrame({
                 "rounded-button border border-border bg-surface text-sm text-foreground",
                 "transition-transform duration-(--duration-press) ease-out",
                 "pointer-coarse:size-(--tap-target)",
-                /*
-                 * **The edge answers the pointer; the fill stays where it is.**
-                 * This control already rests on paper, so the lift the rest of
-                 * the chrome uses is a step it has taken — and the grey it used
-                 * to hover to is the bar's own colour in light theme, which
-                 * would sink a white tile into the bar the moment somebody
-                 * pointed at it. The hairline going to ink says the same thing
-                 * and says it in both themes.
-                 */
-                "pointer-hover:border-border-strong",
+                "pointer-hover:border-border-strong pointer-hover:bg-surface-soft",
                 "[&:active:not(:focus-visible)]:scale-97",
                 "motion-reduce:transition-none",
                 "motion-reduce:[&:active:not(:focus-visible)]:scale-100",
@@ -1134,28 +1077,15 @@ export function PageHeader({
         data-slot="page-topbar"
         className={cn(
           "sticky top-0 z-10 flex min-w-0 flex-none items-center",
-          /*
-           * Chrome, and the same fill as the sidebar across the divider from
-           * it. The two bars are the same 56px for the reason `SidebarBrand`
-           * gives, and they are now the same colour for the same kind of
-           * reason: they are one frame around the page, drawn in two elements
-           * because one of them scrolls with a column the other does not.
-           */
-          "h-(--topbar-height) border-b border-border bg-chrome",
+          "h-(--topbar-height) border-b border-border bg-background",
           "px-(--page-gutter)",
           /*
            * Under the one layout breakpoint the page has a top bar of its own
            * already — the drawer button, the switcher and the account control
            * — so this stops being a bar and becomes the page's first line.
-           *
-           * **And a line of the page is drawn on the page.** The chrome fill
-           * goes with the bar: kept, it would put a grey band across the top
-           * of the content with no edge under it and nothing above it, which
-           * is the frame's colour worn by something that is no longer frame.
            */
           "max-[900px]:static max-[900px]:h-auto max-[900px]:flex-wrap",
-          "max-[900px]:border-b-0 max-[900px]:bg-background",
-          "max-[900px]:px-4 max-[900px]:pt-4",
+          "max-[900px]:border-b-0 max-[900px]:px-4 max-[900px]:pt-4",
         )}
       >
         <PageContentFrame className="items-center gap-3" slot="page-topbar-content">

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -103,33 +103,9 @@
    * The canvas, routine hover, progress, and read-only surfaces stay neutral.
    * Pale orange is reserved for selected, current, open, cited, and other
    * active-attention states.
-   *
-   * **Gray is the chrome, and white is the work.** `--chrome` fills the
-   * application frame — the sidebar and the page title bar — and `--background`
-   * is the content area under it, which is Pure Paper. The two were the other
-   * way round until the developer approved variation V1b on the Paper page
-   * `09 — Gray chrome variations`, 2026-08-28. Going down a page a reader now
-   * crosses three surfaces and not four: the chrome, the content, and the
-   * hairlines that draw structure inside the content.
-   *
-   * `--chrome` spells its own mix rather than reading `--surface-soft`, which
-   * lands on the same `#f3f3f3` in light theme today. They are two facts — the
-   * fill of the application frame, and the quiet neutral step for hover and
-   * read-only — and they part company in dark theme, where the chrome is
-   * `#0f0f0e` and the quiet step is `#262624`.
    */
-  --background: var(--color-paper);
-  --chrome: color-mix(in srgb, var(--color-graphite) 6%, var(--color-paper));
+  --background: color-mix(in srgb, var(--color-graphite) 3%, var(--color-paper));
   --surface: var(--color-paper);
-  /*
-   * What is raised off the page: menus, popovers, dialogs, side sheets, toasts.
-   *
-   * In light theme it is the flush surface exactly, because `DESIGN.md` puts
-   * every raised surface on Pure Paper and because the shared orange-brown
-   * shadow is what separates a menu from the paper under it. Dark theme lifts
-   * it away from the page, and the dark block below says why it has to.
-   */
-  --raised: var(--surface);
   --surface-soft: color-mix(in srgb, var(--color-graphite) 6%, var(--color-paper));
   --surface-active: var(--color-ember-wash);
   --foreground: var(--color-midnight);
@@ -463,57 +439,9 @@
  */
 :root[data-theme="dark"],
 [data-theme="dark"] {
-  /*
-   * **Dark theme separates by surface, not by hairline alone.**
-   *
-   * The chrome is `#0f0f0e` and the content is `#1e1e1c` — about fifteen steps
-   * apart out of 255, in the darkest range where the eye separates best. The
-   * pair before this was `#151514` under `#1b1b1a`: six steps, behind a
-   * `#30302d` hairline, and the whole product read as one flat black. The
-   * hairline lifts with them, and so do the two quiet text colours, so a
-   * secondary label on the lighter content surface stays legible. (Developer
-   * decision, 2026-08-28, Paper page `09 — Gray chrome variations`, V1b.)
-   *
-   * `--surface` and `--background` are deliberately one value. A flush panel —
-   * a table, a form group, an empty-state card — is drawn by its hairline
-   * rather than by a fill of its own, which is the same thing light theme does
-   * now that both are Pure Paper.
-   */
-  --background: #1e1e1c;
-  --chrome: #0f0f0e;
-  --surface: #1e1e1c;
-  --surface-soft: #262624;
-  /*
-   * The one dark value `DESIGN.md` does not name, and the reason it is here.
-   *
-   * `--surface` and `--background` are one value now, so a raised surface can
-   * no longer be told from the page by its fill — and on dark it has nothing
-   * else to fall back on. The shared shadow starts at `rgb(122 49 23 / 0.12)`,
-   * which over `#1e1e1c` resolves to `#29201b`: **lighter** than the page it
-   * falls on. A warm shadow on a dark page is a faint halo at about 1.05:1 at
-   * its strongest point, not a shadow. That leaves the hairline, and
-   * `DESIGN.md` rules that out in as many words: "Dark theme separates by
-   * surface, not by hairline alone."
-   *
-   * The step is small and hemmed in on both sides. Six percent of paper into
-   * the page gives `#2c2c2a`: **1.19:1 against the content**, where the pair it
-   * replaces managed 1.06:1; **1.12:1 against the hairline**, so the panel
-   * keeps its own outline; and **1.08:1 against `--surface-soft`**, so a
-   * highlighted menu item still reads — the same step strength dark theme had
-   * before. Eight percent buries the hairline. Five percent loses the
-   * highlight.
-   *
-   * **The menu highlight now darkens where it used to lighten.** That is the
-   * light theme's own direction — `#f3f3f3` under a white menu — and the
-   * alternative was a raised value *below* `--surface-soft`, where the whole
-   * gap between the page and the quiet step is four steps out of 255.
-   *
-   * A reading side sheet is what makes this load-bearing rather than tidy.
-   * `ui/dialog.tsx` opens one with `modal={false}` and draws no overlay, so it
-   * sits on a live page with one left hairline and nothing else. A dialog and a
-   * drawer have the scrim to fall back on; that sheet has nothing.
-   */
-  --raised: color-mix(in srgb, var(--color-paper) 6%, var(--surface));
+  --background: #151514;
+  --surface: #1b1b1a;
+  --surface-soft: #222220;
   /*
    * The designer's own dark wash, read from the Paper file's tokens
    * (`--color-dark-surface-active`). It was a `color-mix` of Ember into the
@@ -523,9 +451,9 @@
    */
   --surface-active: #43241c;
   --foreground: #f2f2ed;
-  --muted: #b6b6ae;
-  --faint: #94948c;
-  --border: #34342f;
+  --muted: #a3a39b;
+  --faint: #82827b;
+  --border: #30302d;
   --border-strong: #4a4a44;
   --focus: var(--color-ember);
   --accent: var(--color-ember);
@@ -661,27 +589,18 @@
   /* ---------------------------------------------------------------- Colour */
 
   /*
-   * Surfaces. `--chrome` fills the application frame — the sidebar and the page
-   * title bar — and Pure Paper is the content area under it. `--raised` is what
-   * floats above that content, which `DESIGN.md` names as menus, dialogs, and
-   * side sheets, so shadcn's `popover` is that surface.
-   *
-   * **`card` is not, and the split is the one thing to keep straight here.**
-   * `DESIGN.md`, Elevation: "Tables, sidebars, topbars, inputs, search boxes,
-   * and ordinary cards do not float. They carry a hairline and nothing else."
-   * A card wearing the raised fill would be a panel claiming a layer it does
-   * not have — visible the moment dark theme lifts that fill off the page.
+   * Surfaces. Neutral Paper is the canvas; Pure Paper is what is raised off it,
+   * which `DESIGN.md` names as menus, dialogs, and form groups — so shadcn's
+   * `card` and `popover` are both that one surface.
    */
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --color-chrome: var(--chrome);
   --color-surface: var(--surface);
-  --color-raised: var(--raised);
   --color-surface-soft: var(--surface-soft);
   --color-surface-active: var(--surface-active);
   --color-card: var(--surface);
   --color-card-foreground: var(--foreground);
-  --color-popover: var(--raised);
+  --color-popover: var(--surface);
   --color-popover-foreground: var(--foreground);
 
   /*


### PR DESCRIPTION
Backs out [#270](https://github.com/egma-ai/egma/pull/270) in full, at the developer's request.

`git revert -m 1 e009a878`. The resulting tree is byte-identical to `970d767c`, the commit before #270 merged — verified with an empty `git diff` against it.

## What comes back out

- the `--chrome` and `--raised` tokens
- chrome fills on the sidebar, page title bar, mobile bar, drawer and Settings rail
- the table column header treatment, on every table and on the stacked mobile labels
- the dark surface and text values, including the tertiary text lift
- the access page ground
- the three rules #270 wrote into `DESIGN.md`

## Why

A design decision reversed, not a defect. Nothing failed: CI was green on the branch and on `main`, the one Greptile P2 was fixed before the merge, and the deploy completed.

The design boards are untouched — Paper page `09 — Gray chrome variations` still holds V1b and the six other whole-screen treatments, plus the seven table-header options. None of that work is lost if the idea comes back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790564221&installation_model_id=431960&pr_number=271&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F271&signature=b59b8b09c732295459afaa77fdd7a3d71b8e0acdb8b48fd0208bb6f9e0fee9ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fully reverts the gray-chrome design change and restores the web application to its pre-#270 visual system.

- Removes the `--chrome` and `--raised` theme tokens and coordinates all consumers onto the prior surface tokens.
- Restores the previous shell, sidebar, Settings navigation, dialog, sheet, toast, skeleton, and access-page treatments.
- Restores the previous desktop table headers and stacked mobile labels.
- Removes the corresponding gray-chrome rules from `DESIGN.md`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it consistently restores the complete pre-#270 design state without leaving mismatched APIs or theme-token references.

The theme-token removals are coordinated across consumers, table semantics and responsive labels remain intact, shell behavior is unchanged beyond presentation, and the resulting tree matches the commit immediately preceding the reverted design change.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/ui/tailwind-theme.css | Removes the gray-chrome and raised-surface token system while retaining valid light- and dark-theme mappings for every restored utility. |
| apps/web/ui/shell.tsx | Restores the prior sidebar, page, and mobile top-bar surfaces without changing responsive navigation or layout behavior. |
| apps/web/components/ui/table.tsx | Restores the prior table-header typography and surface treatment without altering table semantics or interaction behavior. |
| apps/web/ui/data-table.tsx | Restores the previous stacked mobile-label presentation while preserving labels, responsive structure, and action-column alignment. |
| DESIGN.md | Removes the three gray-chrome design rules so the documented system again matches the restored implementation. |

<sub>Reviews (1): Last reviewed commit: ["revert: back out the gray chrome change ..."](https://github.com/egma-ai/egma/commit/d835baf80d8cd91c8c7cc584c4d1a9be5c65f0b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58149584)</sub>

<!-- /greptile_comment -->