### PR TITLE
Lift dark tertiary text to clear AA

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -124,6 +124,7 @@ Egma uses neutral paper surfaces and one orange-red brand family. Routine produc
 
 - Dark theme uses neutral dark surfaces and the same Ember focus and action family, lightened where a dark surface needs it. The primary action's text is Ember pulled towards paper rather than Deep Ember: Deep Ember on the dark Ember Wash is 2.69:1 and fails AA, and the lighter step is 5.26:1. (Developer decision, 2026-08-23.)
 - Dense evidence may use a dark contained surface in either theme.
+- **Measure quiet text on the raised surface, not on the canvas.** Dark theme has two grounds, and the lighter one is the harder test. The tertiary text colour was `#82827b`, which measured 4.73:1 on the canvas and passed, but 4.46:1 on a table panel, a form group or a menu — and failed. That is where a timestamp, a hint and an empty-state line are actually drawn. The value is `#94948c` now: 5.98:1 on the canvas, 5.64:1 on the raised surface, still a step below the secondary colour at 6.79:1. (Measured 2026-08-28. This enforces the AA rule under **Accessibility** rather than adding one.)
 - Every shared component must support light and dark themes.
 - Verify text, borders, focus, status, overlays, and disabled states in both themes.
 

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -452,7 +452,27 @@
   --surface-active: #43241c;
   --foreground: #f2f2ed;
   --muted: #a3a39b;
-  --faint: #82827b;
+  /*
+   * Lifted from `#82827b`, which failed AA on the surface it is most often
+   * drawn on.
+   *
+   * The tertiary step has two grounds in dark theme and they are not the same
+   * test. On the canvas, `#151514`, the old value measured 4.73:1 and passed.
+   * On the raised surface, `#1b1b1a` — a table panel, a form group, a menu —
+   * it measured **4.46:1 and failed**, and that is where a timestamp, a hint
+   * and an empty-state line actually live. A value that passes on the page and
+   * fails inside every panel on it is a value that fails.
+   *
+   * `#94948c` measures 5.98:1 on the canvas and 5.64:1 on the raised surface,
+   * so the worst ground now clears AA with room rather than by a rounding
+   * step. It stays a step below `--muted`, which is 6.79:1 on the same ground:
+   * the three-level hierarchy is what it was, one rung less quiet at the
+   * bottom.
+   *
+   * Light theme was measured too and did not move — its `--faint` is 5.33:1 on
+   * Pure Paper.
+   */
+  --faint: #94948c;
   --border: #30302d;
   --border-strong: #4a4a44;
   --focus: var(--color-ember);


### PR DESCRIPTION
One value. `--faint` in dark theme: `#82827b` → `#94948c`.

## The bug

Dark theme has two grounds and they are not the same test.

| ground | old `#82827b` | new `#94948c` |
| --- | --- | --- |
| canvas `#151514` | 4.73:1 — passes | 5.98:1 |
| raised surface `#1b1b1a` | **4.46:1 — fails AA** | 5.64:1 |

The old value passed on the page and failed inside every panel on that page. The raised surface is where the tertiary step actually gets used — a timestamp, a field hint, an empty-state line — so it failed where it mattered and passed where it did not.

`--muted` on the same raised ground is 6.79:1, so the new value stays a clear step below it. The three-level hierarchy is unchanged.

Light theme was measured and did not move: `--faint` is 5.33:1 on Pure Paper.

## Scope

`DESIGN.md` already says "Meet WCAG AA text contrast" under Accessibility. This enforces that rule; it adds none. Found while measuring during #270 and kept out of the revert deliberately, because it is not a design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790564965&installation_model_id=431960&pr_number=272&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F272&signature=b28fb697cb8fe4a72cde39a53969df026a256cef03a27acc4cd725608c50b697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR raises the dark-theme tertiary text color to meet WCAG AA contrast on raised surfaces while preserving its hierarchy below secondary text.
- Changes dark-theme `--faint` from `#82827b` to `#94948c`.
- Documents the contrast measurements and raised-surface testing requirement in the design guide.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the token change improving dark-theme text contrast and no actionable regressions identified.

The brighter faint token improves contrast on the repository’s dark surfaces, including the raised and active surfaces where tertiary text is used, while remaining visually subordinate to muted text.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/ui/tailwind-theme.css | Updates the dark-theme faint text token to improve contrast across dark canvas, raised, soft, and active surfaces without changing the light theme. |
| DESIGN.md | Documents why quiet dark-theme text must be measured against raised surfaces and records the revised token’s contrast hierarchy. |

<sub>Reviews (1): Last reviewed commit: ["fix(web): lift dark tertiary text to cle..."](https://github.com/egma-ai/egma/commit/1cf149a9c4fdd8c264977474ddb78f713928883f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58151030)</sub>

<!-- /greptile_comment -->