### PR TITLE
Make LiveKit connection modality explicit

### DIFF
--- a/apps/api/test/agents.test.ts
+++ b/apps/api/test/agents.test.ts
@@ -1564,7 +1564,7 @@ describe("a livekit connection", () => {
 
     expect(registered.status).toBe(201);
     expect(connectionOf(registered)).toMatchObject({
-      name: "livekit_room-1",
+      name: "livekit_voice-1",
       agentPlatform: "livekit",
       connectionType: "livekit_room",
       accessVariant: "livekit_room.project_credentials",
@@ -1632,6 +1632,7 @@ describe("a livekit connection", () => {
 
     expect(registered.status).toBe(201);
     expect(connectionOf(registered)).toMatchObject({
+      name: "livekit_chat-1",
       agentPlatform: "livekit",
       connectionType: "livekit_room",
       accessVariant: "livekit_room.project_credentials",

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -2282,18 +2282,23 @@ describe.skipIf(!storage.available)("hearing a recording from a run", () => {
       await page.getByRole("button", { name: /Reschedules/u }).first().waitFor({
         timeout: 30_000,
       });
-      await page.getByRole("tab", { name: "Transcript & audio" }).click();
+      await page.getByRole("tab", { name: "Transcript", exact: true }).click();
       // The inline transcript tab comes off the same answer a player would
       // have, so waiting for it is waiting for the read that could contradict
       // the absence below.
       const evidence = page.getByRole("tabpanel", {
-        name: "Transcript & audio",
+        name: "Transcript",
+        exact: true,
       });
       await evidence
         .getByRole("heading", { name: "Conversation", exact: true })
         .waitFor();
 
       expect(await page.locator("audio").count()).toBe(0);
+      expect(
+        await evidence.getByRole("heading", { name: "Recording" }).count(),
+        "a chat does not offer a recording section",
+      ).toBe(0);
       // Not even the line that says a recording is being looked for, which is
       // the one thing on this path that could momentarily imply there is one.
       expect(await page.locator("body").innerText()).not.toContain(
@@ -3160,6 +3165,11 @@ describe("the complete product, walked in order in a second project", () => {
       // the next screen asks for. This walk is the voice one.
       await walk.getByRole("radio", { name: /^Voice/u }).click();
       await walk.getByRole("button", { name: "Continue" }).click();
+      await walk
+        .getByRole("heading", {
+          name: "Connect LiveKit Voice for simulations",
+        })
+        .waitFor();
 
       const deployedName = "appointment-scheduling-langsmith";
       await walk.fill("#livekit-agent-name", deployedName);
@@ -3198,10 +3208,13 @@ describe("the complete product, walked in order in a second project", () => {
       const stored = await instance.database.sql<{
         agent_name: string;
         agent_platform: string;
+        connection_name: string;
         access_variant: string;
+        modality: string;
         config: Record<string, unknown>;
       }>(
-        `select a.name as agent_name, a.agent_platform, c.access_variant, c.config
+        `select a.name as agent_name, a.agent_platform, c.name as connection_name,
+                c.access_variant, c.modality, c.config
            from agent a
            join connection c on c.agent_id = a.id
           where a.project_id = '${second}' and a.name = '${deployedName}'`,
@@ -3210,7 +3223,9 @@ describe("the complete product, walked in order in a second project", () => {
         {
           agent_name: deployedName,
           agent_platform: "livekit",
+          connection_name: "livekit_voice-1",
           access_variant: "livekit_room.project_credentials",
+          modality: "voice",
           config: {
             agentName: deployedName,
             url: "wss://browser-test.livekit.cloud",
@@ -3562,7 +3577,7 @@ describe("the complete product, walked in order in a second project", () => {
       await walk.selectOption("#run-agent", { label: "The Support line" });
       await walk.waitForSelector("#run-connection");
       await walk.selectOption("#run-connection", {
-        label: "phone_number-1",
+        label: "phone_number-1 · Voice",
       });
 
       expect(await runBuilder.innerText()).toContain(

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -302,7 +302,7 @@ status: connected
 
 ```
 egma/
-  config.yaml     format 2 platform, project, agents, and connections
+  config.yaml     format 3 platform, project, agents, and connection modalities
   mock-tools.md   what Egma answers for the agent's tools with
   tests/
     release/      one local directory per suite
@@ -321,7 +321,7 @@ are code your team reviews in pull requests.
 each agent can name many connections:
 
 ```yaml
-format: 2
+format: 3
 platform:
   origin: https://app.egma.ai
 project:
@@ -332,18 +332,21 @@ agents:
     name: Front desk
     connections:
       - id: con_01K3XQ7M4E8YB2FVN0H9TZQWER
-        name: livekit-1
+        name: livekit_voice-1
+        modality: voice
       - id: con_01K3XQ7M4E8YB2FVN0H9TZQWES
         name: phone_number-1
+        modality: voice
   - id: agt_01K3XQ7M4E8YB2FVN0H9TZQWES
     name: After hours
     connections: []
 ```
 
-Format 2 is required. The former top-level `agent` and `connection` fields are
-refused; this CLI has no legacy reader or compatibility alias. Run the wizard
-again to add another target or another suite. It keeps the agents, connections,
-and suite directories that are already present.
+Format 3 is required. Every connection records `modality: chat` or
+`modality: voice`. Older folder formats are refused; this CLI has no legacy
+reader or compatibility alias. Run the wizard again to add another target or
+another suite. It keeps the agents, connections, and suite directories that are
+already present.
 
 Create a suite with `egma suite create release --name "Release contract"`.
 Egma creates the platform record first, then writes exactly:
@@ -509,7 +512,7 @@ more than one runnable agent or more than one connection under the selected
 agent, name them exactly:
 
 ```sh
-egma run order-line-tests --agent "Front desk" --connection livekit-1
+egma run order-line-tests --agent "Front desk" --connection livekit_voice-1
 ```
 
 It pins the version of every test it runs, prints every change as it lands, and

--- a/apps/cli/skills/egma/SKILL.md
+++ b/apps/cli/skills/egma/SKILL.md
@@ -30,7 +30,7 @@ The folder has this shape:
 
 ```text
 egma/
-  config.yaml     format 2 platform, project, agents, and connections
+  config.yaml     format 3 platform, project, agents, and connection modalities
   mock-tools.md   what Egma answers for the agent's tools with
   tests/
     release/      one local directory per suite
@@ -44,7 +44,7 @@ egma/
 The config hierarchy is:
 
 ```yaml
-format: 2
+format: 3
 platform:
   origin: https://app.egma.ai
 project:
@@ -55,14 +55,16 @@ agents:
     name: Front desk
     connections:
       - id: con_...
-        name: livekit-1
+        name: livekit_voice-1
+        modality: voice
   - id: agt_...
     name: After hours
     connections: []
 ```
 
-Format 2 is strict. The CLI has no reader, migration, or alias for the former
-top-level `agent` and `connection` fields. Report that refusal as written.
+Format 3 is strict. Every connection has `modality: chat` or `modality: voice`.
+The CLI has no reader, migration, or alias for an older folder format. Report
+that refusal as written.
 
 When the developer asks to onboard or extend the repository, run the wizard.
 It authorizes the CLI before it discovers installed coding agents. The first

--- a/apps/cli/src/commands/connect.ts
+++ b/apps/cli/src/commands/connect.ts
@@ -362,6 +362,7 @@ export async function runConnectCommand(options: ConnectCommandOptions): Promise
         connection: {
           name: registered.connection.name,
           id: registered.connection.id,
+          modality: registered.connection.modality,
         },
       });
       options.out(`retell_agents: ${outcome.onTheAccount}`);

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -57,7 +57,8 @@ function reportTargetRefusal(options: RunCommandOptions, refusal: RefusedTarget)
     options.out(`agent-option: ${agent.id} ${agent.name}`);
   }
   for (const connection of refusal.connections) {
-    options.out(`connection-option: ${connection.id} ${connection.name}`);
+    const modality = connection.modality === "chat" ? "Chat" : "Voice";
+    options.out(`connection-option: ${connection.id} ${connection.name} (${modality})`);
   }
   options.out(`status: ${refusal.status}`);
   options.fail(refusal.message);

--- a/apps/cli/src/folder/egma-folder.ts
+++ b/apps/cli/src/folder/egma-folder.ts
@@ -86,7 +86,10 @@ export type IdentifiedThing = {
 };
 
 /** One committed way Egma can reach an agent. */
-export type FolderConnection = IdentifiedThing;
+export type FolderConnection = IdentifiedThing & {
+  /** Whether this connection carries typed turns or spoken audio. */
+  readonly modality: "chat" | "voice";
+};
 
 /** One agent in this project, and every committed way Egma can reach it. */
 export type FolderAgent = IdentifiedThing & {
@@ -110,7 +113,7 @@ export type FolderConfig = {
   readonly agents: readonly FolderAgent[];
 };
 
-export const CONFIG_FORMAT = 2 as const;
+export const CONFIG_FORMAT = 3 as const;
 
 export const EMPTY_CONFIG: FolderConfig = {
   format: CONFIG_FORMAT,
@@ -121,6 +124,7 @@ export const EMPTY_CONFIG: FolderConfig = {
 
 const ROOT_CONFIG_KEYS = ["format", "platform", "project", "agents"] as const;
 const NAMED_KEYS = ["id", "name"] as const;
+const CONNECTION_KEYS = [...NAMED_KEYS, "modality"] as const;
 const AGENT_KEYS = [...NAMED_KEYS, "connections"] as const;
 
 const CONFIG_HEADER = [
@@ -160,6 +164,7 @@ export function serializeConfig(config: FolderConfig): string {
       for (const connection of agent.connections) {
         lines.push(`      - id: ${yamlScalar(connection.id)}`);
         lines.push(`        name: ${yamlScalar(connection.name)}`);
+        lines.push(`        modality: ${connection.modality}`);
       }
     }
   }
@@ -179,8 +184,12 @@ function unsupportedKeys(
   }
 }
 
-function identifiedThing(mapping: YamlMapping, where: string): IdentifiedThing {
-  unsupportedKeys(mapping, NAMED_KEYS, where);
+function identifiedThing(
+  mapping: YamlMapping,
+  where: string,
+  supported: readonly string[] = NAMED_KEYS,
+): IdentifiedThing {
+  unsupportedKeys(mapping, supported, where);
   const id = textAt(mapping, "id");
   const name = textAt(mapping, "name");
   if (id === null || name === null) {
@@ -190,6 +199,18 @@ function identifiedThing(mapping: YamlMapping, where: string): IdentifiedThing {
     throw new Error(`${where} has outer whitespace in its id or name.`);
   }
   return { id, name };
+}
+
+function identifiedConnection(
+  mapping: YamlMapping,
+  where: string,
+): FolderConnection {
+  const connection = identifiedThing(mapping, where, CONNECTION_KEYS);
+  const modality = textAt(mapping, "modality");
+  if (modality !== "chat" && modality !== "voice") {
+    throw new Error(`${where} must contain modality chat or voice.`);
+  }
+  return { ...connection, modality };
 }
 
 /**
@@ -297,10 +318,10 @@ export function parseConfig(document: string, where: string): FolderConfig {
     ).entries()) {
       if (typeof connectionEntry !== "object") {
         throw new Error(
-          `${where} agent ${agent.id} connection ${String(connectionIndex + 1)} must contain id and name.`,
+          `${where} agent ${agent.id} connection ${String(connectionIndex + 1)} must contain id, name, and modality.`,
         );
       }
-      const connection = identifiedThing(
+      const connection = identifiedConnection(
         connectionEntry,
         `${where} agent ${agent.id} connection ${String(connectionIndex + 1)}`,
       );
@@ -353,7 +374,7 @@ export type RegisteredTarget = {
   readonly project?: IdentifiedThing;
   readonly agent: IdentifiedThing;
   /** Omitted for an agent configured only for production monitoring. */
-  readonly connection?: IdentifiedThing;
+  readonly connection?: FolderConnection;
 };
 
 /**

--- a/apps/cli/src/folder/target-selection.ts
+++ b/apps/cli/src/folder/target-selection.ts
@@ -97,7 +97,7 @@ function chooseAgent(
   if (selected === null && runnable.length === 0 && agents.length !== 1) {
     return refused(
       "not-connected",
-      "This folder does not name any voice agent with a connection. Run egma connect here first. Nothing was started.",
+      "This folder does not name any agent with a connection. Run egma connect here first. Nothing was started.",
       agents,
     );
   }
@@ -109,25 +109,25 @@ function chooseAgent(
     case "ambiguous":
       return refused(
         "ambiguous-agent",
-        `${JSON.stringify(selected)} exactly matches more than one configured voice agent. Use its stable agent id with --agent. Nothing was started.`,
+        `${JSON.stringify(selected)} exactly matches more than one configured agent. Use its stable agent id with --agent. Nothing was started.`,
         choice.choices,
       );
     case "unknown":
       return refused(
         "unknown-agent",
-        `No configured voice agent exactly matches ${JSON.stringify(selected)}. Choose one with --agent <name-or-id>. Nothing was started.`,
+        `No configured agent exactly matches ${JSON.stringify(selected)}. Choose one with --agent <name-or-id>. Nothing was started.`,
         choice.choices,
       );
     case "unchosen":
       return refused(
         "unchosen-agent",
-        `This folder names ${String(choice.choices.length)} voice agents that can run. Choose one with --agent <name-or-id>. Nothing was started.`,
+        `This folder names ${String(choice.choices.length)} agents that can run. Choose one with --agent <name-or-id>. Nothing was started.`,
         choice.choices,
       );
     case "none":
       return refused(
         "not-connected",
-        "This folder does not name any voice agent with a connection. Run egma connect here first. Nothing was started.",
+        "This folder does not name any agent with a connection. Run egma connect here first. Nothing was started.",
         agents,
       );
   }

--- a/apps/cli/src/livekit/connect.ts
+++ b/apps/cli/src/livekit/connect.ts
@@ -28,7 +28,7 @@ type CommonRegistration = {
   /** The agent's name in Egma. */
   readonly name: string;
   readonly project?: string | undefined;
-  /** Omit and the platform chooses `livekit-1`. */
+  /** Omit and the platform chooses `livekit_chat-1` or `livekit_voice-1`. */
   readonly connectionName?: string | undefined;
   readonly environment?: string | undefined;
   /** The customer's LiveKit Cloud project or self-hosted server. */

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -483,7 +483,7 @@ export function helpText(): string {
     "",
     "The wizard signs this machine in before it looks for supported coding agents.",
     "Its first generated suite has four tests. Run the wizard again to add another target or suite.",
-    "egma/config.yaml requires format 2 with agents and nested connections; there is no legacy reader.",
+    "egma/config.yaml requires format 3 with each nested connection's modality; there is no legacy reader.",
   ].join("\n");
 }
 

--- a/apps/cli/src/platform/agents.ts
+++ b/apps/cli/src/platform/agents.ts
@@ -75,7 +75,7 @@ export type RegisteredConnection = {
   readonly agentPlatform: string | null;
   readonly connectionType: string;
   readonly accessVariant: string;
-  readonly modality: string;
+  readonly modality: ConnectionInput["modality"];
   readonly productLabel: string;
   /** The last characters of the sealed secret, which is all that comes back. */
   readonly credentialsHint: string | null;
@@ -178,7 +178,7 @@ function cleanConnection(connection: AnsweredConnection): RegisteredConnection {
       connection.agentPlatform === null ? null : platformText(connection.agentPlatform),
     connectionType: platformText(connection.connectionType),
     accessVariant: platformText(connection.accessVariant),
-    modality: platformText(connection.modality),
+    modality: connection.modality,
     productLabel: platformText(connection.productLabel),
     credentialsHint:
       connection.credentialsHint === null

--- a/apps/cli/src/wizard/exit-line.ts
+++ b/apps/cli/src/wizard/exit-line.ts
@@ -302,7 +302,7 @@ export function buildExitLine(report: ExitReport): string {
     case "run-started":
       return runStartedLine(report.resultsReady, report.total);
     case "connected":
-      return `Egma connected your voice agent: ${report.agentName}, over ${report.connectionName}.`;
+      return `Egma connected your agent: ${report.agentName}, over ${report.connectionName}.`;
     case "tests-pushed":
       return report.count === 1
         ? `Egma put 1 test on Egma and left it in ${TESTS_FOLDER} — commit it, edit it, then run egma push.`

--- a/apps/cli/src/wizard/generate-step.ts
+++ b/apps/cli/src/wizard/generate-step.ts
@@ -394,6 +394,7 @@ async function folderFor(options: GenerateStepOptions): Promise<GeneratedSuite> 
   const connection = {
     name: options.registered.connection.name,
     id: options.registered.connection.id,
+    modality: options.registered.connection.modality,
   };
   const project = await readProject(
     options.signedIn,

--- a/apps/cli/test/connect-command.test.ts
+++ b/apps/cli/test/connect-command.test.ts
@@ -201,7 +201,7 @@ describe("egma connect", () => {
     // The same four things the wizard's own walk writes, so a repository
     // connected by the verb and one connected by the wizard hold one file.
     expect(await readConfig(path.join(workspace.dir, "egma", "config.yaml"))).toEqual({
-      format: 2,
+      format: 3,
       platform: { origin: platform.url },
       project: {
         name: "Fixture project",
@@ -211,7 +211,13 @@ describe("egma connect", () => {
         {
           name: said.agent_name,
           id: said.agent_id,
-          connections: [{ name: said.connection_name, id: said.connection_id }],
+          connections: [
+            {
+              name: said.connection_name,
+              id: said.connection_id,
+              modality: "chat",
+            },
+          ],
         },
       ],
     });
@@ -469,6 +475,7 @@ describe("which connection egma creates", () => {
     expect(written.agents[0]?.connections[0]).toEqual({
       name: "phone_number-1",
       id: said.connection_id,
+      modality: "voice",
     });
     expect(JSON.stringify(written)).not.toContain(KEY);
   });

--- a/apps/cli/test/exit-line.test.ts
+++ b/apps/cli/test/exit-line.test.ts
@@ -178,6 +178,14 @@ describe("the exit line", () => {
     );
 
     expect(
+      buildExitLine({
+        kind: "connected",
+        agentName: "chat-worker",
+        connectionName: "livekit_chat-1",
+      }),
+    ).toBe("Egma connected your agent: chat-worker, over livekit_chat-1.");
+
+    expect(
       buildExitLine({ kind: "unsupported-agent-platform", platform: "pipecat" }),
     ).toContain("CLI support is coming soon");
 

--- a/apps/cli/test/folder-config-v3.test.ts
+++ b/apps/cli/test/folder-config-v3.test.ts
@@ -26,10 +26,10 @@ afterEach(async () => {
   workspace = null;
 });
 
-describe("folder config format 2", () => {
+describe("folder config format 3", () => {
   it("round-trips many agents and their connections", () => {
     const config = {
-      format: 2,
+      format: 3,
       platform: { origin: "https://egma.example" },
       project: { id: PROJECT_ID, name: "LiveKit examples" },
       agents: [
@@ -37,8 +37,8 @@ describe("folder config format 2", () => {
           id: FIRST_AGENT_ID,
           name: "Appointment scheduler",
           connections: [
-            { id: FIRST_CONNECTION_ID, name: "livekit-1" },
-            { id: SECOND_CONNECTION_ID, name: "phone_number-1" },
+            { id: FIRST_CONNECTION_ID, name: "livekit-1", modality: "chat" },
+            { id: SECOND_CONNECTION_ID, name: "phone_number-1", modality: "voice" },
           ],
         },
         {
@@ -57,7 +57,7 @@ describe("folder config format 2", () => {
         "#",
         "# Committed on purpose: nothing in this folder is secret. Egma writes an id",
         "# beside each name once it has registered one.",
-        "format: 2",
+        "format: 3",
         "platform:",
         "  origin: https://egma.example",
         "project:",
@@ -69,8 +69,10 @@ describe("folder config format 2", () => {
         "    connections:",
         `      - id: ${FIRST_CONNECTION_ID}`,
         "        name: livekit-1",
+        "        modality: chat",
         `      - id: ${SECOND_CONNECTION_ID}`,
         "        name: phone_number-1",
+        "        modality: voice",
         `  - id: ${SECOND_AGENT_ID}`,
         "    name: Billing support",
         "    connections: []",
@@ -84,20 +86,43 @@ describe("folder config format 2", () => {
     [
       "the former unversioned singleton shape",
       "platform:\nproject:\nagent:\nconnection:\n",
-      /folder format none.*requires format 2.*no legacy reader/i,
+      /folder format none.*requires format 3.*no legacy reader/i,
     ],
     [
-      "another explicit format",
-      "format: 1\nplatform:\nproject:\nagents: []\n",
-      /folder format 1.*requires format 2.*no legacy reader/i,
+      "the former format",
+      "format: 2\nplatform:\nproject:\nagents: []\n",
+      /folder format 2.*requires format 3.*no legacy reader/i,
     ],
   ])("refuses %s", (_name, document, message) => {
     expect(() => parseConfig(document, "config.yaml")).toThrow(message);
   });
 
+  it.each([
+    ["a missing modality", null],
+    ["an unknown modality", "video"],
+  ])("refuses %s on a stored connection", (_name, modality) => {
+    const document = [
+      "format: 3",
+      "platform:",
+      "project:",
+      "agents:",
+      `  - id: ${FIRST_AGENT_ID}`,
+      "    name: One",
+      "    connections:",
+      `      - id: ${FIRST_CONNECTION_ID}`,
+      "        name: First",
+      ...(modality === null ? [] : [`        modality: ${modality}`]),
+      "",
+    ].join("\n");
+
+    expect(() => parseConfig(document, "config.yaml")).toThrow(
+      /must contain modality chat or voice/i,
+    );
+  });
+
   it("refuses duplicate agent and connection identities", () => {
     const duplicateAgent = [
-      "format: 2",
+      "format: 3",
       "platform:",
       "project:",
       "agents:",
@@ -114,7 +139,7 @@ describe("folder config format 2", () => {
     );
 
     const duplicateConnection = [
-      "format: 2",
+      "format: 3",
       "platform:",
       "project:",
       "agents:",
@@ -123,11 +148,13 @@ describe("folder config format 2", () => {
       "    connections:",
       `      - id: ${FIRST_CONNECTION_ID}`,
       "        name: First",
+      "        modality: chat",
       `  - id: ${SECOND_AGENT_ID}`,
       "    name: Two",
       "    connections:",
       `      - id: ${FIRST_CONNECTION_ID}`,
       "        name: Copy",
+      "        modality: voice",
       "",
     ].join("\n");
     expect(() => parseConfig(duplicateConnection, "config.yaml")).toThrow(
@@ -148,7 +175,9 @@ describe("folder config format 2", () => {
         {
           id: FIRST_AGENT_ID,
           name: "Old appointment name",
-          connections: [{ id: FIRST_CONNECTION_ID, name: "old-livekit" }],
+          connections: [
+            { id: FIRST_CONNECTION_ID, name: "old-livekit", modality: "chat" },
+          ],
         },
         {
           id: SECOND_AGENT_ID,
@@ -161,11 +190,19 @@ describe("folder config format 2", () => {
     await recordRegisteredTarget(file, {
       project: { id: PROJECT_ID, name: "LiveKit Examples" },
       agent: { id: FIRST_AGENT_ID, name: "Appointment scheduler" },
-      connection: { id: SECOND_CONNECTION_ID, name: "phone_number-1" },
+      connection: {
+        id: SECOND_CONNECTION_ID,
+        name: "phone_number-1",
+        modality: "voice",
+      },
     });
     const recorded = await recordRegisteredTarget(file, {
       agent: { id: FIRST_AGENT_ID, name: "Appointment scheduler" },
-      connection: { id: SECOND_CONNECTION_ID, name: "phone-production" },
+      connection: {
+        id: SECOND_CONNECTION_ID,
+        name: "phone-production",
+        modality: "voice",
+      },
     });
 
     expect(recorded.project?.name).toBe("LiveKit Examples");
@@ -174,8 +211,8 @@ describe("folder config format 2", () => {
         id: FIRST_AGENT_ID,
         name: "Appointment scheduler",
         connections: [
-          { id: FIRST_CONNECTION_ID, name: "old-livekit" },
-          { id: SECOND_CONNECTION_ID, name: "phone-production" },
+          { id: FIRST_CONNECTION_ID, name: "old-livekit", modality: "chat" },
+          { id: SECOND_CONNECTION_ID, name: "phone-production", modality: "voice" },
         ],
       },
       {
@@ -197,7 +234,9 @@ describe("folder config format 2", () => {
             {
               id: FIRST_AGENT_ID,
               name: "Appointment scheduler",
-              connections: [{ id: FIRST_CONNECTION_ID, name: "livekit-1" }],
+              connections: [
+                { id: FIRST_CONNECTION_ID, name: "livekit-1", modality: "voice" },
+              ],
             },
           ],
         },

--- a/apps/cli/test/intro-screen.test.ts
+++ b/apps/cli/test/intro-screen.test.ts
@@ -74,7 +74,7 @@ async function wizardInBoundRepository(): Promise<TerminalRun> {
   await createEgmaFolder({
     repository: workspace.dir,
     config: {
-      format: 2,
+      format: 3,
       platform: { origin: platform.url },
       project: null,
       agents: [],

--- a/apps/cli/test/livekit-connect.test.ts
+++ b/apps/cli/test/livekit-connect.test.ts
@@ -66,7 +66,7 @@ describe("the key-pair shape", () => {
     expect(result.registered.result).toBe("created");
     expect(result.registered.agent.name).toBe("front-desk");
     expect(result.registered.connection).toMatchObject({
-      name: "livekit_room-1",
+      name: "livekit_voice-1",
       agentPlatform: "livekit",
       connectionType: "livekit_room",
       accessVariant: LIVEKIT_KEY_PAIR_VARIANT,

--- a/apps/cli/test/livekit-wizard.test.ts
+++ b/apps/cli/test/livekit-wizard.test.ts
@@ -1351,7 +1351,7 @@ describe("LiveKit chat in the wizard", () => {
       LIVEKIT_TOKEN_ENDPOINT_VARIANT,
     );
     expect(ui.record.statuses).toContain(
-      "┊ Reachable over livekit_room-1 (LiveKit chat).",
+      "┊ Reachable over livekit_chat-1 (LiveKit chat).",
     );
     expect(JSON.stringify(ui.record.connectionFieldGroups)).not.toContain(
       API_SECRET,
@@ -1461,7 +1461,7 @@ describe("LiveKit chat in the wizard", () => {
       // modality does not read like a second agent.
       expect(two.ui.record.statuses).toContain(
         "┊ This voice agent was already registered as front-desk, so Egma added " +
-          "livekit_room-2 as another way of reaching it. No second agent was registered.",
+          `livekit_${second}-1 as another way of reaching it. No second agent was registered.`,
       );
     },
   );

--- a/apps/cli/test/repository-command-acceptance.test.ts
+++ b/apps/cli/test/repository-command-acceptance.test.ts
@@ -90,6 +90,7 @@ it("creates a suite first, pushes the complete folder atomically, and runs that 
               {
                 id: registered.connection.id,
                 name: registered.connection.name,
+                modality: "chat",
               },
             ],
           },

--- a/apps/cli/test/repository-suite-commands.test.ts
+++ b/apps/cli/test/repository-suite-commands.test.ts
@@ -70,7 +70,7 @@ beforeEach(async () => {
         {
           id: "agt_one",
           name: "Receptionist",
-          connections: [{ id: "con_one", name: "Phone" }],
+          connections: [{ id: "con_one", name: "Phone", modality: "voice" }],
         },
       ],
     },

--- a/apps/cli/test/run-command.test.ts
+++ b/apps/cli/test/run-command.test.ts
@@ -83,7 +83,7 @@ beforeEach(async () => {
         {
           id: "agt_one",
           name: "Receptionist",
-          connections: [{ id: "con_one", name: "Phone" }],
+          connections: [{ id: "con_one", name: "Phone", modality: "voice" }],
         },
       ],
     },
@@ -305,14 +305,14 @@ describe("runRunCommand operational exit behavior", () => {
       {
         id: "agt_one",
         name: "Receptionist",
-        connections: [{ id: "con_one", name: "Phone" }],
+        connections: [{ id: "con_one", name: "Phone", modality: "voice" }],
       },
       {
         id: "agt_two",
         name: "After hours",
         connections: [
-          { id: "con_two", name: "Phone" },
-          { id: "con_three", name: "Chat" },
+          { id: "con_two", name: "Phone", modality: "voice" },
+          { id: "con_three", name: "Chat", modality: "chat" },
         ],
       },
     ]);
@@ -346,7 +346,7 @@ describe("runRunCommand operational exit behavior", () => {
       {
         id: "agt_one",
         name: "Receptionist",
-        connections: [{ id: "con_one", name: "Phone" }],
+        connections: [{ id: "con_one", name: "Phone", modality: "voice" }],
       },
     ]);
 
@@ -380,12 +380,12 @@ describe("runRunCommand operational exit behavior", () => {
       {
         id: "agt_one",
         name: "Receptionist",
-        connections: [{ id: "con_one", name: "Phone" }],
+        connections: [{ id: "con_one", name: "Phone", modality: "voice" }],
       },
       {
         id: "agt_two",
         name: "After hours",
-        connections: [{ id: "con_two", name: "Chat" }],
+        connections: [{ id: "con_two", name: "Chat", modality: "chat" }],
       },
     ]);
 
@@ -397,7 +397,7 @@ describe("runRunCommand operational exit behavior", () => {
     expect(answer.lines).toContain("agent-option: agt_two After hours");
     expect(answer.lines).toContain("status: unchosen-agent");
     expect(answer.lines).toContain(
-      "stderr: This folder names 2 voice agents that can run. Choose one with --agent <name-or-id>. Nothing was started.",
+      "stderr: This folder names 2 agents that can run. Choose one with --agent <name-or-id>. Nothing was started.",
     );
   });
 
@@ -407,8 +407,8 @@ describe("runRunCommand operational exit behavior", () => {
         id: "agt_one",
         name: "Receptionist",
         connections: [
-          { id: "con_one", name: "Phone" },
-          { id: "con_two", name: "Chat" },
+          { id: "con_one", name: "Primary", modality: "voice" },
+          { id: "con_two", name: "Primary", modality: "chat" },
         ],
       },
     ]);
@@ -417,8 +417,8 @@ describe("runRunCommand operational exit behavior", () => {
 
     expect(answer.code).toBe(1);
     expect(answer.startedWith).toBeNull();
-    expect(answer.lines).toContain("connection-option: con_one Phone");
-    expect(answer.lines).toContain("connection-option: con_two Chat");
+    expect(answer.lines).toContain("connection-option: con_one Primary (Voice)");
+    expect(answer.lines).toContain("connection-option: con_two Primary (Chat)");
     expect(answer.lines).toContain("status: unchosen-connection");
     expect(answer.lines).toContain(
       'stderr: Agent "Receptionist" has 2 connections. Choose one with --connection <name-or-id>. Nothing was started.',
@@ -430,12 +430,12 @@ describe("runRunCommand operational exit behavior", () => {
       {
         id: "agt_one",
         name: "Receptionist",
-        connections: [{ id: "con_one", name: "Phone" }],
+        connections: [{ id: "con_one", name: "Phone", modality: "voice" }],
       },
       {
         id: "agt_two",
         name: "After hours",
-        connections: [{ id: "con_two", name: "Chat" }],
+        connections: [{ id: "con_two", name: "Chat", modality: "chat" }],
       },
     ]);
 
@@ -443,8 +443,8 @@ describe("runRunCommand operational exit behavior", () => {
 
     expect(answer.code).toBe(1);
     expect(answer.startedWith).toBeNull();
-    expect(answer.lines).toContain("connection-option: con_one Phone");
-    expect(answer.lines).not.toContain("connection-option: con_two Chat");
+    expect(answer.lines).toContain("connection-option: con_one Phone (Voice)");
+    expect(answer.lines).not.toContain("connection-option: con_two Chat (Chat)");
     expect(answer.lines).toContain("status: unknown-connection");
   });
 
@@ -453,12 +453,12 @@ describe("runRunCommand operational exit behavior", () => {
       {
         id: "agt_one",
         name: "Receptionist",
-        connections: [{ id: "con_one", name: "Primary" }],
+        connections: [{ id: "con_one", name: "Primary", modality: "voice" }],
       },
       {
         id: "agt_two",
         name: "Receptionist",
-        connections: [{ id: "con_two", name: "Primary" }],
+        connections: [{ id: "con_two", name: "Primary", modality: "chat" }],
       },
     ]);
 
@@ -475,8 +475,8 @@ describe("runRunCommand operational exit behavior", () => {
         id: "agt_one",
         name: "Receptionist",
         connections: [
-          { id: "con_one", name: "Primary" },
-          { id: "con_two", name: "Primary" },
+          { id: "con_one", name: "Primary", modality: "voice" },
+          { id: "con_two", name: "Primary", modality: "chat" },
         ],
       },
     ]);
@@ -485,8 +485,8 @@ describe("runRunCommand operational exit behavior", () => {
     expect(connection.code).toBe(1);
     expect(connection.startedWith).toBeNull();
     expect(connection.lines).toContain("status: ambiguous-connection");
-    expect(connection.lines).toContain("connection-option: con_one Primary");
-    expect(connection.lines).toContain("connection-option: con_two Primary");
+    expect(connection.lines).toContain("connection-option: con_one Primary (Voice)");
+    expect(connection.lines).toContain("connection-option: con_two Primary (Chat)");
   });
 
   it("ignores monitoring-only agents when one runnable target remains", async () => {
@@ -495,7 +495,7 @@ describe("runRunCommand operational exit behavior", () => {
       {
         id: "agt_one",
         name: "Receptionist",
-        connections: [{ id: "con_one", name: "Phone" }],
+        connections: [{ id: "con_one", name: "Phone", modality: "voice" }],
       },
     ]);
 

--- a/apps/cli/test/skills.test.ts
+++ b/apps/cli/test/skills.test.ts
@@ -164,7 +164,7 @@ describe("Egma's instruction content", () => {
   it("agrees with the README about the repository folder", () => {
     const layout = [
       "egma/",
-      "  config.yaml     format 2 platform, project, agents, and connections",
+      "  config.yaml     format 3 platform, project, agents, and connection modalities",
       "  mock-tools.md   what Egma answers for the agent's tools with",
       "  tests/",
       "    release/      one local directory per suite",

--- a/apps/cli/test/suite-repository.test.ts
+++ b/apps/cli/test/suite-repository.test.ts
@@ -217,7 +217,7 @@ describe("the complete suite repository", () => {
     );
 
     await expect(readRepository(folderPathsIn(workspace.dir))).rejects.toThrow(
-      /config\.yaml.*folder format none.*requires format 2.*no legacy reader/i,
+      /config\.yaml.*folder format none.*requires format 3.*no legacy reader/i,
     );
   });
 

--- a/apps/cli/test/support/fixture-platform/agents.ts
+++ b/apps/cli/test/support/fixture-platform/agents.ts
@@ -1275,14 +1275,21 @@ export function agentRoutes(options: {
   const freeConnectionName = (
     agentId: string,
     connectionType: string,
+    modality: string,
   ): string => {
     const taken = new Set(
       connections
         .filter((held) => held.agentId === agentId)
         .map((held) => held.name),
     );
+    const stem =
+      connectionType === "livekit_room"
+        ? modality === "chat"
+          ? "livekit_chat"
+          : "livekit_voice"
+        : connectionType;
     for (let n = 1; ; n += 1) {
-      const candidate = `${connectionType}-${n}`;
+      const candidate = `${stem}-${n}`;
       if (!taken.has(candidate)) return candidate;
     }
   };
@@ -1387,7 +1394,8 @@ export function agentRoutes(options: {
     input: Admitted,
   ): StoredConnection => {
     const { connectionType, modality, config, credentials } = input;
-    const name = input.name ?? freeConnectionName(agent.id, connectionType);
+    const name =
+      input.name ?? freeConnectionName(agent.id, connectionType, modality);
     if (
       connections.some(
         (held) => held.agentId === agent.id && held.name === name,

--- a/apps/cli/test/unusable-keys.test.ts
+++ b/apps/cli/test/unusable-keys.test.ts
@@ -46,7 +46,11 @@ beforeEach(async () => {
           name: "receptionist",
           id: "agt_01K3XQ7M4E8YB2FVN0H9TZQWER",
           connections: [
-            { name: "retell-1", id: "con_01K3XQ7M4E8YB2FVN0H9TZQWES" },
+            {
+              name: "retell-1",
+              id: "con_01K3XQ7M4E8YB2FVN0H9TZQWES",
+              modality: "chat",
+            },
           ],
         },
       ],

--- a/apps/cli/test/wizard-monitoring.test.ts
+++ b/apps/cli/test/wizard-monitoring.test.ts
@@ -488,7 +488,7 @@ describe("choosing monitoring on Retell", () => {
     expect(config.agents).toHaveLength(1);
     expect(config.agents[0]?.connections).toEqual([]);
     expect(config).toMatchObject({
-      format: 2,
+      format: 3,
       platform: { origin: platform.url },
       project: { id: platform.registered.agents[0]?.projectId },
       agents: [
@@ -670,7 +670,7 @@ describe("choosing monitoring on LiveKit", () => {
     expect(config.agents).toHaveLength(1);
     expect(config.agents[0]?.connections).toEqual([]);
     expect(config).toMatchObject({
-      format: 2,
+      format: 3,
       platform: { origin: platform.url },
       project: { id: platform.registered.agents[0]?.projectId },
       agents: [

--- a/apps/web/app/projects/[projectId]/agents/agent-details-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/agents/agent-details-sheet.tsx
@@ -13,7 +13,10 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import type { Refusal } from "@/lib/api.ts";
-import type { ListedAgentWithConnections } from "@/lib/agents.ts";
+import {
+  modalityLabel,
+  type ListedAgentWithConnections,
+} from "@/lib/agents.ts";
 import { cn } from "@/lib/utils";
 import { Failure, Loading, NotFound } from "@/ui/page-state.tsx";
 import { RelativeInstant } from "@/ui/relative-time.tsx";
@@ -245,8 +248,13 @@ export function AgentDetailsSheet({
                     className="flex min-w-0 items-center justify-between gap-3 border-t border-border px-4 py-3 first:border-t-0"
                     key={connection.id}
                   >
-                    <span className="min-w-0 truncate text-sm text-foreground">
-                      {connection.name}
+                    <span className="flex min-w-0 flex-col text-sm">
+                      <span className="truncate text-foreground">
+                        {connection.name}
+                      </span>
+                      <span className="text-faint">
+                        {modalityLabel(connection.modality)}
+                      </span>
                     </span>
                     <Link
                       className="flex-none text-sm underline decoration-border underline-offset-4 pointer-hover:decoration-foreground"
@@ -460,6 +468,16 @@ type Fact = {
   readonly mono?: boolean;
 };
 
+function sharedConnectionValue(
+  values: readonly string[],
+  whenEmpty: string,
+): string {
+  const distinct = new Set(values);
+  if (distinct.size === 0) return whenEmpty;
+  if (distinct.size > 1) return "Varies by connection";
+  return values[0] ?? whenEmpty;
+}
+
 function providerFacts(
   agent: ListedAgentWithConnections,
   provider: AgentProvider,
@@ -482,28 +500,39 @@ function providerFacts(
     ];
   }
 
-  const room = agent.connections.find(
+  const rooms = agent.connections.filter(
     (connection) => connection.connectionType === "livekit_room",
   );
-  const liveKitAgentName = room?.config["agentName"];
+  const liveKitAgentName = sharedConnectionValue(
+    rooms.map(
+      (connection) =>
+        connection.config["agentName"] ??
+        (connection.accessVariant === "livekit_room.customer_token_endpoint"
+          ? "Provided by token endpoint"
+          : "Not set"),
+    ),
+    "Not set",
+  );
+  const webSocketUrl = sharedConnectionValue(
+    rooms.map((connection) => connection.config["url"] ?? "Not saved"),
+    "Not saved",
+  );
   return [
     {
       label: "LiveKit agent",
-      value:
-        liveKitAgentName ??
-        (room?.accessVariant === "livekit_room.customer_token_endpoint"
-          ? "Provided by token endpoint"
-          : "Not set"),
-      mono: liveKitAgentName !== undefined,
+      value: liveKitAgentName,
+      mono:
+        rooms.length > 0 &&
+        rooms.every(
+          (connection) => connection.config["agentName"] === liveKitAgentName,
+        ),
     },
     {
       label: "WebSocket URL",
-      value: room?.config["url"] ?? "Not saved",
-      mono: room?.config["url"] !== undefined,
-    },
-    {
-      label: "Access",
-      value: room?.productLabel ?? "Not configured",
+      value: webSocketUrl,
+      mono:
+        rooms.length > 0 &&
+        rooms.every((connection) => connection.config["url"] === webSocketUrl),
     },
   ];
 }

--- a/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
@@ -28,7 +28,10 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import type { Answer, Refusal } from "@/lib/api.ts";
-import type { ListedAgentWithConnections } from "@/lib/agents.ts";
+import {
+  modalityLabel,
+  type ListedAgentWithConnections,
+} from "@/lib/agents.ts";
 import {
   optionNamed,
   optionsForPlatform,
@@ -1423,7 +1426,11 @@ function LiveKitSimulationStep({
   return (
     <div className="flex flex-col gap-5">
       <StepIntro
-        title="Connect LiveKit for simulations"
+        title={
+          option === undefined
+            ? "Connect LiveKit for simulations"
+            : `Connect LiveKit ${modalityLabel(option.modality)} for simulations`
+        }
         description={
           endpoint
             ? "Egma requests a short-lived room token from your endpoint for every simulation."

--- a/apps/web/app/projects/[projectId]/agents/connection-facts.tsx
+++ b/apps/web/app/projects/[projectId]/agents/connection-facts.tsx
@@ -33,24 +33,6 @@ import { connectionsOnRow, type ListedConnection } from "@/lib/agents.ts";
  */
 
 /**
- * What a person is shown for a channel.
- *
- * Two values, and the words are the product's rather than the API's: a
- * connection's modality is `voice` or `chat`, and a person reading a list is
- * shown Voice or Chat. The connection sheet draws them that way, and these
- * surfaces say the same words rather than inventing a third pair.
- *
- * **It said Text until #158**, which made Retell a Chat connection and renamed
- * the word on the connection page and in the new-connection form. The rename
- * arrives here because saying "the same words" is the whole reason this
- * function exists: leaving it behind would have produced exactly the third
- * pair the paragraph above refuses.
- */
-export function modalityLabel(modality: string): string {
-  return modality === "voice" ? "Voice" : "Chat";
-}
-
-/**
  * Every way into one agent, or the fact that there is none.
  *
  * **"No connections yet" is a state of the agent, not an empty cell.** An agent

--- a/apps/web/app/projects/[projectId]/agents/connection-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/agents/connection-sheet.tsx
@@ -19,7 +19,7 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import type { Refusal } from "@/lib/api.ts";
-import type { ListedConnection } from "@/lib/agents.ts";
+import { modalityLabel, type ListedConnection } from "@/lib/agents.ts";
 import {
   optionNamed,
   type ConnectionOption,
@@ -262,7 +262,7 @@ export function ConnectionSheet({
     if (editing !== null && option !== undefined) {
       return (
         <>
-          <Field label="Name*" htmlFor="edit-connection-name">
+          <Field label="Connection name*" htmlFor="edit-connection-name">
             <Input
               aria-required="true"
               id="edit-connection-name"
@@ -472,9 +472,9 @@ function ReadRow({
 /**
  * The record, read.
  *
- * **Five kinds of row and no more** (`ITZ-0`, `JYY-0`, `K40-0`): Name, Access,
- * the rows the catalog names for what is stored, the Config block, and
- * Created. Updated-at, Env and Platform left with the 2026-08-24 boards —
+ * **Six kinds of row and no more** (`ITZ-0`, `JYY-0`, `K40-0`): Name, Access,
+ * Modality, the rows the catalog names for what is stored, the Config block,
+ * and Created. Updated-at, Env and Platform left with the 2026-08-24 boards —
  * Platform because Access already says which product this is, Updated-at
  * because nobody reads a connection to find out when it was touched, and Env
  * because the product stopped speaking that word (the column stays where it
@@ -520,6 +520,7 @@ function ReadConnection({
       <ReadRow label="Access">
         {option?.accessVariantLabel ?? connection.accessVariant}
       </ReadRow>
+      <ReadRow label="Modality">{modalityLabel(connection.modality)}</ReadRow>
       {rows.map((row) => (
         <ReadRow key={row.label} label={row.label} mono>
           {row.value}

--- a/apps/web/app/projects/[projectId]/runs/[runId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/runs/[runId]/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@egma/platform-api/client";
 
 import type { Refusal } from "../../../../../lib/api.ts";
+import { modalityLabel } from "../../../../../lib/agents.ts";
 import { roleOf } from "../../../../../lib/me.ts";
 import {
   platformAnswer,
@@ -609,18 +610,23 @@ function RunDetailView({
                   {read.connection === null ? (
                     "Unavailable"
                   ) : (
-                    <Link
-                      className={SUMMARY_LINK}
-                      href={projectPath(
-                        projectId,
-                        "agents",
-                        read.agentId,
-                        "connections",
-                        read.connection.id,
-                      )}
-                    >
-                      {read.connection.name}
-                    </Link>
+                    <>
+                      <Link
+                        className={SUMMARY_LINK}
+                        href={projectPath(
+                          projectId,
+                          "agents",
+                          read.agentId,
+                          "connections",
+                          read.connection.id,
+                        )}
+                      >
+                        {read.connection.name}
+                      </Link>
+                      <span className="text-faint">
+                        {modalityLabel(read.modality)}
+                      </span>
+                    </>
                   )}
                   {read.connection?.archived === true ? (
                     <span className="text-sm text-warning">Archived</span>

--- a/apps/web/app/projects/[projectId]/runs/[runId]/run-scenario-workbench.tsx
+++ b/apps/web/app/projects/[projectId]/runs/[runId]/run-scenario-workbench.tsx
@@ -550,25 +550,27 @@ function TranscriptAndAudio({
 
   return (
     <div className="flex min-w-0 flex-col gap-6">
-      <section aria-labelledby="run-evidence-recording">
-        <h3 className="m-0 mb-3 text-base font-medium text-foreground" id="run-evidence-recording">
-          Recording
-        </h3>
-        <RecordingEvidence
-          active={active}
-          recording={recording}
-          speakerTimeline={
-            evidence.transcript === null
-              ? null
-              : {
-                  startedAt:
-                    recordingStartedAt ?? evidence.transcript.startedAt,
-                  endedAt: evidence.transcript.endedAt,
-                  turns: evidence.transcript.turns,
-                }
-          }
-        />
-      </section>
+      {evidence.modality === "voice" ? (
+        <section aria-labelledby="run-evidence-recording">
+          <h3 className="m-0 mb-3 text-base font-medium text-foreground" id="run-evidence-recording">
+            Recording
+          </h3>
+          <RecordingEvidence
+            active={active}
+            recording={recording}
+            speakerTimeline={
+              evidence.transcript === null
+                ? null
+                : {
+                    startedAt:
+                      recordingStartedAt ?? evidence.transcript.startedAt,
+                    endedAt: evidence.transcript.endedAt,
+                    turns: evidence.transcript.turns,
+                  }
+            }
+          />
+        </section>
+      ) : null}
       <section aria-labelledby="run-evidence-conversation">
         <h3 className="m-0 mb-3 text-base font-medium text-foreground" id="run-evidence-conversation">
           Conversation
@@ -582,7 +584,7 @@ function TranscriptAndAudio({
                 className="m-0 border border-s-[3px] border-border border-s-brand bg-selected px-5 py-3 text-sm text-foreground max-[40rem]:px-4"
                 role="status"
               >
-                {`This simulation filed ${String(evidence.transcript.spanCount)} steps. This view shows the first steps in order, so later tool calls or speech may be absent.`}
+                {`This simulation filed ${String(evidence.transcript.spanCount)} steps. This view shows the first steps in order, so later tool calls or conversation turns may be absent.`}
               </p>
             ) : null}
             <ChatTranscript
@@ -718,7 +720,9 @@ function EvidenceDetail({
       >
         <TabsList variant="line" className="w-full border-b border-border px-5 max-[40rem]:px-4">
           <TabsTrigger value="results">Results summary</TabsTrigger>
-          <TabsTrigger value="transcript">Transcript &amp; audio</TabsTrigger>
+          <TabsTrigger value="transcript">
+            {evidence.modality === "voice" ? "Transcript & audio" : "Transcript"}
+          </TabsTrigger>
         </TabsList>
         <TabsContent
           value="results"

--- a/apps/web/app/projects/[projectId]/runs/[runId]/simulations/[simulationId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/runs/[runId]/simulations/[simulationId]/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@egma/platform-api/client";
 
 import type { Refusal } from "../../../../../../../lib/api.ts";
+import { modalityLabel } from "../../../../../../../lib/agents.ts";
 import { roleOf } from "../../../../../../../lib/me.ts";
 import {
   platformAnswer,
@@ -267,12 +268,12 @@ function EvidenceView({
              */}
             <Link href={projectPath(projectId, "personas")}>
               {read.persona.name ?? "A persona"}
-            </Link>{" "}
-            calling{" "}
+            </Link>
+            {read.modality === "chat" ? " chatting with " : " calling "}
             <Link href={projectPath(projectId, "agents", read.agent.id)}>
               {read.agent.name ?? "the agent"}
             </Link>
-            {` through ${read.connection.name ?? "the connection"}`}
+            {` through ${read.connection.name ?? "the connection"} · ${modalityLabel(read.modality)}`}
             {read.startedAt === null ? null : (
               <>
                 {" · started "}

--- a/apps/web/app/projects/[projectId]/runs/create-run-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/runs/create-run-sheet.tsx
@@ -24,10 +24,11 @@ import {
   SheetFooter,
   SheetTitle,
 } from "@/components/ui/sheet";
-import type {
-  AgentDetail,
-  AgentPage,
-  ListedAgentWithConnections,
+import {
+  connectionLabel,
+  type AgentDetail,
+  type AgentPage,
+  type ListedAgentWithConnections,
 } from "../../../../lib/agents.ts";
 import type { Refusal } from "../../../../lib/api.ts";
 import { useDraftNavigation } from "../../../../ui/draft-navigation.tsx";
@@ -468,7 +469,7 @@ export function CreateRunSheet({
                   <option value="">Choose a connection</option>
                   {connections.map((connection) => (
                     <option key={connection.id} value={connection.id}>
-                      {connection.name}
+                      {connectionLabel(connection)}
                     </option>
                   ))}
                 </Select>

--- a/apps/web/app/projects/[projectId]/runs/runs-screen.tsx
+++ b/apps/web/app/projects/[projectId]/runs/runs-screen.tsx
@@ -15,7 +15,7 @@ import { Select } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 
 import type { Refusal } from "../../../../lib/api.ts";
-import type { AgentPage } from "../../../../lib/agents.ts";
+import { modalityLabel, type AgentPage } from "../../../../lib/agents.ts";
 import { asListInstant, formatViewerInstant } from "../../../../lib/instants.ts";
 import { firstProjectOf, roleOf } from "../../../../lib/me.ts";
 import {
@@ -92,8 +92,11 @@ function columnsFor(
       header: "Agent",
       width: "22%",
       cell: (run) => (
-        <span className="text-foreground">
-          {agentNames.get(run.agentId) ?? "Unavailable agent"}
+        <span className="flex min-w-0 flex-col">
+          <span className="truncate text-foreground">
+            {agentNames.get(run.agentId) ?? "Unavailable agent"}
+          </span>
+          <span className="text-faint">{modalityLabel(run.modality)}</span>
         </span>
       ),
     },

--- a/apps/web/lib/agents.ts
+++ b/apps/web/lib/agents.ts
@@ -43,6 +43,18 @@ export type AgentPage = ListAgentsResponse;
 
 export type ListedConnection = ListedAgentWithConnections["connections"][number];
 
+/** One stored modality in the words a person reads. */
+export function modalityLabel(modality: string): string {
+  return modality === "voice" ? "Voice" : "Chat";
+}
+
+/** A compact connection identity that never asks the editable name to imply modality. */
+export function connectionLabel(
+  connection: Pick<ListedConnection, "name" | "modality">,
+): string {
+  return `${connection.name} · ${modalityLabel(connection.modality)}`;
+}
+
 /**
  * One agent as a *list* of them answers it: the identity above, and every
  * living way egma can reach it.

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -190,7 +190,8 @@ const MEASURED_CONNECTION = {
 const LIVEKIT_CONNECTION = {
   ...CONNECTION,
   id: "con_3",
-  name: "livekit room",
+  // A connection created before modality-aware defaults must still be clear.
+  name: "livekit_room-1",
   agentPlatform: "livekit",
   connectionType: "livekit_room",
   accessVariant: "livekit_room.project_credentials",
@@ -962,9 +963,45 @@ describe("reading an agent's reach from the list", () => {
       "/projects/prj_1/agents?sheet=connection&agent=agt_1&connection=con_2",
       "/projects/prj_1/agents?sheet=connection&agent=agt_1&connection=con_3",
     ]);
-    expect(panel.getByText("staging")).toBeDefined();
-    expect(panel.getByText("phone line")).toBeDefined();
-    expect(panel.getByText("livekit room")).toBeDefined();
+    const connections = panel
+      .getByRole("heading", { name: "Connections" })
+      .closest("section");
+    expect(connections).not.toBeNull();
+    const rows = within(connections!).getAllByRole("listitem");
+    expect(within(rows[0]!).getByText("staging")).toBeDefined();
+    expect(within(rows[0]!).getByText("Chat")).toBeDefined();
+    expect(within(rows[1]!).getByText("phone line")).toBeDefined();
+    expect(within(rows[1]!).getByText("Voice")).toBeDefined();
+    expect(within(rows[2]!).getByText("livekit_room-1")).toBeDefined();
+    expect(within(rows[2]!).getByText("Voice")).toBeDefined();
+  });
+
+  it("does not present one LiveKit connection's access as an agent fact", async () => {
+    const chat = {
+      ...LIVEKIT_CONNECTION,
+      id: "con_4",
+      name: "livekit_room-2",
+      productLabel: "LiveKit chat",
+      modality: "chat",
+      config: { url: "wss://chat.livekit.cloud", agentName: "chat-worker" },
+    };
+    listOf({
+      ...LISTED_AGENT,
+      agentPlatform: "livekit",
+      connections: [chat, LIVEKIT_CONNECTION],
+    });
+    routed.search = "?sheet=agent&agent=agt_1";
+    render(<AgentsPage />);
+
+    const panel = within(
+      await screen.findByRole("dialog", { name: "Front desk" }),
+    );
+    const facts = panel.getByText("LiveKit agent").closest("section");
+    expect(facts).not.toBeNull();
+    expect(within(facts!).queryByText("Access")).toBeNull();
+    expect(
+      within(facts!).getAllByText("Varies by connection"),
+    ).toHaveLength(2);
   });
 
   it("tells a viewer why the control is not theirs, where a keyboard can reach it", async () => {
@@ -1115,7 +1152,7 @@ describe("goal-first agent setup", () => {
   async function fillLiveKitSimulation(): Promise<void> {
     expect(
       await screen.findByRole("heading", {
-        name: "Connect LiveKit for simulations",
+        name: "Connect LiveKit Voice for simulations",
       }),
     ).toBeDefined();
     const connectionType = screen.getByRole("combobox", {
@@ -2068,7 +2105,7 @@ describe("goal-first agent setup", () => {
 
     expect(
       await screen.findByRole("heading", {
-        name: "Connect LiveKit for simulations",
+        name: "Connect LiveKit Chat for simulations",
       }),
     ).toBeDefined();
     // Egma has to dispatch the worker to tell it the simulation is typed, so
@@ -2252,7 +2289,7 @@ describe("goal-first agent setup", () => {
     );
     expect(
       await screen.findByRole("heading", {
-        name: "Connect LiveKit for simulations",
+        name: "Connect LiveKit Voice for simulations",
       }),
     ).toBeDefined();
     expect(screen.getByLabelText("LiveKit agent name*")).toBeDefined();
@@ -2452,7 +2489,7 @@ describe("goal-first agent setup", () => {
     await chooseLiveKitModality("Voice");
     expect(
       await screen.findByRole("heading", {
-        name: "Connect LiveKit for simulations",
+        name: "Connect LiveKit Voice for simulations",
       }),
     ).toBeDefined();
     expect(screen.getByLabelText("LiveKit agent name*")).toBeDefined();
@@ -2530,6 +2567,9 @@ describe("one connection's page", () => {
     expect(screen.queryByText("Platform")).toBeNull();
     expect(screen.queryByText("Env")).toBeNull();
     expect(screen.queryByText(/^Updated/)).toBeNull();
+    const modality = screen.getByText("Modality").parentElement;
+    expect(modality).not.toBeNull();
+    expect(within(modality!).getByText("Chat")).toBeDefined();
     /* The credential is a hint of its last characters, never the secret. */
     expect(screen.getByText("…WXYZ")).toBeDefined();
 
@@ -2616,7 +2656,7 @@ describe("one connection's page", () => {
 
     await openConnectionMenu();
     fireEvent.click(screen.getByRole("menuitem", { name: "Edit connection" }));
-    fireEvent.change(screen.getByLabelText("Name*"), {
+    fireEvent.change(screen.getByLabelText("Connection name*"), {
       target: { value: "Primary Retell connection" },
     });
     fireEvent.change(screen.getByLabelText("Retell agent ID*"), {

--- a/apps/web/test/run-history.test.tsx
+++ b/apps/web/test/run-history.test.tsx
@@ -472,6 +472,7 @@ describe("one run after suites", () => {
     for (const label of ["Status", "Started", "Test suite", "Agent", "Connection"]) {
       expect(within(summary).getByText(label)).toBeTruthy();
     }
+    expect(within(summary).getByText("Chat")).toBeTruthy();
     const completedStatus = within(summary)
       .getByText("Completed")
       .closest('[data-slot="run-status"]');
@@ -617,9 +618,11 @@ describe("one run after suites", () => {
     );
     render(<RunDetailPage />);
 
-    fireEvent.click(await screen.findByRole("tab", { name: "Transcript & audio" }));
+    fireEvent.click(await screen.findByRole("tab", { name: "Transcript" }));
     expect(
-      await screen.findByText(/later tool calls or speech may be absent/iu),
+      await screen.findByText(
+        /later tool calls or conversation turns may be absent/iu,
+      ),
     ).toBeTruthy();
   });
 
@@ -822,7 +825,7 @@ describe("one run after suites", () => {
       expect(meaning.className).toContain("sr-only");
     }
 
-    fireEvent.click(screen.getByRole("tab", { name: "Transcript & audio" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Transcript" }));
     const conversationHeading = await screen.findByRole("heading", {
       name: "Conversation",
     });
@@ -1154,18 +1157,16 @@ describe("one run after suites", () => {
     expect(within(policy).getByText("The agent did not confirm consent.")).toBeTruthy();
   });
 
-  it("keeps transcript, speakers, audio, and tool calls in one ordered detail tab", async () => {
+  it("keeps a chat transcript and its tool calls in one ordered detail tab", async () => {
     routed.pathname = "/projects/prj_1/runs/run_1";
     answers(detailStubs());
     render(<RunDetailPage />);
 
-    const transcriptTab = await screen.findByRole("tab", {
-      name: "Transcript & audio",
-    });
+    const transcriptTab = await screen.findByRole("tab", { name: "Transcript" });
     fireEvent.click(transcriptTab);
 
-    expect(await screen.findByRole("heading", { name: "Recording" })).toBeTruthy();
-    expect(screen.getByText("No audio was recorded.")).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Recording" })).toBeNull();
+    expect(screen.queryByText("No audio was recorded.")).toBeNull();
     expect(screen.getByRole("heading", { name: "Conversation" })).toBeTruthy();
     const conversation = screen.getByRole("list", { name: "Transcript messages" });
     const events = within(conversation).getAllByRole("listitem");
@@ -1189,6 +1190,56 @@ describe("one run after suites", () => {
       within(details!).getByRole("region", { name: "lookup_appointment response" })
         .textContent,
     ).toContain('{"appointment":"Tuesday at 10"}');
+  });
+
+  it("keeps recording evidence on the voice simulation path", async () => {
+    routed.pathname = "/projects/prj_1/runs/run_1";
+    const voiceSnapshot = {
+      agentPlatform: "livekit",
+      connectionType: "livekit_room",
+      accessVariant: "livekit_room.project_credentials",
+      modality: "voice",
+      topology: "agent-dials-out",
+      environment: null,
+      config: {},
+    };
+    answers(
+      detailStubs(
+        runDetail({
+          modality: "voice",
+          connectionSnapshot: voiceSnapshot,
+          connection: {
+            id: "con_1",
+            name: "livekit_voice-1",
+            productLabel: "LiveKit project credentials",
+            archived: false,
+          },
+        }),
+        {
+          status: 200,
+          body: {
+            simulations: [simulation({ modality: "voice" })],
+            nextPageToken: null,
+          },
+        },
+        {
+          status: 200,
+          body: simulationEvidence({
+            modality: "voice",
+            connectionSnapshot: voiceSnapshot,
+          }),
+        },
+      ),
+    );
+    render(<RunDetailPage />);
+
+    const evidence = await screen.findByRole("tab", {
+      name: "Transcript & audio",
+    });
+    fireEvent.click(evidence);
+
+    expect(await screen.findByRole("heading", { name: "Recording" })).toBeTruthy();
+    expect(screen.getByText("No audio was recorded.")).toBeTruthy();
   });
 
   it("keeps a selected later-page simulation open while its row refreshes", async () => {

--- a/apps/web/test/runs-list-presentation.test.tsx
+++ b/apps/web/test/runs-list-presentation.test.tsx
@@ -231,6 +231,7 @@ describe("runs list presentation", () => {
     expect(within(table).queryByText("Total avg score")).toBeNull();
     expect(within(table).queryByText("Combined score")).toBeNull();
     expect(within(table).getByText("Front desk")).toBeTruthy();
+    expect(within(table).getByText("Chat")).toBeTruthy();
     const started = within(table).getByText("Aug 25, 2026");
     expect(started.getAttribute("datetime")).toBe("2026-08-25T18:00:01.000Z");
     const headerCells = within(table).getAllByRole("columnheader");

--- a/apps/web/test/simulation-evidence.test.tsx
+++ b/apps/web/test/simulation-evidence.test.tsx
@@ -337,6 +337,50 @@ describe("one simulation's grades", () => {
     expect(within(summary).queryByText(/overall|verdict/iu)).toBeNull();
   });
 
+  it("presents chat as chat and leaves every audio control out", async () => {
+    page({
+      read: evidence({
+        modality: "chat",
+        providerReference: "egma-sim-chat-1",
+        connection: {
+          id: "con_1",
+          name: "livekit_room-1",
+          archived: false,
+        },
+        connectionSnapshot: {
+          agentPlatform: "livekit",
+          connectionType: "livekit_room",
+          accessVariant: "livekit_room.project_credentials",
+          modality: "chat",
+          topology: "agent-dials-out",
+          environment: null,
+          config: {},
+        },
+        transcript: null,
+      }),
+    });
+    render(<SimulationEvidencePage />);
+
+    await screen.findByRole("heading", {
+      name: "Reschedules a booked appointment",
+    });
+    expect(document.body.textContent).toContain(
+      "Impatient Rita chatting with Front desk through livekit_room-1 · Chat",
+    );
+    expect(
+      screen.getByRole("button", { name: "Open transcript" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Open transcript and audio" }),
+    ).toBeNull();
+    const transcript = await screen.findByRole("dialog", { name: "Transcript" });
+    expect(within(transcript).queryByRole("heading", { name: "Recording" })).toBeNull();
+    expect(
+      within(transcript).getByText(/no conversation turns for this simulation/iu),
+    ).toBeTruthy();
+    expect(within(transcript).queryByText(/speech/iu)).toBeNull();
+  });
+
   it("shows a dash for every summary value that was not recorded", async () => {
     page({
       read: evidence({

--- a/apps/web/test/test-suites-pages.test.tsx
+++ b/apps/web/test/test-suites-pages.test.tsx
@@ -155,8 +155,8 @@ function gridAnswers(options: {
 function runBuilderAnswers(options: {
   readonly role?: "admin" | "member" | "viewer";
   readonly started?: Stub | readonly Stub[];
-  /** The one connection this agent holds, when the walk needs a named lane. */
-  readonly connection?: Record<string, unknown>;
+  /** The connections this agent holds when a walk needs named lanes. */
+  readonly connections?: readonly Record<string, unknown>[];
 } = {}): void {
   const started = options.started ?? {
     status: 201,
@@ -188,8 +188,8 @@ function runBuilderAnswers(options: {
       status: 200,
       body: {
         agent: { id: "agt_1", name: "Receptionist", archived: false },
-        connections: [
-          options.connection ?? {
+        connections: options.connections ?? [
+          {
             id: "con_1",
             name: "Production",
             productLabel: "Retell",
@@ -216,7 +216,7 @@ async function chooseRunTarget(): Promise<void> {
     target: { value: "ste_1" },
   });
   fireEvent.change(screen.getByLabelText("Agent *"), { target: { value: "agt_1" } });
-  await screen.findByRole("option", { name: "Production" });
+  await screen.findByRole("option", { name: "Production · Voice" });
   fireEvent.change(screen.getByLabelText("Connection *"), {
     target: { value: "con_1" },
   });
@@ -459,8 +459,9 @@ describe("the suite-first Tests route", () => {
     });
     const connection = await within(sheet).findByLabelText("Connection *");
     expect(connection.getAttribute("aria-required")).toBe("true");
-    expect(within(sheet).getByRole("option", { name: "Production" })).toBeTruthy();
-    expect(within(sheet).queryByRole("option", { name: /Retell|voice/ })).toBeNull();
+    expect(
+      within(sheet).getByRole("option", { name: "Production · Voice" }),
+    ).toBeTruthy();
     expect(screen.queryByLabelText("Run name [optional]")).toBeNull();
 
     fireEvent.change(within(sheet).getByLabelText("Connection *"), {
@@ -481,16 +482,18 @@ describe("the suite-first Tests route", () => {
     routed.pathname = "/projects/prj_1/runs/new";
     routed.params = { projectId: "prj_1" };
     runBuilderAnswers({
-      connection: {
-        id: "con_1",
-        name: "Web call",
-        productLabel: "Retell web call",
-        connectionType: "retell_web_call",
-        modality: "voice",
-        mockToolsEnabled: false,
-        environment: null,
-        archived: false,
-      },
+      connections: [
+        {
+          id: "con_1",
+          name: "Web call",
+          productLabel: "Retell web call",
+          connectionType: "retell_web_call",
+          modality: "voice",
+          mockToolsEnabled: false,
+          environment: null,
+          archived: false,
+        },
+      ],
     });
 
     const { unmount } = render(<NewRunPage />);
@@ -509,15 +512,17 @@ describe("the suite-first Tests route", () => {
     unmount();
     cleanup();
     runBuilderAnswers({
-      connection: {
-        id: "con_1",
-        name: "Room",
-        productLabel: "LiveKit room",
-        connectionType: "livekit_room",
-        modality: "voice",
-        environment: null,
-        archived: false,
-      },
+      connections: [
+        {
+          id: "con_1",
+          name: "Room",
+          productLabel: "LiveKit room",
+          connectionType: "livekit_room",
+          modality: "voice",
+          environment: null,
+          archived: false,
+        },
+      ],
     });
 
     render(<NewRunPage />);
@@ -531,6 +536,43 @@ describe("the suite-first Tests route", () => {
     });
     expect(screen.getByLabelText("Run name [optional]")).toBeTruthy();
     expect(room.querySelector('[data-slot="run-lane-note"]')).toBeNull();
+  });
+
+  it("distinguishes legacy LiveKit chat and voice names in the run picker", async () => {
+    routed.pathname = "/projects/prj_1/runs/new";
+    routed.params = { projectId: "prj_1" };
+    runBuilderAnswers({
+      connections: [
+        {
+          id: "con_chat",
+          name: "livekit_room-1",
+          productLabel: "LiveKit chat",
+          modality: "chat",
+          environment: null,
+          archived: false,
+        },
+        {
+          id: "con_voice",
+          name: "livekit_room-2",
+          productLabel: "LiveKit project credentials",
+          modality: "voice",
+          environment: null,
+          archived: false,
+        },
+      ],
+    });
+
+    render(<NewRunPage />);
+    fireEvent.change(await screen.findByLabelText("Agent *"), {
+      target: { value: "agt_1" },
+    });
+
+    expect(
+      await screen.findByRole("option", { name: "livekit_room-1 · Chat" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("option", { name: "livekit_room-2 · Voice" }),
+    ).toBeTruthy();
   });
 
   it.each(["Close", "Cancel"])(
@@ -1961,7 +2003,7 @@ describe("the suite-first Tests route", () => {
     await screen.findByRole("option", { name: "Northside Ford" });
     fireEvent.change(screen.getByLabelText("Test suite *"), { target: { value: "ste_1" } });
     fireEvent.change(screen.getByLabelText("Agent *"), { target: { value: "agt_1" } });
-    await screen.findByRole("option", { name: "Production" });
+    await screen.findByRole("option", { name: "Production · Voice" });
     fireEvent.change(screen.getByLabelText("Connection *"), {
       target: { value: "con_1" },
     });

--- a/apps/web/ui/simulation-evidence.tsx
+++ b/apps/web/ui/simulation-evidence.tsx
@@ -2141,6 +2141,7 @@ function SimulationEvidencePanel({
   const simulationActive = ["queued", "claimed", "running"].includes(
     evidence.status,
   );
+  const voice = evidence.modality === "voice";
   const toolCalls = useMemo(() => simulationToolCalls(evidence), [evidence]);
   const pendingTurn = useRef<number | null>(null);
 
@@ -2201,7 +2202,7 @@ function SimulationEvidencePanel({
             aria-expanded={evidenceOpen}
             onClick={() => onEvidenceChange(true)}
           >
-            Open transcript and audio
+            {voice ? "Open transcript and audio" : "Open transcript"}
           </Button>
         </header>
         {stillGrading ? (
@@ -2261,33 +2262,35 @@ function SimulationEvidencePanel({
         <Dialog
           kind="sheet"
           size="wide"
-          title="Transcript and audio"
+          title={voice ? "Transcript and audio" : "Transcript"}
           onClose={() => onEvidenceChange(false)}
         >
           <div
             className="flex min-h-0 flex-auto flex-col gap-6 overflow-y-auto bg-background p-5 max-[40rem]:p-4"
             id="transcript-audio-evidence"
           >
-            <section className={SHEET_BLOCK} aria-labelledby="evidence-recording">
-              <h3 className={SHEET_BLOCK_TITLE} id="evidence-recording">
-                Recording
-              </h3>
-              <RecordingEvidence
-                active={simulationActive}
-                recording={recording}
-                speakerTimeline={
-                  evidence.transcript === null
-                    ? null
-                    : {
-                        startedAt:
-                          recordingOriginOf(evidence.transcript) ??
-                          evidence.transcript.startedAt,
-                        endedAt: evidence.transcript.endedAt,
-                        turns: evidence.transcript.turns,
-                      }
-                }
-              />
-            </section>
+            {voice ? (
+              <section className={SHEET_BLOCK} aria-labelledby="evidence-recording">
+                <h3 className={SHEET_BLOCK_TITLE} id="evidence-recording">
+                  Recording
+                </h3>
+                <RecordingEvidence
+                  active={simulationActive}
+                  recording={recording}
+                  speakerTimeline={
+                    evidence.transcript === null
+                      ? null
+                      : {
+                          startedAt:
+                            recordingOriginOf(evidence.transcript) ??
+                            evidence.transcript.startedAt,
+                          endedAt: evidence.transcript.endedAt,
+                          turns: evidence.transcript.turns,
+                        }
+                  }
+                />
+              </section>
+            ) : null}
             <section
               className={cn(SHEET_BLOCK, "flex-auto")}
               aria-labelledby="evidence-transcript"
@@ -2301,8 +2304,8 @@ function SimulationEvidencePanel({
                     No transcript was filed
                   </strong>
                   <p className={EMPTY_STATE_LEAD}>
-                    Egma has no speech for this simulation. It may not have started,
-                    or it may have stopped before the first turn.
+                    Egma has no conversation turns for this simulation. It may not
+                    have started, or it may have stopped before the first turn.
                   </p>
                 </div>
               ) : (

--- a/docs/concepts/agents-and-connections.mdx
+++ b/docs/concepts/agents-and-connections.mdx
@@ -38,6 +38,7 @@ The supported combinations are:
 | Retell | `retell_web_call` | `retell_web_call.api_key` | voice | Retell web call |
 | Retell | `phone_number` | `phone_number.public_e164` | voice | Retell phone |
 | LiveKit | `livekit_room` | `livekit_room.project_credentials` | voice | LiveKit project credentials |
+| LiveKit | `livekit_room` | `livekit_room.project_credentials` | chat | LiveKit chat |
 | LiveKit | `livekit_room` | `livekit_room.customer_token_endpoint` | voice | LiveKit token endpoint |
 | LiveKit | `phone_number` | `phone_number.public_e164` | voice | Phone number |
 | Any or unknown | `phone_number` | `phone_number.public_e164` | voice | Phone number |
@@ -92,8 +93,9 @@ deployment's telephony configuration.
 
 ### LiveKit room
 
-`livekit_room` joins a room in the customer's LiveKit project. It is
-voice-only and has two access variants:
+`livekit_room` joins a room in the customer's LiveKit project. Project
+credentials support chat and voice simulations. A customer token endpoint
+supports voice simulations. The connection type has two access variants:
 
 - `livekit_room.project_credentials`: Egma stores the project key pair sealed,
   mints a token, creates the room, and can dispatch a named worker.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -12,11 +12,12 @@ Voice agents are hard to test with unit tests alone. The behavior that matters e
 
 **Simulation testing** lets you group Markdown scenarios into test suites, then
 run one complete suite as real conversations against your agent. The simulator
-conducts each test and produces a recording and a transcript. The Expected
-behaviors grader checks each behavior statement, keeps its evidence in the
-details, and returns one normalized score for the completed simulation.
+conducts each test and produces a transcript. Voice simulations also produce a
+recording when the call connects; chat simulations never produce audio. The
+Expected behaviors grader checks each behavior statement, keeps its evidence
+in the details, and returns one normalized score for the completed simulation.
 
-**Production monitoring** starts with the agent platform. For Retell voice agents, Egma polls the selected agents after conversations finish. For LiveKit, the Egma Python SDK configures OpenTelemetry export inside the running agent. Both paths produce production conversation records. Egma shows a transcript, observed metrics, and grades when a project grader applies. Simulation recordings stay with the run that Egma conducted.
+**Production monitoring** starts with the agent platform. For Retell voice agents, Egma polls the selected agents after conversations finish. For LiveKit, the Egma Python SDK configures OpenTelemetry export inside the running agent. Both paths produce production conversation records. Egma shows a transcript, observed metrics, and grades when a project grader applies. Voice simulation recordings stay with the run that Egma conducted.
 
 ## How it works
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -144,7 +144,7 @@ This creates:
 
 ```
 egma/
-  config.yaml       format 2 platform, project, agents, and connections
+  config.yaml       format 3 platform, project, agents, and connection modalities
   mock-tools.md     default tool mock responses for simulations
   tests/
     receptionist-core/  one direct directory per test suite
@@ -160,7 +160,7 @@ Everything in this folder is committed to version control. No secrets ever land 
 The config supports many agents and many connections under each agent:
 
 ```yaml
-format: 2
+format: 3
 platform:
   origin: https://app.egma.ai
 project:
@@ -171,16 +171,19 @@ agents:
     name: Front desk
     connections:
       - id: con_01JXMK8P2QN4R6S9T1UV3WX5Y
-        name: livekit-1
+        name: livekit_voice-1
+        modality: voice
       - id: con_01JXMK8P2QN4R6S9T1UV3WX5Z
         name: phone_number-1
+        modality: voice
   - id: agt_01JXMK8P2QN4R6S9T1UV3WX5Z
     name: After hours
     connections: []
 ```
 
-Format 2 is required. The CLI refuses the former top-level `agent` and
-`connection` fields. It does not translate or alias an old folder shape.
+Format 3 is required. Every connection records `modality: chat` or
+`modality: voice`. The CLI refuses older folder formats. It does not translate
+or alias an old folder shape.
 
 <Note>
   LiveKit monitoring setup does not pause for a separate environment-line
@@ -277,7 +280,7 @@ connection together. If the config has more than one runnable agent or the
 selected agent has more than one connection, use exact names or IDs:
 
 ```bash
-egma run receptionist-core --agent "Front desk" --connection livekit-1
+egma run receptionist-core --agent "Front desk" --connection livekit_voice-1
 ```
 
 The simulator claims each simulation and conducts the conversation. The

--- a/packages/db/migrations/0002_livekit_connection_names.sql
+++ b/packages/db/migrations/0002_livekit_connection_names.sql
@@ -1,0 +1,73 @@
+-- Carry the old generated LiveKit names into the modality-specific naming
+-- scheme. The old rows do not record whether a name was generated or typed,
+-- so this clean cut treats every exact livekit_room-N shape as legacy. Every
+-- name outside that former generated namespace remains customer-owned.
+--
+-- A custom or already-migrated connection may own a direct target such as
+-- livekit_chat-1. Keep that row and give the legacy row the first free number,
+-- while reserving the direct target of every legacy row still to be renamed.
+-- Archived rows take part too, so every migrated name can be restored later.
+
+lock table "connection" in share row exclusive mode;
+
+do $$
+declare
+  legacy record;
+  stem text;
+  target_name text;
+  candidate_number bigint;
+begin
+  for legacy in
+    select id, agent_id, modality, name, archived_at
+      from "connection"
+     where connection_type = 'livekit_room'
+       and name ~ '^livekit_room-[1-9][0-9]*$'
+     order by agent_id, archived_at is not null, name collate "C", id
+  loop
+    stem := case legacy.modality
+      when 'chat' then 'livekit_chat'
+      else 'livekit_voice'
+    end;
+    target_name := stem || '-' || substring(
+      legacy.name from '^livekit_room-([1-9][0-9]*)$'
+    );
+
+    if exists (
+      select 1
+       from "connection" occupied
+       where occupied.agent_id = legacy.agent_id
+         and occupied.id <> legacy.id
+         and occupied.name = target_name
+    ) then
+      candidate_number := 1;
+      loop
+        target_name := stem || '-' || candidate_number::text;
+        exit when not exists (
+          select 1
+            from "connection" occupied
+           where occupied.agent_id = legacy.agent_id
+             and occupied.id <> legacy.id
+             and occupied.name = target_name
+        ) and not exists (
+          select 1
+            from "connection" reserved
+           where reserved.agent_id = legacy.agent_id
+             and reserved.id <> legacy.id
+             and reserved.connection_type = 'livekit_room'
+             and reserved.modality = legacy.modality
+             and reserved.name ~ '^livekit_room-[1-9][0-9]*$'
+             and stem || '-' || substring(
+               reserved.name from '^livekit_room-([1-9][0-9]*)$'
+             ) = target_name
+        );
+        candidate_number := candidate_number + 1;
+      end loop;
+    end if;
+
+    update "connection"
+       set name = target_name,
+           updated_at = now()
+     where id = legacy.id;
+  end loop;
+end
+$$;

--- a/packages/db/src/access/agents.ts
+++ b/packages/db/src/access/agents.ts
@@ -81,7 +81,7 @@ import { within } from "./within.ts";
  */
 
 export type NewConnection = {
-  /** Defaults from the product label, so onboarding never stalls. */
+  /** Defaults from the connection kind and modality, so onboarding never stalls. */
   readonly name?: string | undefined;
   readonly agentPlatform: AgentPlatform | null;
   readonly connectionType: ConnectionType;
@@ -713,15 +713,26 @@ function admitConnection(input: NewConnection): AdmittedConnection {
   };
 }
 
+/** The stable stem for one generated connection name. */
+function defaultNameStem(
+  connectionType: ConnectionType,
+  modality: Modality,
+): string {
+  if (connectionType !== "livekit_room") return connectionType;
+  return modality === "chat" ? "livekit_chat" : "livekit_voice";
+}
+
 /**
  * The smallest free `<kind>-<n>` among the agent's living names, so an unnamed
  * add always lands — a removed connection's number comes back into play the
- * same way its name does.
+ * same way its name does. LiveKit includes its modality because one worker can
+ * have both a chat connection and a voice connection.
  */
 async function freeDefaultName(
   on: Queryable,
   agentId: string,
   connectionType: ConnectionType,
+  modality: Modality,
 ): Promise<string> {
   const taken = new Set(
     (
@@ -732,8 +743,9 @@ async function freeDefaultName(
     ).map((row) => row.name),
   );
 
+  const stem = defaultNameStem(connectionType, modality);
   for (let n = 1; ; n += 1) {
-    const candidate = `${connectionType}-${n}`;
+    const candidate = `${stem}-${n}`;
     if (!taken.has(candidate)) return candidate;
   }
 }
@@ -849,7 +861,12 @@ async function insertConnection(
   );
   const name =
     admitted.name ??
-    (await freeDefaultName(on, home.id, admitted.connectionType));
+    (await freeDefaultName(
+      on,
+      home.id,
+      admitted.connectionType,
+      admitted.modality,
+    ));
 
   const [inserted] = await on
     .insert(connection)

--- a/packages/db/test/connections.test.ts
+++ b/packages/db/test/connections.test.ts
@@ -657,15 +657,34 @@ describe("a livekit connection", () => {
     });
   });
 
-  it("defaults its name from the type, like every other", async () => {
+  it("defaults LiveKit names from the modality and leaves explicit names alone", async () => {
     const agentId = await agentNamed("LiveKit Unnamed");
 
-    const first = await addConnection(
+    const firstChat = await addConnection(
       actingAsAcme(),
       agentId,
-      livekitConnection({ name: undefined }),
+      livekitConnection({ name: undefined, modality: "chat" }),
     );
-    expect(first?.name).toBe("livekit_room-1");
+    const firstVoice = await addConnection(
+      actingAsAcme(),
+      agentId,
+      livekitConnection({ name: undefined, modality: "voice" }),
+    );
+    const secondChat = await addConnection(
+      actingAsAcme(),
+      agentId,
+      livekitConnection({ name: undefined, modality: "chat" }),
+    );
+    const explicitLegacyName = await addConnection(
+      actingAsAcme(),
+      agentId,
+      livekitConnection({ name: "livekit_room-1", modality: "chat" }),
+    );
+
+    expect(firstChat?.name).toBe("livekit_chat-1");
+    expect(firstVoice?.name).toBe("livekit_voice-1");
+    expect(secondChat?.name).toBe("livekit_chat-2");
+    expect(explicitLegacyName?.name).toBe("livekit_room-1");
   });
 
   it("seals both halves, and neither is in the row", async () => {

--- a/packages/db/test/livekit-connection-name-migration.test.ts
+++ b/packages/db/test/livekit-connection-name-migration.test.ts
@@ -1,0 +1,186 @@
+import { cp, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { newId } from "@egma/ids";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { MIGRATIONS_DIRECTORY, runMigrations } from "@egma/db";
+
+import {
+  createEmptyDatabase,
+  openSingleConnection,
+  type EmptyDatabase,
+  type SingleConnection,
+} from "./support/database.ts";
+
+const MIGRATION = "0002_livekit_connection_names.sql";
+
+const acme = {
+  organization: newId("org"),
+  project: newId("prj"),
+  directAgent: newId("agt"),
+  collisionAgent: newId("agt"),
+  archivedAgent: newId("agt"),
+};
+
+let database: EmptyDatabase;
+let beforeBackfill: string;
+let store: SingleConnection;
+
+beforeAll(async () => {
+  database = await createEmptyDatabase("livekit_connection_name_migration");
+  beforeBackfill = await mkdtemp(path.join(tmpdir(), "egma-before-livekit-names-"));
+
+  await cp(
+    path.join(MIGRATIONS_DIRECTORY, "0000_baseline.sql"),
+    path.join(beforeBackfill, "0000_baseline.sql"),
+  );
+  await cp(
+    path.join(MIGRATIONS_DIRECTORY, "0001_persona_rework.sql"),
+    path.join(beforeBackfill, "0001_persona_rework.sql"),
+  );
+  await runMigrations(database.url, beforeBackfill);
+
+  store = await openSingleConnection(database.url);
+  await seedRowsFromBeforeTheBackfill();
+  await runMigrations(database.url);
+});
+
+afterAll(async () => {
+  await store?.close();
+  await database?.drop();
+  if (beforeBackfill !== undefined) {
+    await rm(beforeBackfill, { recursive: true, force: true });
+  }
+});
+
+async function seedRowsFromBeforeTheBackfill(): Promise<void> {
+  await store.sql(
+    "insert into organization (id, name, slug) values ($1, 'Acme', 'acme')",
+    [acme.organization],
+  );
+  await store.sql(
+    `insert into project (id, organization_id, name, slug, revision)
+     values ($1, $2, 'Default', 'default', $3)`,
+    [acme.project, acme.organization, newId("rev")],
+  );
+
+  for (const [id, name] of [
+    [acme.directAgent, "Direct names"],
+    [acme.collisionAgent, "Occupied names"],
+    [acme.archivedAgent, "Archived names"],
+  ] as const) {
+    await store.sql(
+      `insert into agent
+         (id, organization_id, project_id, name, agent_platform)
+       values ($1, $2, $3, $4, 'livekit')`,
+      [id, acme.organization, acme.project, name],
+    );
+  }
+
+  const insertConnection = (
+    agentId: string,
+    name: string,
+    modality: "chat" | "voice",
+    options: { archived?: boolean; type?: "livekit_room" | "phone_number" } = {},
+  ) =>
+    store.sql(
+      `insert into connection
+         (id, organization_id, project_id, agent_id, name, connection_type,
+          access_variant, modality, topology, config, archived_at)
+       values ($1, $2, $3, $4, $5, $6, $7, $8, 'hosted-broker', '{}'::jsonb, $9)`,
+      [
+        newId("con"),
+        acme.organization,
+        acme.project,
+        agentId,
+        name,
+        options.type ?? "livekit_room",
+        options.type === "phone_number"
+          ? "phone_number.public_e164"
+          : "livekit_room.customer_token_endpoint",
+        modality,
+        options.archived === true ? new Date("2026-08-20T10:00:00.000Z") : null,
+      ],
+    );
+
+  await insertConnection(acme.directAgent, "livekit_room-1", "chat");
+  await insertConnection(acme.directAgent, "livekit_room-2", "voice");
+  await insertConnection(acme.directAgent, "livekit_room-main", "chat");
+  await insertConnection(acme.directAgent, "livekit_room-3", "voice", {
+    type: "phone_number",
+  });
+  await insertConnection(acme.directAgent, "livekit_voice-4", "voice");
+  await insertConnection(acme.directAgent, "livekit_room-4", "voice", {
+    archived: true,
+  });
+
+  await insertConnection(acme.collisionAgent, "livekit_chat-1", "chat");
+  await insertConnection(acme.collisionAgent, "livekit_room-1", "chat");
+  await insertConnection(acme.collisionAgent, "livekit_room-2", "chat");
+  await insertConnection(acme.collisionAgent, "livekit_voice-7", "voice");
+  await insertConnection(acme.collisionAgent, "livekit_room-7", "voice");
+
+  await insertConnection(acme.archivedAgent, "livekit_room-1", "chat", {
+    archived: true,
+  });
+  await insertConnection(acme.archivedAgent, "livekit_room-1", "chat", {
+    archived: true,
+  });
+}
+
+async function namesFor(agentId: string): Promise<string[]> {
+  const { rows } = await store.sql<{ name: string }>(
+    `select name from connection
+      where agent_id = $1
+      order by name collate "C"`,
+    [agentId],
+  );
+  return rows.map((row) => row.name);
+}
+
+describe("the LiveKit connection name backfill", () => {
+  it("uses modality-specific names and leaves unrelated names alone", async () => {
+    expect(await namesFor(acme.directAgent)).toEqual([
+      "livekit_chat-1",
+      "livekit_room-3",
+      "livekit_room-main",
+      "livekit_voice-1",
+      "livekit_voice-2",
+      "livekit_voice-4",
+    ]);
+
+    const { rows } = await store.sql<{ name: string }>(
+      `select name from connection
+        where agent_id = $1 and archived_at is not null`,
+      [acme.directAgent],
+    );
+    expect(rows).toEqual([{ name: "livekit_voice-1" }]);
+  });
+
+  it("keeps active custom names and allocates collision-safe numbers", async () => {
+    expect(await namesFor(acme.collisionAgent)).toEqual([
+      "livekit_chat-1",
+      "livekit_chat-2",
+      "livekit_chat-3",
+      "livekit_voice-1",
+      "livekit_voice-7",
+    ]);
+  });
+
+  it("gives duplicate archived legacy names distinct restorable names", async () => {
+    expect(await namesFor(acme.archivedAgent)).toEqual([
+      "livekit_chat-1",
+      "livekit_chat-2",
+    ]);
+  });
+
+  it("records the backfill as the next migration", async () => {
+    const { rows } = await store.sql<{ name: string }>(
+      "select name from egma_meta.migration where name = $1",
+      [MIGRATION],
+    );
+    expect(rows).toEqual([{ name: MIGRATION }]);
+  });
+});

--- a/skills/egma/SKILL.md
+++ b/skills/egma/SKILL.md
@@ -30,7 +30,7 @@ The folder has this shape:
 
 ```text
 egma/
-  config.yaml     format 2 platform, project, agents, and connections
+  config.yaml     format 3 platform, project, agents, and connection modalities
   mock-tools.md   what Egma answers for the agent's tools with
   tests/
     release/      one local directory per suite
@@ -44,7 +44,7 @@ egma/
 The config hierarchy is:
 
 ```yaml
-format: 2
+format: 3
 platform:
   origin: https://app.egma.ai
 project:
@@ -55,14 +55,16 @@ agents:
     name: Front desk
     connections:
       - id: con_...
-        name: livekit-1
+        name: livekit_voice-1
+        modality: voice
   - id: agt_...
     name: After hours
     connections: []
 ```
 
-Format 2 is strict. The CLI has no reader, migration, or alias for the former
-top-level `agent` and `connection` fields. Report that refusal as written.
+Format 3 is strict. Every connection has `modality: chat` or `modality: voice`.
+The CLI has no reader, migration, or alias for an older folder format. Report
+that refusal as written.
 
 When the developer asks to onboard or extend the repository, run the wizard.
 It authorizes the CLI before it discovers installed coding agents. The first


### PR DESCRIPTION
## What changed

- Generate `livekit_chat-N` and `livekit_voice-N` names instead of the ambiguous `livekit_room-N` default.
- Carry Chat or Voice as an explicit connection fact through CLI folder format 3, run selection, agent and connection details, run lists, and run evidence.
- Show transcript-only evidence for chat simulations. Chat views no longer offer recording or audio controls.
- Backfill exact legacy `livekit_room-N` database names to the modality-specific form. Active-name collisions receive the first free modality-specific number.
- Update the public CLI docs and Egma skill examples.

## Why

The linked simulation used a LiveKit chat connection. Chat simulations produce conversation turns, not audio. The old generated connection name hid that fact and made the missing recording look like a failure.

## Breaking changes

- `egma/config.yaml` now requires format 3 and a `chat` or `voice` modality on every connection. Format 2 is refused; there is no compatibility reader.
- Old rows did not record whether `livekit_room-N` was generated or typed. This clean cut treats every exact legacy-shaped name as legacy. Names outside that former generated namespace are unchanged.

## Verification

- `pnpm typecheck`
- `pnpm --filter @egma/web build`
- `pnpm test:fast` — 3,246 passed, 2 skipped
- `pnpm test:browser` — 58 passed
- `pnpm test:simulator` — 683 passed, 7 skipped
- `pnpm test:sdk` — 175 passed, 1 skipped
- `pnpm test:fixture` — 28 passed
- Independent standards and spec review completed. The exact-pattern migration tradeoff above is the only standards concern and is intentional under this clean break.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790567567&installation_model_id=431960&pr_number=273&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F273&signature=03fac2163e0cf5e40cc2766f2b0ea20d9a601c129762742b6cdbf6408098aefe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes connection modality explicit throughout LiveKit naming, CLI configuration, run selection, web presentation, and simulation evidence.
- Generates modality-specific `livekit_chat-N` and `livekit_voice-N` connection names.
- Introduces strict CLI folder format 3 with a required connection modality.
- Hides recording and audio controls for chat simulations.
- Migrates exact legacy LiveKit names while allocating collision-safe names across active and archived connections.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because both previously reported archived-name collision paths are resolved at the current head.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/db/migrations/0002_livekit_connection_names.sql | Backfills exact legacy LiveKit names and checks both active and archived rows while allocating collision-safe modality-specific names. |
| packages/db/test/livekit-connection-name-migration.test.ts | Covers direct-name collisions, archived-versus-active collisions, duplicate archived names, and migration registration. |
| apps/cli/src/folder/egma-folder.ts | Advances repository configuration to format 3 and requires every stored connection to declare chat or voice modality. |
| apps/web/ui/simulation-evidence.tsx | Adapts simulation evidence presentation so chat runs expose transcript evidence without audio or recording controls. |
| packages/db/src/access/agents.ts | Generates modality-specific default LiveKit connection names while preserving existing connection naming behavior elsewhere. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Registration[LiveKit registration] --> Modality{Connection modality}
  Modality -->|chat| ChatName[livekit_chat-N]
  Modality -->|voice| VoiceName[livekit_voice-N]
  ChatName --> Config[CLI format 3]
  VoiceName --> Config
  Config --> Runs[Run selection and details]
  Runs --> Evidence{Evidence presentation}
  Evidence -->|chat| Transcript[Transcript only]
  Evidence -->|voice| Audio[Transcript and recording controls]
  Legacy[livekit_room-N rows] --> Migration[Collision-safe migration]
  Migration --> ChatName
  Migration --> VoiceName
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: make LiveKit connection modality ex..."](https://github.com/egma-ai/egma/commit/94209bff8461646883a3eadaab805337e9986f3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58155804)</sub>

<!-- /greptile_comment -->