### PR TITLE
Grader sheet Rework and one rationale said once

### DIFF
--- a/apps/web/app/projects/[projectId]/graders/grader-sheets.tsx
+++ b/apps/web/app/projects/[projectId]/graders/grader-sheets.tsx
@@ -574,6 +574,7 @@ export function LibraryGraderSheet({
               <UseGraderForm
                 entry={read}
                 projectId={projectId}
+                open={open}
                 onCancel={() => setMode("details")}
                 onUsed={onUsed}
               />
@@ -660,11 +661,13 @@ function LibraryDetails({
 function UseGraderForm({
   entry,
   projectId,
+  open,
   onCancel,
   onUsed,
 }: {
   readonly entry: GraderLibraryEntry;
   readonly projectId: string;
+  readonly open: boolean;
   readonly onCancel: () => void;
   readonly onUsed: () => void;
 }) {
@@ -685,7 +688,7 @@ function UseGraderForm({
     JSON.stringify(settings) !==
       JSON.stringify(initialSettings(entry.settingDefinitions)) ||
     threshold !== "1";
-  useUnsavedChanges(changed && !saving, saving);
+  useUnsavedChanges(open && changed && !saving, saving);
 
   async function useGrader(): Promise<void> {
     if (!valid || saving) return;
@@ -864,7 +867,7 @@ function EditGraderForm({
     threshold !== String(grader.passThreshold);
   const valid =
     scopeValid && filledSettings !== null && filledThreshold !== null;
-  useUnsavedChanges(changed && !saving, saving);
+  useUnsavedChanges(open && changed && !saving, saving);
 
   async function save(): Promise<void> {
     if (!valid || saving || !changed || !mayAuthor) return;
@@ -1069,7 +1072,7 @@ export function CreateCustomGraderSheet({
     failsWhen !== "" ||
     JSON.stringify(scope) !== JSON.stringify(ALL_SIMULATIONS_SCOPE) ||
     threshold !== "1";
-  useUnsavedChanges(changed && !saving, saving);
+  useUnsavedChanges(open && changed && !saving, saving);
 
   async function create(): Promise<void> {
     if (!valid || saving || filledThreshold === null) return;
@@ -1181,7 +1184,7 @@ export function CreateCustomGraderSheet({
                 value={passesWhen}
                 disabled={saving}
                 aria-required="true"
-                rows={3}
+                rows={2}
                 onChange={(event) => setPassesWhen(event.target.value)}
               />
             </Field>
@@ -1195,7 +1198,7 @@ export function CreateCustomGraderSheet({
                 value={failsWhen}
                 disabled={saving}
                 aria-required="true"
-                rows={3}
+                rows={2}
                 onChange={(event) => setFailsWhen(event.target.value)}
               />
             </Field>

--- a/apps/web/app/projects/[projectId]/graders/page.tsx
+++ b/apps/web/app/projects/[projectId]/graders/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { XIcon } from "lucide-react";
 import Link from "next/link";
 import { useParams, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState, type ReactNode } from "react";
@@ -693,9 +694,34 @@ function ProjectGraders({ projectId }: { readonly projectId: string }) {
         />
         <PageBody>
           {said === null ? null : (
-            <p className="m-0 mb-4 text-sm text-success" role="status">
-              {said}
-            </p>
+            /*
+             * The notice stays until it is dismissed. No timer, on purpose: a
+             * line that removes itself is gone before a person who looked away
+             * could read it. The way out is the same dismiss control the
+             * product's feedback banner uses, and one control serves all four
+             * of this page's messages because refreshAll writes them all here.
+             */
+            <div className="mb-4 flex items-center justify-between gap-3">
+              <p className="m-0 text-sm text-success" role="status">
+                {said}
+              </p>
+              <button
+                className={cn(
+                  "grid size-(--control-sm) shrink-0 cursor-pointer place-items-center p-0",
+                  "rounded-button border-0 bg-transparent text-muted-foreground",
+                  "transition-transform duration-(--duration-press) ease-out",
+                  "pointer-hover:bg-surface-soft pointer-hover:text-foreground",
+                  "[&:active:not(:focus-visible)]:scale-97",
+                  "motion-reduce:transition-none",
+                  "motion-reduce:[&:active:not(:focus-visible)]:scale-100",
+                )}
+                type="button"
+                aria-label={`Dismiss ${said}`}
+                onClick={() => setSaid(null)}
+              >
+                <XIcon className="size-4" />
+              </button>
+            </div>
           )}
           <TabsContent value="active">{activePanel()}</TabsContent>
           <TabsContent value="library">{libraryPanel()}</TabsContent>

--- a/apps/web/test/graders-pages.test.tsx
+++ b/apps/web/test/graders-pages.test.tsx
@@ -19,6 +19,7 @@ import {
   type ProjectGrader,
 } from "../lib/graders.ts";
 import type { Me } from "../lib/me.ts";
+import { currentDraftState } from "../ui/settings-read.ts";
 import { observeRequest, type FetchInput } from "./platform-request.ts";
 
 /*
@@ -289,6 +290,50 @@ function rowOf(name: string): HTMLElement {
   const row = screen.getByRole("button", { name }).closest("tr");
   if (row === null) throw new Error(`no row for ${name}`);
   return row;
+}
+
+/** A create that is answered, so the page's own notice and draft can be read. */
+function answersThatCreateAGrader(): Record<string, Stubbed | Stubbed[]> {
+  return {
+    ...standardAnswers(),
+    "POST /v1/grader-library/custom": {
+      status: 201,
+      body: {
+        definition: {
+          ...LATENCY_DEFINITION,
+          id: "grl_custom",
+          name: "Polite resolution",
+          owner: "organization",
+          type: "llm_as_judge",
+          settingDefinitions: [],
+          activeProjectGraderId: "grd_custom",
+        },
+        grader: {
+          ...LATENCY,
+          id: "grd_custom",
+          graderDefinitionId: "grl_custom",
+          name: "Polite resolution",
+          owner: "organization",
+        },
+      },
+    },
+  };
+}
+
+/** Everything the create sheet asks for before it will send. */
+function fillCustomGrader(sheet: HTMLElement): void {
+  fireEvent.change(within(sheet).getByLabelText("Name*"), {
+    target: { value: "Polite resolution" },
+  });
+  fireEvent.change(within(sheet).getByLabelText("Grading instructions*"), {
+    target: { value: "the agent resolved the request" },
+  });
+  fireEvent.change(within(sheet).getByLabelText("Passes when*"), {
+    target: { value: "the agent confirms the request is done" },
+  });
+  fireEvent.change(within(sheet).getByLabelText("Fails when*"), {
+    target: { value: "the agent leaves the request open" },
+  });
 }
 
 function ScopeHarness() {
@@ -918,6 +963,98 @@ describe("the project Graders surface", () => {
         },
       });
     });
+  });
+
+  /**
+   * The notice a grader change leaves behind stays until somebody clears it.
+   *
+   * It carries no timer on purpose: a line that removed itself after a few
+   * seconds would be gone before a person who looked away could read it. So the
+   * way out is a control, and the control is the product's own icon button with
+   * the dismiss label `ui/feedback.tsx` already uses. One control serves all
+   * four of the page's messages, because `refreshAll` writes them all here.
+   */
+  it("lets a person dismiss the notice a grader change leaves behind", async () => {
+    apiAnswers(answersThatCreateAGrader());
+    render(<GradersPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Create custom grader" }),
+    );
+
+    const sheet = await screen.findByRole("dialog", {
+      name: "Create custom grader",
+    });
+    fillCustomGrader(sheet);
+    fireEvent.click(
+      within(sheet).getByRole("button", { name: "Create grader" }),
+    );
+
+    const said = "Custom grader created and added to Active graders.";
+    expect(await screen.findByText(said)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: `Dismiss ${said}` }));
+    expect(screen.queryByText(said)).toBeNull();
+  });
+
+  /**
+   * A sheet that is not open holds no draft.
+   *
+   * The create sheet stays mounted after it closes — the page renders it
+   * unconditionally — and its fields are reset when it opens rather than when
+   * it closes, so what was typed survives and its `changed` stays true. With no
+   * `open` in the condition, that closed sheet kept a draft registered in the
+   * shared registry, and the next product link asked "Leave without saving?"
+   * about a grader that was already created.
+   */
+  it("stops protecting the custom-grader draft once the sheet closes", async () => {
+    apiAnswers(answersThatCreateAGrader());
+    render(<GradersPage />);
+    let sheet: HTMLElement;
+
+    async function openTheSheet(): Promise<HTMLElement> {
+      fireEvent.click(
+        screen.getByRole("button", { name: "Create custom grader" }),
+      );
+      return await screen.findByRole("dialog", {
+        name: "Create custom grader",
+      });
+    }
+
+    async function waitForTheSheetToClose(): Promise<void> {
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("dialog", { name: "Create custom grader" }),
+        ).toBeNull();
+      });
+    }
+
+    function leaves(): boolean {
+      const leaving = new Event("beforeunload", { cancelable: true });
+      window.dispatchEvent(leaving);
+      return !leaving.defaultPrevented;
+    }
+
+    await screen.findByRole("button", { name: "Create custom grader" });
+    sheet = await openTheSheet();
+    fillCustomGrader(sheet);
+    /* Open and typed into: this is a real draft, and it is protected. */
+    expect(currentDraftState()).toBe("unsaved");
+    expect(leaves()).toBe(false);
+
+    fireEvent.click(
+      within(sheet).getByRole("button", { name: "Create grader" }),
+    );
+    await waitForTheSheetToClose();
+    expect(currentDraftState()).toBe("unchanged");
+    expect(leaves()).toBe(true);
+
+    /* Cancel throws the draft away as plainly as creating does. */
+    sheet = await openTheSheet();
+    fillCustomGrader(sheet);
+    expect(currentDraftState()).toBe("unsaved");
+    fireEvent.click(within(sheet).getByRole("button", { name: "Cancel" }));
+    await waitForTheSheetToClose();
+    expect(currentDraftState()).toBe("unchanged");
+    expect(leaves()).toBe(true);
   });
 
   it("offers no mechanism and no modality choice, and keeps the pass threshold", async () => {

--- a/apps/web/test/transcript-detail.test.tsx
+++ b/apps/web/test/transcript-detail.test.tsx
@@ -651,15 +651,52 @@ describe("what egma made of the exchange", () => {
     expect(grades.textContent).toContain("will appear here");
   });
 
-  it("shows nested assertion details inside the grade", async () => {
+  /*
+   * The stored grade says its one rationale twice — once at the top, once in
+   * its assertion — because the judge copies it. The assertion is the record,
+   * so the top line reads as the count and the sentence appears exactly once.
+   * Cited span ids stay stored but unshown: this surface has no way to say
+   * them that a reader can follow.
+   */
+  it("shows nested assertion details inside the grade, said once", async () => {
     stub({ status: 200, body: detail() });
     await open();
     await settled();
 
+    expect(screen.getByText("1 of 1 assertion passed.")).toBeTruthy();
     expect(screen.getByText("Assertion details")).toBeTruthy();
     expect(screen.getByText("Behavior 1")).toBeTruthy();
-    expect(screen.getAllByText("The agent offered Tuesday and the caller agreed.").length)
-      .toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("The agent offered Tuesday and the caller agreed.")
+        .length,
+    ).toBe(1);
+    expect(screen.queryByText(/Cited spans/)).toBeNull();
+    expect(screen.queryByText(/span_turn_agent/)).toBeNull();
+  });
+
+  it("keeps a written summary above assertions it does not repeat", async () => {
+    const SUMMARIZED = {
+      ...GRADE,
+      details: {
+        rationale: "1 of 1 expected behaviors passed.",
+        assertions: GRADE.details.assertions,
+      },
+    };
+    stub({
+      status: 200,
+      body: detail({
+        grades: [SUMMARIZED],
+        gradeHistory: [SUMMARIZED],
+      }),
+    });
+    await open();
+    await settled();
+
+    expect(screen.getByText("1 of 1 expected behaviors passed.")).toBeTruthy();
+    expect(
+      screen.getAllByText("The agent offered Tuesday and the caller agreed.")
+        .length,
+    ).toBe(1);
   });
 });
 

--- a/apps/web/ui/grade.tsx
+++ b/apps/web/ui/grade.tsx
@@ -15,6 +15,24 @@ function summaryScore(score: number | null): string {
   return score === null ? "Not available" : score.toFixed(2);
 }
 
+/** The count a repeated single-assertion rationale gives way to. */
+function assertionCount(
+  assertions: readonly DisplayGradeAssertion[],
+): string {
+  const total = assertions.length;
+  const unit = total === 1 ? "assertion" : "assertions";
+  const ungraded = assertions.filter(
+    (assertion) => assertion.error !== undefined,
+  ).length;
+  if (ungraded > 0) {
+    return `${String(ungraded)} of ${String(total)} ${unit} could not be graded.`;
+  }
+  const passed = assertions.filter(
+    (assertion) => assertion.score === 1,
+  ).length;
+  return `${String(passed)} of ${String(total)} ${unit} passed.`;
+}
+
 /** The semantic tone shared by a grade badge and its evidence card. */
 export function gradeResultTone(
   result: DisplayGrade["result"],
@@ -85,11 +103,21 @@ export function GradeDetails({
   const rationale = grade.details.rationale;
   const error = grade.details.error;
   const assertions = grade.details.assertions ?? [];
+  /*
+   * The LLM judge writes one assertion and copies its rationale to the top of
+   * the grade, and every stored grade carries that copy. The assertion below is
+   * the record, so a top line that only repeats it becomes the count instead —
+   * computed here, so grades written before this rule read the same way.
+   */
+  const repeated =
+    typeof rationale === "string" &&
+    assertions.some((assertion) => assertion.rationale === rationale);
+  const topLine = repeated ? assertionCount(assertions) : rationale;
 
   return (
     <>
-      {typeof rationale === "string" && rationale.trim() !== "" ? (
-        <p className="m-0 text-sm wrap-anywhere text-foreground">{rationale}</p>
+      {typeof topLine === "string" && topLine.trim() !== "" ? (
+        <p className="m-0 text-sm wrap-anywhere text-foreground">{topLine}</p>
       ) : null}
       {typeof error === "string" && error.trim() !== "" ? (
         <p className="m-0 text-sm wrap-anywhere text-failure">{error}</p>
@@ -125,14 +153,13 @@ export function GradeDetails({
                       {assertion.error}
                     </p>
                   )}
-                  {citations === undefined || citations === null ? (
-                    assertion.citedSpanIds === undefined ||
-                    assertion.citedSpanIds.length === 0 ? null : (
-                      <p className="mt-1 mb-0 wrap-anywhere text-muted-foreground">
-                        Cited spans: {assertion.citedSpanIds.join(", ")}
-                      </p>
-                    )
-                  ) : (
+                  {/*
+                    * Only a surface that can say a citation well says it at
+                    * all: the simulation page passes turn links here. A raw
+                    * span id tells a reader nothing, so without a renderer the
+                    * cited ids stay stored and unshown.
+                    */}
+                  {citations === undefined || citations === null ? null : (
                     <p className="mt-1 mb-0 wrap-anywhere text-muted-foreground">
                       {citations}
                     </p>


### PR DESCRIPTION
Follow-ups from testing the custom-grader boundary form ([#278](https://github.com/egma-ai/egma/pull/278)), settled with the developer 2026-08-31. Design record: the Grade Card Rework artifact.

## The grader sheets

**The success notice is dismissible.** It had no timer and no control, so "Custom grader created…" sat until an unrelated action cleared it. It now carries the product's dismiss control — the same one the feedback banner uses — serving all four of the page's messages. Deliberately no timer: a line that removes itself is gone before a person who looked away could read it.

**A sheet that is not open holds no draft.** All three grader sheets stay mounted after closing, and the create sheet resets on open rather than close, so typed values survived and the shared draft registry kept counting them. The next navigation asked "Leave without saving?" about a grader that was already created — after Cancel too. The `useUnsavedChanges` condition now includes `open`, in all three sheets. Pre-existing bug, not a regression from #278. The web typecheck caught a bonus bug in the fix itself: the Use form has no `open` prop, so the bare word resolved to `window.open` (always truthy) — the sheet's `open` is now threaded down as a prop.

**Passes when and Fails when drop to two rows.** Each side of the boundary is a sentence or two; three equally tall boxes read as three essays rather than one criterion.

## The grade card (trace panel and simulation page — one shared component)

**A top line that repeats its assertion becomes a count.** The LLM judge writes one assertion and copies its rationale to the top of the grade, so every custom grader's card said its explanation twice, verbatim. When the top rationale equals an assertion's rationale it now renders as `1 of 1 assertion passed.` (or `… could not be graded.`), computed at render time — so every grade already stored reads the new way without a regrade. Expected behaviors keeps its own written count untouched (never a repeat), and a grade with no assertions, like Response latency, keeps its paragraph.

**Raw cited-span ids leave the card.** A hex id answers nothing a reader can follow. Citations render only through a surface's own renderer — the simulation page's "Read turn N" links are untouched. The ids stay stored, so a trace-panel citation design can come later with no data work.

## Verification

- Red-first on the draft-guard and dismiss tests: both failed before the fix (2 failed / 23 passed), all pass after.
- Scoped tests across every touched surface: graders pages 25/25, transcript detail 40/40, plus simulation-evidence, run-history, monitoring, feedback — 161/161 combined.
- `pnpm build`, `pnpm lint`, `tsc -p tsconfig.tests.json`, and the web typecheck all green.
- Latest `main` merged in before the PR.

The full suite runs here in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTgk3hcJuJTAEf1CgEUK8j)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790791621&installation_model_id=431960&pr_number=281&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F281&signature=0df84deb9e554a39cbd4aac3cdaafa074ba959f85b30d9bb287d04379a3c686e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refines grader-sheet draft handling and feedback presentation, and removes duplicated or opaque information from shared grade cards.

- Gates unsaved-change registration on whether each grader sheet is open and threads the open state into the library-use form.
- Adds a persistent, dismissible grader-operation notice and reduces custom-grader boundary fields to two rows.
- Replaces duplicated single-assertion rationales with an assertion count and hides raw citation identifiers when no surface-specific renderer exists.
- Adds focused coverage for notice dismissal, closed-sheet draft cleanup, rationale deduplication, and citation presentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The changed draft lifecycle matches the explicitly documented close behavior, while current grade producers constrain rationale replacement to the intended binary single-assertion case and preserve distinct multi-assertion summaries.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/graders/grader-sheets.tsx | Gates draft protection by sheet visibility, supplies the missing open prop to the use form, and reduces boundary textarea height. |
| apps/web/app/projects/[projectId]/graders/page.tsx | Replaces the passive grader-operation status line with a persistent notice carrying an accessible dismiss control. |
| apps/web/ui/grade.tsx | Converts duplicated single-assertion rationales into result counts and suppresses raw citation IDs without affecting rendered citation links. |
| apps/web/test/graders-pages.test.tsx | Adds regression coverage for notice dismissal and draft-registry cleanup after creating or cancelling. |
| apps/web/test/transcript-detail.test.tsx | Covers rationale deduplication, preservation of distinct summaries, and suppression of unrendered citation identifiers. |

<sub>Reviews (1): Last reviewed commit: ["Say a grade&#39;s one rationale once, and co..."](https://github.com/egma-ai/egma/commit/4fd4260733d1f4fe17e1c1168e42e091a7cc3da2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58721161)</sub>

<!-- /greptile_comment -->