### PR TITLE
Settle the second ingestion drainer before tests

### DIFF
--- a/apps/api/test/ingestion-drain.test.ts
+++ b/apps/api/test/ingestion-drain.test.ts
@@ -1091,6 +1091,8 @@ describe.skipIf(!storage.available)("the end fact and the evidence, in either or
       log: { warn: () => undefined, error: () => undefined },
       scanIntervalMilliseconds: 60 * 60_000,
     });
+    // Finish the automatic recovery pass before this suite arranges its first segment.
+    await drainer.drainNow();
   });
 
   afterAll(async () => {

--- a/apps/api/test/ingestion-drain.test.ts
+++ b/apps/api/test/ingestion-drain.test.ts
@@ -780,13 +780,16 @@ describe.skipIf(!storage.available)("draining an accepted segment", () => {
    * lock with the session, so what the holder has afterwards is a dead
    * connection and no claim.
    *
+   * Wait for the backend to finish stopping, so the next assertion observes
+   * the released lock rather than the short gap after Postgres sent the signal.
+   *
    * Scoped to this suite's own database, because an advisory lock is, and
    * because suites share a cluster: an unscoped kill would reach into another
    * suite's deployment and end a claim that is nothing to do with this one.
    */
   async function killTheDrainClaim(): Promise<void> {
     await api.database.sql(
-      `select pg_terminate_backend(pid) from pg_locks
+      `select pg_terminate_backend(pid, 5000) from pg_locks
         where locktype = 'advisory' and classid = $1 and objid = $2
           and granted and pid <> pg_backend_pid()
           and database = (select oid from pg_database


### PR DESCRIPTION
## What changed

Wait for the second ingestion test drainer's automatic startup recovery pass before the suite creates its first segment.

## Why

PR #280 fixed this race in the first drainer block after CI observed it. Independent review found the same startup pattern in the second block: its background pass could consume the first arranged segment before the explicit drain, making the explicit count return zero.

## Validation

- pnpm typecheck
- git diff --check
- Independent review identified this exact missing wait

The database-backed test cannot run locally while Docker Desktop is stopped. The fast lane is the acceptance proof.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790792942&installation_model_id=431960&pr_number=282&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F282&signature=fef599b5b2d9a5aa9a61fd20fd4640ddd3145d7878c10c3145861fabb11acdbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes ingestion-drainer tests deterministic by waiting for the second drainer’s startup recovery pass and by waiting for test-scoped PostgreSQL backend termination.
- Settles the automatic recovery pass before arranging the second suite’s first segment.
- Uses timed backend termination so advisory-lock assertions observe completed shutdown.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/test/ingestion-drain.test.ts | Adds synchronization around drainer startup and advisory-lock-holder termination without introducing an established blocking failure. |

<sub>Reviews (2): Last reviewed commit: ["test: wait for drain claim backend to st..."](https://github.com/egma-ai/egma/commit/82d1fc460caa61706626aebcd6c89d1760eeffa7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58729024)</sub>

<!-- /greptile_comment -->