### PR TITLE
Unblock production deployment and CLI release

### DIFF
--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -1992,7 +1992,9 @@ describe("the saved theme", () => {
       await expect
         .poll(() => page.locator("html").getAttribute("data-theme"))
         .toBe("light");
-      const account = page.locator('aside button[aria-label^="Account"]');
+      const accountSelector = 'aside button[aria-label^="Account"]';
+      await reactHasTakenOver(page, accountSelector);
+      const account = page.locator(accountSelector);
       await account.click();
       const controls = page.getByRole("switch", { name: "Dark theme" });
       await expect.poll(() => controls.count()).toBe(1);
@@ -2012,7 +2014,8 @@ describe("the saved theme", () => {
       await expect
         .poll(() => page.locator("html").getAttribute("data-theme"))
         .toBe("dark");
-      await page.locator('aside button[aria-label^="Account"]').click();
+      await reactHasTakenOver(page, accountSelector);
+      await page.locator(accountSelector).click();
       await expect
         .poll(() => page.getByRole("switch", { name: "Dark theme" }).first().getAttribute("aria-checked"))
         .toBe("true");

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -2927,6 +2927,9 @@ describe("the complete product, walked in order in a second project", () => {
       );
       const handoff = walk.getByRole("dialog", { name: "Connect an agent" });
       await handoff.waitFor();
+      await handoff
+        .getByRole("heading", { level: 3, name: "Simulation" })
+        .waitFor();
       expect(
         await handoff.getByRole("heading", { level: 3 }).allInnerTexts(),
       ).toEqual(["Simulation", "Monitoring", "Both"]);
@@ -3150,6 +3153,9 @@ describe("the complete product, walked in order in a second project", () => {
       await walk.goto(`${at("agents", "new")}?goal=monitoring&platform=livekit`);
       const sheet = walk.getByRole("dialog", { name: "Connect an agent" });
       await sheet.waitFor();
+      await sheet
+        .getByRole("heading", { level: 3, name: "Simulation" })
+        .waitFor();
       expect(
         await sheet.getByRole("heading", { level: 3 }).allInnerTexts(),
         "an old narrowed link still offers all three current outcomes",

--- a/apps/api/test/ingestion-drain.test.ts
+++ b/apps/api/test/ingestion-drain.test.ts
@@ -273,6 +273,9 @@ describe.skipIf(!storage.available)("draining an accepted segment", () => {
       // an arrangement and its assertion.
       scanIntervalMilliseconds: 60 * 60_000,
     });
+    // The product starts with one recovery pass. Finish that pass before this
+    // file begins arranging objects for its explicitly requested passes.
+    await drainer.drainNow();
   });
 
   afterAll(async () => {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egma/cli",
-  "version": "0.2.15",
+  "version": "0.3.1",
   "type": "module",
   "description": "Promptless commands and public agent skills for integrating voice agents with Egma.",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What changed

- Wait for rendered onboarding prompt content before checking all three browser headings.
- Apply the same readiness gate to both browser paths that open the sheet.
- Wait for React hydration before the saved-theme test clicks the server-rendered account menu after reload.
- Finish the drainer's automatic startup recovery pass before arranging objects for explicit test passes.
- Advance the CLI to 0.3.1 because the failed public 0.3.0 tag cannot be reused safely.

## Why

The first main run after PR #279 skipped Deploy because the browser test saw the dialog shell before its prompt content rendered. The separate CLI release stopped because cli-v0.3.0 pointed to a manifest that still declared 0.2.15.

The first run of this PR passed both onboarding cases, then exposed two older synchronization faults elsewhere in the deployment gate: an inert pre-hydration account click and an automatic startup drain racing the test's first object. Both now use the repository's existing readiness contracts; no sleeps or product behavior changed.

## Validation

- pnpm build
- pnpm typecheck after each change
- CLI package created as @egma/cli@0.3.1
- npm publish --dry-run passed for the packed tarball
- git diff --check
- Independent diff review: no findings on the original repair

Docker Desktop is stopped locally. GitHub's real browser and fast lanes are the acceptance proof for the two CI-only races.

## Landing and release

After every check and the exact-head Greptile Review pass, merge this PR. Then verify the complete main deployment before creating cli-v0.3.1 at the exact deployed merge commit and verifying npm latest is 0.3.1.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes browser and ingestion-drain test setup and advances the CLI package version for a releasable tag.
- Waits for React-controlled account actions and rendered onboarding content in browser tests.
- Completes the initial ingestion recovery pass before arranging test objects.
- Updates `@egma/cli` from 0.2.15 to 0.3.1.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/test/browser.test.ts | Adds readiness waits before account interactions and onboarding-heading assertions; no eligible follow-up issue was established. |
| apps/api/test/ingestion-drain.test.ts | Finishes the drainer's initial recovery pass during setup before tests arrange objects. |
| apps/cli/package.json | Advances the public CLI package version to 0.3.1. |

<sub>Reviews (2): Last reviewed commit: ["test: remove deployment gate races"](https://github.com/egma-ai/egma/commit/131df4d9f8374992583f28e6cd1f883b6f8a422e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58720684)</sub>

<!-- /greptile_comment -->