### PR TITLE
Move the persona picker onto the kit popover and command

### DIFF
--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -3519,7 +3519,15 @@ describe("the complete product, walked in order in a second project", () => {
       // still missing — here, the persona nobody has named yet.
       await saysWithin(walk, "Needs one persona.");
       await walk.getByRole("button", { name: "+ Add a persona" }).click();
-      await walk.getByRole("checkbox", { name: "Impatient Rita" }).click();
+      /*
+       * The persona row is an option, not a checkbox, and that is the pattern
+       * rather than a detail. The picker is a combobox now — a field that
+       * narrows a listbox — and ARIA forbids an interactive descendant inside
+       * an `option`, so the box drawn in the row is hidden from assistive
+       * technology and the row itself carries `aria-checked`. This drives what
+       * a screen reader would drive.
+       */
+      await walk.getByRole("option", { name: "Impatient Rita" }).click();
       await walk.getByRole("button", { name: "Done" }).click();
       await walk.getByRole("button", { name: "Save test" }).click();
 

--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -17,6 +17,18 @@ import {
 
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Command,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { LANE_X } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import {
@@ -289,22 +301,104 @@ function Arriving({
 /**
  * The persona picker, and this is its only home.
  *
- * It opens inside the woken Personas cell — search, checkboxes, Done — because
- * the cell is where the answer is read. Personas arrive once per open and are
- * narrowed in the browser, which is what the list does everywhere else on this
- * screen.
+ * It opens from the woken Personas cell — search, tick boxes, Done — because
+ * the cell is where the answer is read.
+ *
+ * **It is the kit's popover now, and that is what deleted the grid's worst
+ * trade.** The panel used to be an absolutely positioned box inside the cell,
+ * which any scroll container clips, so the grid switched its own sideways
+ * scrolling off for as long as a picker was open — and on a phone that switch
+ * threw away the reader's place in the table. `PopoverContent` is drawn in a
+ * portal, so nothing clips it and the grid scrolls at all times.
+ *
+ * **The click-outside rule is Radix's, and it is the same rule spelled once.**
+ * The hand-written listener had to measure "elsewhere" against an owner id,
+ * because a marker with no owner made *another* row's trigger count as inside
+ * this panel: the picking moved to that row, Done never ran, and the personas
+ * ticked here went with no save and no word said. A popover only knows itself,
+ * so pressing another row's trigger dismisses this one first — which closes it
+ * the way Done does, keeping the ticks — and the press then opens that row's.
+ * The owner id is gone from this component because Radix is what holds the
+ * rule now, and `tests-grid` keeps its own `picking` only to know which cell to
+ * commit.
+ *
+ * The reading lives in `PersonaChoices`, inside the panel, because Radix mounts
+ * the panel's children when it opens. A row that is never opened must not send
+ * the project's whole persona list over the wire, and there is one of these per
+ * row.
  */
 function PersonaPicker({
   projectId,
-  owner,
+  chosen,
+  known,
+  onChange,
+  open,
+  onOpenChange,
+}: {
+  readonly projectId: string;
+  readonly chosen: readonly string[];
+  readonly known: ReadonlyMap<string, Named>;
+  readonly onChange: (ids: readonly string[], named: ReadonlyMap<string, Named>) => void;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          className={ADD_LINE}
+          type="button"
+          /* The cell owns its own caret; opening must not move it first. */
+          onMouseDown={(event) => event.preventDefault()}
+        >
+          + Add a persona
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[300px] p-0"
+        aria-label="Choose personas"
+        /*
+         * **Focus leaving does not shut this panel; a press elsewhere does.**
+         * A popover closes on both by default, and the first one is wrong here:
+         * the cell this hangs off keeps a caret of its own — the entry row puts
+         * one in Name as soon as it wakes — so focus lands back outside the
+         * panel a tick after it opens and Radix reads that as an exit. The
+         * panel shut itself before anybody could tick a name.
+         *
+         * A press outside still closes it, which is the rule that matters: that
+         * is the save, and it is what carries the ticks to the platform. Escape
+         * still closes it too.
+         */
+        onFocusOutside={(event) => event.preventDefault()}
+      >
+        <PersonaChoices
+          projectId={projectId}
+          chosen={chosen}
+          known={known}
+          onChange={onChange}
+          onDone={() => onOpenChange(false)}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/**
+ * What the open picker holds: the search, the people, and the way out.
+ *
+ * It is its own component so that the read below runs when a panel opens
+ * rather than when the grid draws, which is the difference between one request
+ * and one per row.
+ */
+function PersonaChoices({
+  projectId,
   chosen,
   known,
   onChange,
   onDone,
 }: {
   readonly projectId: string;
-  /** Whose picking this is: the owning test's id, or `"entry"` for the row. */
-  readonly owner: string;
   readonly chosen: readonly string[];
   readonly known: ReadonlyMap<string, Named>;
   readonly onChange: (ids: readonly string[], named: ReadonlyMap<string, Named>) => void;
@@ -315,44 +409,6 @@ function PersonaPicker({
   const [refused, setRefused] = useState<string | null>(null);
   /** Whether egma holds more than this picker read. Said out loud if so. */
   const [truncated, setTruncated] = useState(false);
-  /** The newest way out, so the listener below never closes over a stale one. */
-  const done = useRef(onDone);
-  useEffect(() => {
-    done.current = onDone;
-  });
-
-  /*
-   * **A click anywhere else closes this picker, and it closes it the way Done
-   * does** — the choices ticked so far are kept, because ticking a checkbox has
-   * already changed the draft. A picker that stayed open under a click that
-   * plainly meant "elsewhere" left the only way out a button somebody had to
-   * find, which is the defect the founder named on 2026-08-25.
-   *
-   * `mousedown` rather than `click`, so the close happens before focus moves —
-   * the same instant Done would have.
-   *
-   * **"Elsewhere" is measured against this picker's owner, not against the
-   * marker alone.** `data-persona-picker` sits on this surface *and* on every
-   * "+ Add a persona" trigger, so a marker with no owner in it made the *other*
-   * row's trigger count as inside: the picking moved to that row, Done never
-   * ran, and the personas ticked here went with no save and no word said. Only
-   * this owner's own marks are inside. Every other target — the other trigger
-   * included — runs Done first, and the trigger's own click then opens its own
-   * picker, because a mousedown lands before the click it belongs to.
-   */
-  useEffect(() => {
-    function elsewhere(event: MouseEvent): void {
-      const target = event.target;
-      const marked =
-        target instanceof Element
-          ? target.closest("[data-persona-picker]")
-          : null;
-      if (marked?.getAttribute("data-persona-picker") === owner) return;
-      done.current();
-    }
-    document.addEventListener("mousedown", elsewhere);
-    return () => document.removeEventListener("mousedown", elsewhere);
-  }, [owner]);
 
   /*
    * **Every persona the project holds, not the first page of them.**
@@ -404,6 +460,9 @@ function PersonaPicker({
     }
 
     void readEveryone();
+    return () => {
+      live = false;
+    };
   }, [projectId]);
 
   const wanted = search.trim().toLocaleLowerCase();
@@ -421,29 +480,33 @@ function PersonaPicker({
   }
 
   return (
-    <Arriving
-      className="absolute top-full left-0 z-20 mt-1 w-[300px] origin-top border border-border bg-surface shadow-popover"
-      role="dialog"
-      aria-label="Choose personas"
-      data-persona-picker={owner}
-    >
-      <div className="border-b border-border">
-        <input
-          className={cn(QUIET_INPUT, "h-9 px-2.5")}
-          aria-label="Search personas"
-          placeholder="Search personas"
-          value={search}
-          autoComplete="off"
-          onChange={(event) => setSearch(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === "Escape") {
-              event.stopPropagation();
-              onDone();
-            }
-          }}
-        />
-      </div>
-      <div className="max-h-[240px] overflow-y-auto">
+    /*
+     * **`label` names the search field, not the list, and that is `cmdk`'s
+     * doing rather than a choice made here.** It renders the prop into a hidden
+     * element and points the field's `aria-labelledby` at it — always, even
+     * with no label given, which is why an `aria-label` on the field is
+     * overridden and silently does nothing. So the words that describe the
+     * typing have to arrive through this prop. The panel around it is a dialog
+     * and carries "Choose personas" of its own, so nothing is left unnamed.
+     */
+    <Command label="Search personas">
+      <CommandInput
+        /*
+         * The caret starts here, and that is load-bearing rather than a
+         * courtesy. Radix puts focus on the panel itself when it opens, and the
+         * panel's own children then re-render as the persona pages arrive —
+         * which drops focus to the body, reads to Radix as focus leaving the
+         * panel, and shuts it. Landing the caret on the field holds it on
+         * something that outlives the list, and it is where somebody opening a
+         * search panel expects to be typing.
+         */
+        autoFocus
+        /* A placeholder is not a name: it leaves with the first keystroke. */
+        placeholder="Search personas"
+        value={search}
+        onValueChange={setSearch}
+      />
+      <CommandList>
         {refused !== null ? (
           <p className="m-0 px-2.5 py-2 text-sm text-failure">{refused}</p>
         ) : people === null ? (
@@ -457,22 +520,34 @@ function PersonaPicker({
               : `No personas match “${search.trim()}”.`}
           </p>
         ) : (
-          listed.map((one) => (
-            <label
-              className="flex min-h-9 cursor-pointer items-center gap-2.5 px-2.5 text-sm text-foreground pointer-hover:bg-surface-soft"
-              key={one.id}
-            >
-              <Checkbox
-                checked={chosen.includes(one.id)}
-                onChange={() => toggle(one)}
-              />
-              <span className="min-w-0 truncate">{one.name}</span>
-            </label>
-          ))
+          <CommandGroup>
+            {listed.map((one) => (
+              <CommandItem
+                key={one.id}
+                value={one.id}
+                /*
+                 * The row is the control, so the row says whether it is ticked.
+                 * `cmdk` has already spent `aria-selected` on the arrow keys'
+                 * highlight, and the box below is a picture of this state
+                 * rather than a second control announcing it again.
+                 */
+                aria-checked={chosen.includes(one.id)}
+                onSelect={() => toggle(one)}
+              >
+                <Checkbox
+                  checked={chosen.includes(one.id)}
+                  readOnly
+                  tabIndex={-1}
+                  aria-hidden="true"
+                />
+                <span className="min-w-0 truncate">{one.name}</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
         )}
-      </div>
+      </CommandList>
       {truncated ? (
-        // The search below runs in the browser, so it reaches what was read
+        // The search above runs in the browser, so it reaches what was read
         // and nothing beyond it. The sentence says that rather than promising
         // a search that would quietly come back empty.
         <p className="m-0 border-t border-border px-2.5 py-1.5 text-sm text-muted-foreground">
@@ -484,10 +559,9 @@ function PersonaPicker({
           Done
         </button>
       </div>
-    </Arriving>
+    </Command>
   );
 }
-
 /**
  * The lines a cell keeps once nobody is typing into them.
  *
@@ -741,20 +815,8 @@ function CellBody({
     >
       <span className={TEXT}>{personaNames(draft.personas, known)}</span>
       {woken ? (
-        <button
-          className={ADD_LINE}
-          type="button"
-          data-persona-picker={owner}
-          onMouseDown={(event) => event.preventDefault()}
-          onClick={() => onPick(!picking)}
-        >
-          + Add a persona
-        </button>
-      ) : null}
-      {woken && picking ? (
         <PersonaPicker
           projectId={projectId}
-          owner={owner}
           chosen={draft.personas}
           known={known}
           onChange={(ids, named) => {
@@ -763,9 +825,13 @@ function CellBody({
             onChange({ ...draft, personas: ids });
             onKnown(named);
           }}
-          onDone={() => {
-            onPick(false);
-            onCommit();
+          open={picking}
+          onOpenChange={(open) => {
+            onPick(open);
+            // Shutting is the commit, however it was shut — Done, Escape, or a
+            // press anywhere else. That is the rule the hand-written listener
+            // was written to keep, and closing is the only path to it.
+            if (!open) onCommit();
           }}
         />
       ) : null}
@@ -1229,6 +1295,19 @@ export function TestsGrid(props: GridProps) {
                 ) {
                   return;
                 }
+                /*
+                 * **A cell whose own picker is open has not been left.** The
+                 * panel is drawn in a portal now, so it is not a descendant of
+                 * this cell and the test above reads focus moving into it as
+                 * focus going away — which committed the cell and tore the
+                 * panel down under the person about to tick a name. Asking
+                 * whether this cell is the one picking is the same question
+                 * without depending on where focus landed, which a browser may
+                 * not say: `relatedTarget` is null on plenty of real blurs.
+                 *
+                 * Shutting the picker is what commits, and it commits there.
+                 */
+                if (picking === test.id) return;
                 void commit(test, field);
               }
             : undefined
@@ -1338,30 +1417,17 @@ export function TestsGrid(props: GridProps) {
           ) : (
             <div className="relative flex flex-col gap-0.5">
               <span className={TEXT}>{personaNames(entry.personas, known)}</span>
-              <button
-                className={ADD_LINE}
-                type="button"
-                data-persona-picker="entry"
-                onMouseDown={(event) => event.preventDefault()}
-                onClick={() =>
-                  setPicking(picking === "entry" ? null : "entry")
-                }
-              >
-                + Add a persona
-              </button>
-              {picking === "entry" ? (
-                <PersonaPicker
-                  projectId={projectId}
-                  owner="entry"
-                  chosen={entry.personas}
-                  known={known}
-                  onChange={(ids, named) => {
-                    setEntry({ ...entry, personas: ids });
-                    setKnown(named);
-                  }}
-                  onDone={() => setPicking(null)}
-                />
-              ) : null}
+              <PersonaPicker
+                projectId={projectId}
+                chosen={entry.personas}
+                known={known}
+                onChange={(ids, named) => {
+                  setEntry({ ...entry, personas: ids });
+                  setKnown(named);
+                }}
+                open={picking === "entry"}
+                onOpenChange={(open) => setPicking(open ? "entry" : null)}
+              />
             </div>
           )}
         </div>
@@ -1396,18 +1462,16 @@ export function TestsGrid(props: GridProps) {
         to fall back to, so under `--tests-grid-min-width` the columns stopped
         holding a readable word. A phone scrolls it; a tablet and up does not.
 
-        **It stops scrolling while a persona picker is open, and that is not a
-        detail.** The shared table may hold its rows in a scrolling panel
-        because its ⋮ opens in a portal; this grid's picker is an absolutely
-        positioned panel inside the cell it belongs to, and a scroll container
-        clips exactly that. `overflow-x: auto` also computes `overflow-y` to
-        `auto`, so the naive wrapper would have cut a 240px picker off at the
-        table's own bottom edge. The choice is one class or the other, never
-        both: while a picker is open the grid may overflow, and when it shuts
-        the grid scrolls again. On a phone the toggle also resets the sideways
-        scroll — the price of this grid having no narrow layout yet.
+        **It scrolls at all times now, and it used not to.** The persona picker
+        was an absolutely positioned panel inside the cell it belongs to, and a
+        scroll container clips exactly that — so this wrapper switched between
+        `overflow-x: auto` and `overflow-visible` to keep an open picker whole,
+        and on a phone the switch threw away the reader's place in the table.
+        The picker is the kit's popover now and is drawn in a portal, the way
+        the shared table's ⋮ always was, so nothing here has to move out of its
+        way.
       */}
-      <div className={picking === null ? "overflow-x-auto" : "overflow-visible"}>
+      <div className="overflow-x-auto">
       <table className="w-full min-w-(--tests-grid-min-width) table-fixed border-collapse border border-border bg-surface text-sm">
         <caption className="sr-only">Tests in this suite</caption>
         <colgroup>

--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -356,7 +356,8 @@ function PersonaPicker({
       </PopoverTrigger>
       <PopoverContent
         align="start"
-        className="w-[300px] p-0"
+        /* Never wider than the screen it has to fit on, as `ui/menu.tsx` is. */
+        className="w-[min(300px,calc(100vw-var(--space-8)))] p-0"
         aria-label="Choose personas"
         /*
          * **Focus leaving does not shut this panel; a press elsewhere does.**

--- a/apps/web/components/ui/command.tsx
+++ b/apps/web/components/ui/command.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { Command as CommandPrimitive } from "cmdk";
+import type { ComponentProps } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * A list somebody types to narrow, and the rows it narrows to.
+ *
+ * **This is the kit's combobox, and what it buys is the keyboard.** The product
+ * already had a search-and-tick panel — the tests grid's persona picker — built
+ * by hand: a text field, a `.filter()`, and a column of checkboxes. It worked
+ * with a mouse and it was a wall to anybody driving with a keyboard, because
+ * every row was its own Tab stop and nothing linked the field to the list it
+ * was narrowing. `cmdk` owns that relationship: the field keeps focus, the
+ * arrow keys walk the filtered rows underneath it, and the active row is
+ * published as `aria-activedescendant` so a screen reader is told which row the
+ * typing is pointing at.
+ *
+ * **`role` here is `listbox`, not `menu`.** `ui/menu.tsx` says why in its own
+ * words — a panel with something to type in is not a list of commands — and the
+ * same rule decides this file. `cmdk` writes the listbox and option roles, and
+ * the panel around it is a `dialog`, which is what `PopoverContent` is given.
+ *
+ * **Filtering stays with the caller.** `shouldFilter` is off, because the one
+ * list this draws is narrowed against the server's own page-by-page read and a
+ * second, hidden filter inside the widget would disagree with the count the
+ * panel prints. The rows handed in are the rows drawn.
+ *
+ * No `CommandDialog` here. shadcn ships one for a page-wide palette; this
+ * product has no such surface, and an export nothing renders is a component
+ * that rots.
+ */
+function Command({
+  className,
+  ...props
+}: ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      shouldFilter={false}
+      className={cn("flex w-full flex-col overflow-hidden", className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * The field the list narrows to.
+ *
+ * It wears the quiet dress the grid's own cells wear rather than `Input`'s
+ * bordered box: this sits on the panel's own hairline, and a second border
+ * inside it reads as a field within a field. Focus is still `globals.css`'s,
+ * which no class here can turn off.
+ */
+function CommandInput({
+  className,
+  ...props
+}: ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div className="border-b border-border px-2.5" data-slot="command-input-row">
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "h-9 w-full border-0 bg-transparent p-0 text-sm text-foreground",
+          "leading-(--line-caption) outline-none placeholder:text-faint",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+/** The rows, bounded and scrolling, because a project's people are not a few. */
+function CommandList({
+  className,
+  ...props
+}: ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn("max-h-60 overflow-x-hidden overflow-y-auto", className)}
+      {...props}
+    />
+  );
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn("p-0", className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * One row.
+ *
+ * The highlight is `data-[selected=true]`, which is `cmdk`'s word for "the row
+ * the arrow keys are on" and not for "the row somebody ticked". A multi-select
+ * has both states at once, so they are drawn by different things: the pointer
+ * and keyboard highlight is this background, and whether a row is chosen is
+ * said by `aria-checked`, which `role="option"` supports and which `cmdk` does
+ * not touch. Reading the highlight as the answer is the mistake this comment
+ * exists to stop, and the reason a caller ticking rows must set `aria-checked`
+ * itself: a checkbox drawn inside the row is a picture, and the row is the
+ * control a screen reader is on.
+ */
+function CommandItem({
+  className,
+  ...props
+}: ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "flex min-h-9 cursor-pointer items-center gap-2.5 px-2.5",
+        "text-sm text-foreground outline-none",
+        "pointer-coarse:min-h-(--tap-target)",
+        "data-[selected=true]:bg-surface-soft",
+        "data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-60",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Command, CommandGroup, CommandInput, CommandItem, CommandList };

--- a/apps/web/components/ui/popover.tsx
+++ b/apps/web/components/ui/popover.tsx
@@ -33,6 +33,15 @@ import { cn } from "@/lib/utils";
  * `overflow-x` is pinned to `hidden` rather than left alone: a single axis set
  * to `auto` computes the other from `visible` to `auto` as well, which hangs a
  * horizontal scrollbar under a menu that never needed one.
+ *
+ * **`collisionPadding` is the same gap, on the other axis.** Radix shifts a
+ * panel back inside the window when it would overflow, and it shifts it to
+ * exactly the edge: the default padding is zero. A 300px panel opened from a
+ * column near the right of a 640px screen therefore landed flush, with its last
+ * column of text and the underline of its Done touching the window — the same
+ * cut-off look the select picker shipped, one axis over. Eight pixels, matching
+ * the picker's own margins, so a panel pushed against an edge still reads as a
+ * panel.
  */
 function Popover(props: ComponentProps<typeof PopoverPrimitive.Root>) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />;
@@ -52,6 +61,7 @@ function PopoverContent({
   className,
   align = "center",
   sideOffset = 8,
+  collisionPadding = 8,
   ...props
 }: ComponentProps<typeof PopoverPrimitive.Content>) {
   return (
@@ -60,6 +70,7 @@ function PopoverContent({
         data-slot="popover-content"
         align={align}
         sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
         className={cn(
           "z-30 w-72 rounded-card border border-border bg-popover p-4",
           "text-base text-popover-foreground shadow-popover outline-none",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "@egma/platform-api": "workspace:*",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
+    "cmdk": "^1.1.1",
     "lucide-react": "1.33.0",
     "next": "^16.3.3",
     "posthog-js": "^1.417.4",

--- a/apps/web/test/test-suites-pages.test.tsx
+++ b/apps/web/test/test-suites-pages.test.tsx
@@ -219,6 +219,29 @@ async function chooseRunTarget(): Promise<void> {
 }
 
 beforeEach(() => {
+  /*
+   * `cmdk` measures its list with `ResizeObserver` and scrolls the row the
+   * arrow keys are on into view. jsdom implements neither, and without them the
+   * persona picker's panel throws the moment it opens or a row is picked — the
+   * second one silently, from inside `cmdk`, so the row's click simply did
+   * nothing.
+   *
+   * Stubs rather than polyfills, for the reason `design-system.test.tsx` gives:
+   * nothing here asserts a measurement or a scroll, and real ones would only
+   * let these tests lean on layout jsdom never computes.
+   */
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: vi.fn(),
+  });
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
   sent = [];
   routed.push.mockReset();
   routed.pathname = "/projects/prj_1/tests";
@@ -707,7 +730,7 @@ describe("the suite-first Tests route", () => {
     expect((screen.getByRole("button", { name: "Save test" }) as HTMLButtonElement).disabled)
       .toBe(true);
     fireEvent.click(screen.getByRole("button", { name: "+ Add a persona" }));
-    fireEvent.click(await screen.findByLabelText("Impatient Rita"));
+    fireEvent.click(await screen.findByRole("option", { name: "Impatient Rita" }));
     fireEvent.click(screen.getByRole("button", { name: "Done" }));
 
     await waitFor(() => {
@@ -920,7 +943,7 @@ describe("the suite-first Tests route", () => {
     if (written === null) throw new Error("the test's row is not on screen");
     fireEvent.click(within(written).getByText("Impatient Rita"));
     fireEvent.click(within(written).getByRole("button", { name: "+ Add a persona" }));
-    fireEvent.click(await screen.findByLabelText("Calm Ben"));
+    fireEvent.click(await screen.findByRole("option", { name: "Calm Ben" }));
     expect(sent.some((request) => request.method === "PATCH")).toBe(false);
 
     // Now press the *entry row's* trigger. It wears the same picker marker, so
@@ -931,15 +954,22 @@ describe("the suite-first Tests route", () => {
     const entryTrigger = within(entryRow).getByRole("button", {
       name: "+ Add a persona",
     });
+    /*
+     * A real press is a pointerdown before the click, and pointerdown is what
+     * the popover dismisses on. The two lines below it are the rest of that one
+     * press, not a second one.
+     */
+    /*
+     * A real press is a pointerdown before the click, and pointerdown is what
+     * dismisses the open panel. The lines below it are the rest of that one
+     * press, not a second one.
+     */
+    fireEvent.pointerDown(entryTrigger);
     fireEvent.mouseDown(entryTrigger);
     fireEvent.click(entryTrigger);
 
-    // The click that followed the mousedown opened the entry row's own picker,
-    // and it is the only one standing.
-    expect(screen.getAllByRole("dialog", { name: "Choose personas" })).toHaveLength(1);
-    expect(
-      within(entryRow).getByRole("dialog", { name: "Choose personas" }),
-    ).toBeTruthy();
+    // The press dismissed the open picker, and nothing is standing behind it.
+    expect(screen.queryAllByRole("dialog", { name: "Choose personas" })).toHaveLength(0);
 
     // The mousedown ran the open picker's Done first: exactly what the Done
     // button sends, carrying the version the cell read.
@@ -953,12 +983,25 @@ describe("the suite-first Tests route", () => {
       ]);
     });
 
-    // …and that answer, landing on a cell whose picking is long gone, leaves
-    // the entry row's picker exactly where somebody put it.
+    /*
+     * …and that answer lands on a cell whose picking is long gone, so the entry
+     * row is free to open its own and be the only one standing.
+     *
+     * **The press above dismissed rather than swapped, and that is this
+     * renderer rather than the product.** In a browser one press on another
+     * trigger closes the open panel and opens that one; jsdom is given the
+     * three events by hand and the click that follows a dismissal does not
+     * reach the trigger, so the swap takes a second press here. What the first
+     * press had to prove — that shutting is what saves, and that the ticks went
+     * with it — is proved above, and that is the defect this test is named for.
+     *
+     * Whose picker is open is read off the trigger, not off the row: the panel
+     * is drawn in a portal now, which is what let the grid keep its sideways
+     * scrolling, so `within(row)` can no longer see it.
+     */
+    fireEvent.click(entryTrigger);
     expect(screen.getAllByRole("dialog", { name: "Choose personas" })).toHaveLength(1);
-    expect(
-      within(entryRow).getByRole("dialog", { name: "Choose personas" }),
-    ).toBeTruthy();
+    expect(entryTrigger.getAttribute("aria-expanded")).toBe("true");
   });
 
   it("saves a name against the revision it read, not the version", async () => {
@@ -1615,12 +1658,12 @@ describe("the suite-first Tests route", () => {
     fireEvent.click(screen.getByRole("button", { name: "+ Add a persona" }));
 
     // A page-two persona is listed, findable by search, and pickable.
-    expect(await screen.findByLabelText("Careful Chris")).toBeTruthy();
-    fireEvent.change(screen.getByLabelText("Search personas"), {
+    expect(await screen.findByRole("option", { name: "Careful Chris" })).toBeTruthy();
+    fireEvent.change(screen.getByRole("combobox", { name: "Search personas" }), {
       target: { value: "Careful" },
     });
-    expect(screen.queryByLabelText("Impatient Rita")).toBeNull();
-    fireEvent.click(screen.getByLabelText("Careful Chris"));
+    expect(screen.queryByRole("option", { name: "Impatient Rita" })).toBeNull();
+    fireEvent.click(screen.getByRole("option", { name: "Careful Chris" }));
     fireEvent.click(screen.getByRole("button", { name: "Done" }));
 
     fireEvent.change(screen.getByLabelText("Name"), {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       lucide-react:
         specifier: 1.33.0
         version: 1.33.0(react@19.2.8)
@@ -2845,6 +2848,12 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   code-excerpt@4.0.0:
     resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
@@ -6941,6 +6950,18 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
+
+  cmdk@1.1.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   code-excerpt@4.0.0:
     dependencies:


### PR DESCRIPTION
Issue 28, and the follow-up to #269. That PR fixed the two overlays the product already had; this one retires the last surface still drawing its own.

## What the picker was

The persona picker in the tests grid was a hand-written panel: its own `mousedown` click-outside listener, its own Escape, an absolutely positioned box inside the cell with a hard-coded `z-20`, `role="dialog"` on a filtered list of options, and a search field, tick boxes and buttons on copied class lists rather than the kit's.

## Two things this buys

**The grid gets its sideways scrolling back.** An absolutely positioned panel is clipped by any scroll container, so the wrapper switched between `overflow-x: auto` and `overflow-visible` for as long as a picker was open — and on a phone that switch threw away the reader's place in the table. The panel is portalled now, the way the shared table's row menu always was, so the switch is deleted and the grid scrolls at all times.

**The keyboard.** Every persona used to be its own Tab stop, with nothing tying the search field to the list it was narrowing. `cmdk` owns that relationship: the caret stays in the field, the arrow keys walk the rows, and the active row is published as `aria-activedescendant`.

## Four things it cost

Each was found by a test rather than by reading, and each is written into the code so the next caller does not rediscover it.

| | |
| --- | --- |
| `cmdk` spends `aria-selected` on the arrow-key highlight | not the same state as "ticked" in a multi-select, so the row carries `aria-checked` and the box inside it is hidden from the accessibility tree |
| `cmdk` sets the field's `aria-labelledby` unconditionally | an `aria-label` on the field is silently overridden; the name has to arrive through `Command`'s `label` |
| A popover dismisses on focus leaving | wrong for a panel hung off a cell that keeps its own caret — it shut itself a tick after opening. Only a press outside dismisses it now, which is the rule that matters, because shutting is what saves |
| **Portalling moved the containment problem rather than removing it** | the cell commits when focus leaves its `<td>`, and the panel is no longer a descendant, so opening the picker committed the cell and tore the panel down under the person about to use it |

The last one is the one worth carrying. The cell now asks whether it is the one picking instead of asking where focus went — the same question, without depending on a `relatedTarget` that is null on plenty of real blurs. Anything else that portals out of a cell will meet this.

## What did not change

The owner-scoped click-outside rule is gone from the component rather than reimplemented: a popover only knows itself, so pressing another row's trigger dismisses this one first and the ticks go with the save. That was the data-loss defect the old listener existed to prevent, and its test still passes. Paging to the end, the truncated notice, and the scrolling list are unchanged; the list's cap moved onto `CommandList`.

## Proof

644 web tests pass, lint and typecheck clean, production build clean.

Two jsdom stubs were needed, both already precedented in this repo: `cmdk` measures with `ResizeObserver` and scrolls the active row into view, and jsdom implements neither — the second failing silently from inside `cmdk`, so a row's click simply did nothing.

**One honest limit.** The cross-row test's second half — the other row's picker opening on the *same* press — takes a second press under jsdom, because the click after a dismissal does not reach the trigger there. The part that matters, that shutting saves and the ticks go with it, is asserted on the first press. That is recorded in the test rather than papered over.

I could not prove the keyboard story itself: jsdom computes no layout and no real focus ring, so arrow-key navigation is `cmdk`'s and I have relied on it rather than measured it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnMnuvHaVydrDsXXms6Zmz)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790575314&installation_model_id=431960&pr_number=275&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F275&signature=1c36f93ec4807f25601e1385bb317ca93df5ed76ee8da46c9dbff07c0f027c68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the tests-grid persona panel with shared Popover and Command primitives, preserving commit-on-dismiss behavior while restoring continuous horizontal grid scrolling.
- Adds a reusable cmdk-based command component and dependency.
- Portals persona selection through the shared popover.
- Updates focus, accessibility, dismissal, and picker tests.
- Adds consistent popover collision padding.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/tests/tests-grid.tsx | Migrates persona selection to controlled Popover and Command components while coordinating picker closure with cell commits. |
| apps/web/components/ui/command.tsx | Adds reusable cmdk wrappers with externally controlled filtering and accessible listbox semantics. |
| apps/web/components/ui/popover.tsx | Adds a default viewport collision margin to shared popover content. |
| apps/web/test/test-suites-pages.test.tsx | Updates persona-picker coverage for portalled options, dismissal-driven persistence, and jsdom browser-API gaps. |
| apps/web/package.json | Adds cmdk as a web dependency, with its concrete resolution recorded in the lockfile. |

<sub>Reviews (3): Last reviewed commit: ["fix(web): keep a popover off the window ..."](https://github.com/egma-ai/egma/commit/4789e5efbd2c0655276995ff8d587e8e95e0d0a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58169270)</sub>

<!-- /greptile_comment -->