### PR TITLE
Restore guided web agent onboarding

### DIFF
--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -2915,85 +2915,101 @@ describe("the complete product, walked in order in a second project", () => {
   );
 
   it(
-    "offers three coding-agent setup prompts, then reads the API-seeded agent",
+    "registers an agent, and gives egma a way to reach it",
     async () => {
       // A project nobody has put anything in says it is empty, which is a
       // different sentence from a page that failed to load.
       await walk.goto(at("agents"));
       await saysWithin(walk, "No agents in this project yet");
 
-      /* The web surface offers three outcomes for a coding agent. It performs
-       * no provider discovery or setup write. */
+      /*
+       * **One panel does both halves, and opening it is not a navigation.**
+       * The agent and its first way in used to be two pages with a forward
+       * between them, and an agent that never reached the second one sat in
+       * the list unreachable. Now the control changes query state on the
+       * address the person is already at (founder ruling, 2026-08-24) — it no
+       * longer sends the browser to `/agents/new`, which is why this used to
+       * wait for that address and time out.
+       *
+       * `/agents/new` is still an address and still opens this panel; the
+       * copied-link table below is where that promise is checked, because that
+       * is what a link in the CLI or the documentation actually does.
+       */
       await walk.getByRole("link", { name: "Connect an agent" }).first().click();
       await walk.waitForURL(
         new RegExp(`/projects/${second}/agents\\?sheet=connect$`),
       );
-      const handoff = walk.getByRole("dialog", { name: "Connect an agent" });
-      await handoff.waitFor();
-      await handoff
-        .getByRole("heading", { level: 3, name: "Simulation" })
-        .waitFor();
-      expect(
-        await handoff.getByRole("heading", { level: 3 }).allInnerTexts(),
-      ).toEqual(["Simulation", "Monitoring", "Both"]);
-      expect(
-        await handoff.getByRole("button", { name: /^Copy .* prompt$/u }).allInnerTexts(),
-      ).toEqual(["Copy", "Copy", "Copy"]);
-      const prompts = await handoff.innerText();
-      expect(prompts).toContain("simulation testing for this repository's voice agent end to end");
-      expect(prompts).toContain("production monitoring for this repository's voice agent end to end");
-      expect(prompts).toContain("simulation testing and production monitoring");
-      expect(prompts).toContain("npx --yes @egma/cli");
-      expect(prompts).toContain(`Use ${origin} as the Egma platform URL`);
-      expect(prompts).toContain("Use existing credentials");
-      expect(prompts).toContain("an unsafe conflict");
-      expect(prompts).toContain("real phone run that may cost money");
-      expect(await handoff.locator("input, select, textarea").count()).toBe(0);
-      expect(
-        (
-          await instance.database.sql<{ id: string }>(
-            `select id from agent where project_id = '${second}'`,
-          )
-        ).rows,
-        "opening the handoff writes no agent",
-      ).toEqual([]);
+      await reactHasTakenOver(walk, "form");
 
-      /* A browser test cannot run the coding agent. Seed the downstream API
-       * state directly, then return to the browser to prove only the handoff
-       * and the UI that reads a completed setup. CLI acceptance checks cover
-       * the ordered command writes separately. */
-      const cookie = (await walk.context().cookies(origin))
-        .map((one) => `${one.name}=${one.value}`)
-        .join("; ");
-      const connected = await fetch(`${origin}/v1/agents`, {
-        method: "POST",
-        headers: { "content-type": "application/json", cookie },
-        body: JSON.stringify({
-          projectId: second,
-          name: "The Support line",
-          agentPlatform: "retell",
-          connection: {
-            agentPlatform: "retell",
-            connectionType: "phone_number",
-            accessVariant: "phone_number.public_e164",
-            modality: "voice",
-            config: { phoneNumber: BROWSER_RETELL_NUMBER },
-            platformAgentId: BROWSER_RETELL_AGENT,
-            pullProductionCalls: true,
-            credentials: { apiKey: BROWSER_RETELL_KEY },
-          },
-        }),
-      });
-      expect(connected.status, await connected.clone().text()).toBe(201);
+      /*
+       * **The job comes first.** This one agent will run simulations and pull
+       * Retell production calls, so the browser states that goal before it
+       * chooses the provider. The provider then owns every question that
+       * follows; the browser never invents an Egma-only agent name.
+       */
+      await walk.getByRole("radio", { name: /^Set up both/u }).click();
+      await walk.getByRole("button", { name: "Continue" }).click();
+      await walk.getByRole("radio", { name: "Retell" }).click();
+      await walk.getByRole("button", { name: "Continue" }).click();
+      /* **One key discovers the account.** It is supplied once, then the
+       * person explicitly asks Egma to find the provider's real agents. */
+      const discoveryResponse = walk.waitForResponse(
+        (response) =>
+          response.request().method() === "POST" &&
+          new URL(response.url()).pathname === "/v1/agents:discover",
+      );
+      await walk.fill("#retell-api-key", BROWSER_RETELL_KEY);
+      await walk.getByRole("button", { name: "Find agents" }).click();
+      const discovered = await discoveryResponse;
+      expect(discovered.status(), await discovered.text()).toBe(200);
+      // Retell supplies both the agent name and its available phone route.
+      // The person selects those real account records; Egma does not ask them
+      // to type either record a second time.
+      await walk
+        .getByRole("radio", { name: /^The Support line/u })
+        .click();
+      await walk.getByRole("button", { name: "Continue" }).click();
+      await walk.waitForSelector("#retell-phone-number");
+      expect(await walk.inputValue("#retell-phone-number")).toBe(
+        `phone:${BROWSER_RETELL_NUMBER}`,
+      );
+      /*
+       * **One write, both halves.** `registerAgent` carries the connection, so
+       * there is no window in which the agent exists and nothing can reach it.
+       */
+      const connectionResponse = walk.waitForResponse(
+        (response) =>
+          response.request().method() === "POST" &&
+          new URL(response.url()).pathname === "/v1/agents",
+      );
+      await walk.getByRole("button", { name: "Set up both" }).click();
+      const connected = await connectionResponse;
+      expect(connected.status(), await connected.text()).toBe(201);
 
-      await handoff.getByRole("button", { name: "Close" }).last().click();
-      await walk.waitForURL(new RegExp(`/projects/${second}/agents$`));
-      await walk.goto(at("agents"));
+      /*
+       * **The panel closes onto the list, because the row is the agent.** The
+       * agent page is retired (founder ruling, 2026-08-24): everything it held
+       * is on the row behind the panel, so a save that navigated would be
+       * taking somebody away from what they just made.
+       *
+       * **What is waited for is the outcome, not a navigation.** Closing is a
+       * query-state change on the address the panel was opened over, so there
+       * is no load to wait for: the panel goes, the row arrives, and the
+       * address settles back to the bare list. Waiting on any one of the three
+       * alone would pass while the other two had not happened.
+       */
+      await expect
+        .poll(() => walk.getByRole("dialog").count(), { timeout: 30_000 })
+        .toBe(0);
+      await expect
+        .poll(() => walk.url(), { timeout: 30_000 })
+        .toMatch(new RegExp(`/projects/${second}/agents$`));
       await saysWithin(walk, "The Support line");
       await saysWithin(walk, "Active");
 
-      // The API-seeded connection stores only the public phone destination;
-      // the Retell key and agent id do not enter it.
+      // The selected discovery candidate goes through the generic connection
+      // write. The stored connection is only the public phone destination; the
+      // Retell key and agent id do not enter it.
       const stored = await instance.database.sql<{
         id: string;
         name: string;
@@ -3150,52 +3166,95 @@ describe("the complete product, walked in order in a second project", () => {
   );
 
   it(
-    "keeps an old LiveKit link on the three prompts, then reads the registered agent",
+    "captures LiveKit Monitoring language before it connects the exact Python agent",
     async () => {
-      const deployedName = "appointment-scheduling-langsmith";
-      await walk.goto(`${at("agents", "new")}?goal=monitoring&platform=livekit`);
-      const sheet = walk.getByRole("dialog", { name: "Connect an agent" });
-      await sheet.waitFor();
-      await sheet
-        .getByRole("heading", { level: 3, name: "Simulation" })
-        .waitFor();
-      expect(
-        await sheet.getByRole("heading", { level: 3 }).allInnerTexts(),
-        "an old narrowed link still offers all three current outcomes",
-      ).toEqual(["Simulation", "Monitoring", "Both"]);
-      expect(await sheet.getByText(/monitor_livekit\(ctx\)/u).count()).toBe(0);
-      expect(await sheet.getByText(/monitorLiveKit\(ctx\)/u).count()).toBe(0);
-      expect(await sheet.getByText(/npm install @egma\/livekit/u).count()).toBe(
-        0,
-      );
+      await walk.goto(at("agents"));
+      await walk.getByRole("link", { name: "Connect an agent" }).first().click();
+      await reactHasTakenOver(walk, "form");
 
-      const cookie = (await walk.context().cookies(origin))
-        .map((one) => `${one.name}=${one.value}`)
-        .join("; ");
-      const connected = await fetch(`${origin}/v1/agents`, {
-        method: "POST",
-        headers: { "content-type": "application/json", cookie },
-        body: JSON.stringify({
-          projectId: second,
-          name: deployedName,
-          agentPlatform: "livekit",
-          connection: {
-            agentPlatform: "livekit",
-            connectionType: "livekit_room",
-            accessVariant: "livekit_room.project_credentials",
-            modality: "voice",
-            config: {
-              agentName: deployedName,
-              url: "wss://browser-test.livekit.cloud",
-            },
-            credentials: {
-              apiKey: "browser-livekit-api-key",
-              apiSecret: "browser-livekit-api-secret",
-            },
-          },
-        }),
-      });
-      expect(connected.status, await connected.clone().text()).toBe(201);
+      await walk.getByRole("radio", { name: /^Set up both/u }).click();
+      await walk.getByRole("button", { name: "Continue" }).click();
+      await walk.getByRole("radio", { name: "LiveKit" }).click();
+      await walk.getByRole("button", { name: "Continue" }).click();
+
+      const sheet = walk.getByRole("dialog", { name: "Set up an agent" });
+      await sheet
+        .getByRole("heading", {
+          name: "Add monitoring to your LiveKit agent",
+        })
+        .waitFor();
+      expect(await sheet.innerText()).toContain(
+        "What language is your LiveKit worker?",
+      );
+      expect(await sheet.innerText()).not.toContain("monitor_livekit(ctx)");
+      expect(
+        await sheet.getByRole("tab", { name: "Python" }).getAttribute(
+          "aria-selected",
+        ),
+      ).toBe("false");
+
+      // The switch shows both monitoring contracts before any simulation
+      // connection exists. JavaScript says plainly why Both ends here; Python
+      // can continue into the session-isolated testing path.
+      await sheet.getByRole("tab", { name: "JavaScript" }).click();
+      const javascriptInstructions = await sheet.innerText();
+      expect(javascriptInstructions).toContain("npm install @egma/livekit");
+      expect(javascriptInstructions).toContain("monitorLiveKit(ctx)");
+      expect(javascriptInstructions).toContain("Testing remains unsupported");
+      await sheet.getByRole("tab", { name: "Python" }).click();
+      const pythonInstructions = await sheet.innerText();
+      expect(pythonInstructions).toContain("monitor_livekit(ctx)");
+      expect(pythonInstructions).not.toContain("monitorLiveKit(ctx)");
+      await sheet
+        .getByRole("button", { name: "Continue to simulation" })
+        .click();
+
+      // How the agent is tested is asked before anything is pasted, because it
+      // is the choice a person understands and it decides which credentials
+      // the next screen asks for. This walk is the voice one.
+      await walk.getByRole("radio", { name: /^Voice/u }).click();
+      await walk.getByRole("button", { name: "Continue" }).click();
+      await walk
+        .getByRole("heading", {
+          name: "Connect LiveKit Voice for simulations",
+        })
+        .waitFor();
+
+      const deployedName = "appointment-scheduling-langsmith";
+      await walk.fill("#livekit-agent-name", deployedName);
+      await walk.fill("#config-url", "wss://browser-test.livekit.cloud");
+      await walk.getByLabel("API key*").fill("browser-livekit-api-key");
+      await walk
+        .getByLabel("API secret*")
+        .fill("browser-livekit-api-secret");
+
+      const connectionResponse = walk.waitForResponse(
+        (response) =>
+          response.request().method() === "POST" &&
+          new URL(response.url()).pathname === "/v1/agents",
+      );
+      await walk
+        .getByRole("button", { name: "Continue to testing" })
+        .click();
+      const connected = await connectionResponse;
+      expect(connected.status(), await connected.text()).toBe(201);
+
+      await sheet
+        .getByRole("heading", {
+          name: "Add simulation testing to your LiveKit agent",
+        })
+        .waitFor();
+      expect(await sheet.innerText()).toContain(
+        "await mockable(agent, ctx, session)",
+      );
+      expect(
+        await sheet.getByRole("button", { name: /start monitoring/iu }).count(),
+        "LiveKit monitoring is configured in customer code, not toggled here",
+      ).toBe(0);
+      expect(
+        await sheet.getByRole("button", { name: /stop monitoring/iu }).count(),
+      ).toBe(0);
+
       const stored = await instance.database.sql<{
         agent_name: string;
         agent_platform: string;
@@ -3224,9 +3283,10 @@ describe("the complete product, walked in order in a second project", () => {
         },
       ]);
 
-      await sheet.getByRole("button", { name: "Close" }).last().click();
-      await walk.waitForURL(new RegExp(`/projects/${second}/agents$`));
-      await walk.goto(at("agents"));
+      await sheet.getByRole("button", { name: "Return to agents" }).click();
+      await expect
+        .poll(() => walk.getByRole("dialog").count(), { timeout: 30_000 })
+        .toBe(0);
       const row = walk
         .locator('table[aria-label="Agents in this project"] tbody tr')
         .filter({ hasText: deployedName })
@@ -3821,6 +3881,8 @@ describe("the complete product, walked in order in a second project", () => {
     readonly says: string;
     /** A route that opens a named sheet reads that sheet, not the page behind it. */
     readonly dialog?: string;
+    /** A goal-carrying deep link can also promise which choice is selected. */
+    readonly selectedRadio?: string;
     /**
      * Where this address ends up, when that is not itself.
      *
@@ -3863,9 +3925,9 @@ describe("the complete product, walked in order in a second project", () => {
       {
         what: "Register an agent",
         address: at("agents", "new"),
-        // The deep link opens the same coding-agent handoff as the list.
-        dialog: "Connect an agent",
-        says: "Copy one prompt into the coding agent",
+        // The deep link opens the same goal-first setup sheet as the list.
+        dialog: "Set up an agent",
+        says: "What do you want Egma to do?",
       },
       /*
        * **A retired address, kept in the table on purpose.** The agent page is
@@ -3885,9 +3947,10 @@ describe("the complete product, walked in order in a second project", () => {
       {
         what: "Add a connection",
         address: `${agentAddress}/connections/new`,
-        // Adding a connection now hands the repository work to a coding agent.
-        dialog: "Connect an agent",
-        says: "Copy one prompt into the coding agent",
+        // Adding a connection uses the same goal-first state machine for this
+        // existing agent.
+        dialog: "Set up an agent",
+        says: "What do you want Egma to do?",
       },
       {
         what: "one connection",
@@ -3968,19 +4031,20 @@ describe("the complete product, walked in order in a second project", () => {
         address: at("monitoring", "start"),
         /*
          * **The retired Start-monitoring address, now a forwarding deep link.**
-         * The full page is gone: Agents owns one coding-agent handoff, and
-         * this address carries an old Monitoring link into that sheet.
+         * The full page is gone: Agents owns one goal-first setup flow, and
+         * this address carries the Monitoring goal into that flow.
          *
          * The phrase is the open sheet's own, so the walk cannot pass on the
          * Agents list behind it. The redirect target is exact because the
-         * query is kept so the old copied address still lands safely.
+         * query is the durable setup state a copied link must keep.
          *
          * The Traces list itself is not here: this walk opens it many times
          * already, under `monitoringAt`, and against its own states.
          */
-        lands: `${at("agents")}?sheet=connect`,
-        dialog: "Connect an agent",
-        says: "Copy one prompt into the coding agent",
+        lands: `${at("agents")}?sheet=connect&goal=monitoring`,
+        dialog: "Set up an agent",
+        says: "What do you want Egma to do?",
+        selectedRadio: "Monitor production",
       },
       {
         what: "Settings",
@@ -4024,6 +4088,16 @@ describe("the complete product, walked in order in a second project", () => {
     await expect
       .poll(() => surface.innerText().catch(() => ""), { timeout: 30_000 })
       .toContain(route.says);
+    const selectedRadio = route.selectedRadio;
+    if (selectedRadio !== undefined) {
+      await expect
+        .poll(() =>
+          surface
+            .getByRole("radio", { name: selectedRadio })
+            .isChecked(),
+        )
+        .toBe(true);
+    }
   }
 
   /**
@@ -4768,7 +4842,7 @@ describe("the complete product, walked in order in a second project", () => {
      * than survive it.
      */
     it(
-      "uses the settled compact tokens on the shell, a list and an editor",
+      "uses the settled compact tokens on the shell, a list and a form",
       async () => {
         await walk.goto(at("agents"));
         await walk.locator("table tbody tr").first().waitFor({ timeout: 30_000 });
@@ -4786,16 +4860,23 @@ describe("the complete product, walked in order in a second project", () => {
         expect(row).toBeGreaterThanOrEqual(tokens.row);
         expect(row).toBeLessThanOrEqual(tokens.row + tokens.control);
 
-        // An editor's controls are the same height as the ones in a toolbar,
-        // which stops the editor from becoming a different product. Agent
-        // setup is now a copy-only handoff, so the suite sheet supplies the
-        // representative editable field.
+        // A form's controls are the same height as the ones in a toolbar, which
+        // is what stops an editor from becoming a different product.
+        await walk.goto(at("agents", "new"));
+        await reactHasTakenOver(walk, "form");
+        await walk.getByRole("radio", { name: /^Run simulations/u }).click();
+        await walk.getByRole("button", { name: "Continue" }).click();
+        await walk.getByRole("radio", { name: "Retell" }).click();
+        await walk.getByRole("button", { name: "Continue" }).click();
+        const field = Math.round(await heightOf(walk, "#retell-api-key"));
+        expect(field).toBe(tokens.control);
+
+        // The tests grid draws no form of its own — its cells are the form —
+        // so the paired reading is the suite sheet's own field.
         await walk.goto(at("tests"));
         await reactHasTakenOver(walk, "main");
         await walk.getByRole("button", { name: "Create suite" }).click();
-        expect(Math.round(await heightOf(walk, "#suite-name"))).toBe(
-          tokens.control,
-        );
+        expect(Math.round(await heightOf(walk, "#suite-name"))).toBe(field);
 
         // And a transcript is dense: its turns are lines rather than cards.
         await walk.goto(runAddress);

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/connections/new/page.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/connections/new/page.tsx
@@ -10,18 +10,20 @@ import { AgentsScreen } from "../../../screen.tsx";
  * A first connection for one agent — the address, which is now a state of the
  * list.
  *
- * The old address remains valid, but the sheet now hands the repository work
- * to a coding agent. It does not keep wizard state or make setup writes.
+ * The kept address is the same argument as `agents/new`: the CLI, the
+ * documentation and the browser walk all point here.
  */
 export default function NewConnectionPage() {
-  const { projectId } = useParams<{
+  const { projectId, agentId } = useParams<{
     projectId: string;
     agentId: string;
   }>();
-
   return (
     <AppShell>
-      <AgentsScreen projectId={projectId} forced={{ kind: "connect" }} />
+      <AgentsScreen
+        projectId={projectId}
+        forced={{ kind: "connect", agentId }}
+      />
     </AppShell>
   );
 }

--- a/apps/web/app/projects/[projectId]/agents/agent-details-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/agents/agent-details-sheet.tsx
@@ -193,7 +193,8 @@ export function AgentDetailsSheet({
   const simulation = simulationCapabilityOf(agent);
   const monitoring = monitoringCapabilityOf(agent);
   const mockTools = mockToolsCapabilityOf(agent);
-  const setup = `${home}?sheet=connect`;
+  const setup = (goal: "simulation" | "monitoring") =>
+    `${home}?sheet=connect&agent=${encodeURIComponent(agent.id)}&goal=${goal}&platform=${provider}`;
   const restoreFocus = useSheetReturnFocus(returnFocusTo);
 
   return (
@@ -232,7 +233,7 @@ export function AgentDetailsSheet({
               <h2 className="m-0 text-base font-medium" id="agent-connections-heading">
                 Connections
               </h2>
-              <Link className="text-sm underline decoration-border underline-offset-4 pointer-hover:decoration-foreground" href={setup}>
+              <Link className="text-sm underline decoration-border underline-offset-4 pointer-hover:decoration-foreground" href={setup("simulation")}>
                 Add connection
               </Link>
             </div>
@@ -279,7 +280,7 @@ export function AgentDetailsSheet({
                   simulation === "Configured" ? undefined : (
                     <Link
                       className="text-sm underline decoration-border underline-offset-4 pointer-hover:decoration-foreground"
-                      href={setup}
+                      href={setup("simulation")}
                     >
                       Set up simulation
                     </Link>
@@ -298,7 +299,7 @@ export function AgentDetailsSheet({
                   provider === "livekit" ? (
                     <Link
                       className="text-sm underline decoration-border underline-offset-4 pointer-hover:decoration-foreground"
-                      href={setup}
+                      href={setup("monitoring")}
                     >
                       View setup instructions
                     </Link>
@@ -316,7 +317,7 @@ export function AgentDetailsSheet({
                   ) : (
                     <Link
                       className="text-sm underline decoration-border underline-offset-4 pointer-hover:decoration-foreground"
-                      href={setup}
+                      href={setup("monitoring")}
                     >
                       {monitoring === "Stopped" ? "Resume monitoring" : "Set up monitoring"}
                     </Link>

--- a/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
@@ -664,6 +664,50 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
     };
   }
 
+  async function startRetellMonitoringFor(
+    targetAgentId: string,
+    targetPlatformAgentId: string,
+  ): Promise<boolean> {
+    setSaving(true);
+    setRefused(null);
+    const answer = await platformAnswer(
+      startMonitoring(
+        {
+          projectId,
+          agentPlatform: "retell",
+          ...(storedRetellKey ? {} : { apiKey: apiKey.trim() }),
+          watch: [
+            {
+              agentId: targetAgentId,
+              platformAgentId: targetPlatformAgentId,
+            },
+          ],
+        },
+        { client: platformClient },
+      ),
+    );
+    setSaving(false);
+    if (!finishAnswer(answer)) return false;
+
+    const watching = answer.value.watching.find(
+      (one) => one.agentId === targetAgentId,
+    );
+    if (watching === undefined) {
+      const refusal = answer.value.refused.find(
+        (one) => one.platformAgentId === targetPlatformAgentId,
+      );
+      setRefused({
+        error: "monitoring_not_started",
+        message:
+          refusal?.message ??
+          "Egma did not start monitoring this agent. Try again.",
+      });
+      return false;
+    }
+
+    return true;
+  }
+
   async function resumeRetellMonitoring(): Promise<ConnectSheetResult | null> {
     if (
       agentId === undefined ||
@@ -674,41 +718,11 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
       return null;
     }
 
-    setSaving(true);
-    setRefused(null);
-    const answer = await platformAnswer(
-      startMonitoring(
-        {
-          projectId,
-          agentPlatform: "retell",
-          watch: [
-            {
-              agentId,
-              platformAgentId: known.platformAgentId,
-            },
-          ],
-        },
-        { client: platformClient },
-      ),
+    const started = await startRetellMonitoringFor(
+      agentId,
+      known.platformAgentId,
     );
-    setSaving(false);
-    if (!finishAnswer(answer)) return null;
-
-    const watching = answer.value.watching.find(
-      (one) => one.agentId === agentId,
-    );
-    if (watching === undefined) {
-      const refusal = answer.value.refused.find(
-        (one) => one.platformAgentId === known.platformAgentId,
-      );
-      setRefused({
-        error: "monitoring_not_started",
-        message:
-          refusal?.message ??
-          "Egma did not start monitoring this agent. Try again.",
-      });
-      return null;
-    }
+    if (!started) return null;
 
     return { agentId, connectionId: null, created: false };
   }
@@ -744,7 +758,12 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
       retellProgress?.signature === retellSaveSignature
         ? retellProgress
         : null;
-    let landed: ConnectSheetResult | null = saved?.landed ?? null;
+    const existingLanding =
+      agentId === undefined || agentId === NEW_AGENT
+        ? null
+        : { agentId, connectionId: null, created: false };
+    let landed: ConnectSheetResult | null =
+      saved?.landed ?? existingLanding;
     const firstUnsavedLane = saved?.completedLanes ?? 0;
     let retryConnections: readonly ListedConnection[] = [];
     let retryPullEnabled = false;
@@ -779,8 +798,29 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
       const committed = retryConnections.find((one) =>
         sameConnection(one, body),
       );
+      if (
+        committed !== undefined &&
+        pullsProduction &&
+        !retryPullEnabled
+      ) {
+        const started = await startRetellMonitoringFor(
+          landed?.agentId ?? committed.agentId,
+          selectedRetellAgent.platformAgentId,
+        );
+        if (!started) return;
+        retryPullEnabled = true;
+      }
+      if (committed === undefined && landed !== null) {
+        // Preserve the landed agent even when this POST commits but its
+        // response is lost, including a one-lane setup on an existing agent.
+        setRetellProgress({
+          signature: retellSaveSignature,
+          completedLanes: index,
+          landed,
+        });
+      }
       const result =
-        committed !== undefined && (!pullsProduction || retryPullEnabled)
+        committed !== undefined
           ? {
               agentId: landed?.agentId ?? committed.agentId,
               connectionId: committed.id,

--- a/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
@@ -5,6 +5,7 @@ import {
   addConnection,
   discoverAgents,
   getAgent,
+  listAgents,
   listConnectionOptions,
   registerAgent,
   startMonitoring,
@@ -92,6 +93,10 @@ export type ConnectSheetResult = {
 
 export type ConnectAgentGoal = AgentSetupGoal;
 export type ConnectAgentPlatform = AgentSetupPlatform;
+export type RetellRecovery = {
+  readonly agentId: string | null;
+  readonly platformAgentId: string;
+};
 
 type ConnectionBody = NonNullable<
   Parameters<typeof registerAgent>[0]["connection"]
@@ -132,8 +137,10 @@ type ConnectAgentSheetProps = {
   readonly platform?: ConnectAgentPlatform;
   readonly mayAuthor: boolean;
   readonly role: string | null;
+  readonly retellRecovery: RetellRecovery | null;
   readonly onClose: () => void;
   readonly onConnected: (result: ConnectSheetResult) => void;
+  readonly onRecoveryNeeded: (recovery: RetellRecovery) => void;
 };
 
 const NEW_AGENT = "";
@@ -188,8 +195,10 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
     platform: initialPlatform,
     mayAuthor,
     role,
+    retellRecovery,
     onClose,
     onConnected,
+    onRecoveryNeeded,
   } = props;
   const draftNavigation = useDraftNavigation();
 
@@ -645,7 +654,7 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
       return {
         agentId: answer.value.agent.id,
         connectionId: answer.value.connection?.id ?? null,
-        created: true,
+        created: answer.value.result === "created",
       };
     }
 
@@ -742,6 +751,27 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
     if (goal === "" || selectedRetellAgent === undefined) return;
     if (lanesToSave.length === 0) return;
 
+    const requestedLanes: Array<{
+      readonly body: ConnectionBody;
+      readonly pullsProduction: boolean;
+    }> = [];
+    for (const lane of lanesToSave) {
+      const candidate = retellCandidateForLane(
+        selectedRoutes,
+        lane,
+        retellRoute,
+      );
+      if (candidate === undefined) return;
+      const option = optionNamed(catalog, candidate);
+      if (option === undefined) return;
+      const pullsProduction =
+        plan?.pullWithConnection === true && lane === "phone";
+      requestedLanes.push({
+        body: connectionBody(option, candidate, pullsProduction),
+        pullsProduction,
+      });
+    }
+
     const resumesStoredMonitoring =
       goal !== "simulation" &&
       storedRetellKey &&
@@ -758,16 +788,77 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
       retellProgress?.signature === retellSaveSignature
         ? retellProgress
         : null;
-    const existingLanding =
+    const explicitLanding =
       agentId === undefined || agentId === NEW_AGENT
         ? null
         : { agentId, connectionId: null, created: false };
+    const recoveryLanding =
+      retellRecovery !== null &&
+      retellRecovery.platformAgentId ===
+        selectedRetellAgent.platformAgentId &&
+      retellRecovery.agentId !== null
+        ? {
+            agentId: retellRecovery.agentId,
+            connectionId: null,
+            created: false,
+          }
+        : null;
+    const exactLandings = (
+      listed: readonly ListedAgentWithConnections[],
+    ): readonly ListedAgentWithConnections[] =>
+      listed.filter(
+        (one) =>
+          one.agentPlatform === "retell" &&
+          one.platformAgentId === selectedRetellAgent.platformAgentId &&
+          one.connections.some((stored) =>
+            requestedLanes.some(({ body }) => sameConnection(stored, body)),
+          ),
+      );
+    let listedLandings =
+      saved !== null || explicitLanding !== null || recoveryLanding !== null
+        ? []
+        : exactLandings(agents);
+    if (
+      saved === null &&
+      explicitLanding === null &&
+      recoveryLanding === null &&
+      listedLandings.length === 0 &&
+      retellRecovery?.platformAgentId ===
+        selectedRetellAgent.platformAgentId
+    ) {
+      setSaving(true);
+      setRefused(null);
+      const answer = await platformAnswer(
+        listAgents({ projectId }, { client: platformClient }),
+      );
+      setSaving(false);
+      if (!finishAnswer(answer)) return;
+      listedLandings = exactLandings(answer.value.agents);
+    }
+    if (listedLandings.length > 1) {
+      setRefused({
+        error: "unprocessable",
+        message:
+          "More than one Egma agent already has this Retell setup. Open the agent you want to finish, then try again.",
+      });
+      return;
+    }
+    const listedLanding = listedLandings[0];
     let landed: ConnectSheetResult | null =
-      saved?.landed ?? existingLanding;
-    const firstUnsavedLane = saved?.completedLanes ?? 0;
+      saved?.landed ??
+      explicitLanding ??
+      recoveryLanding ??
+      (listedLanding === undefined
+        ? null
+        : {
+            agentId: listedLanding.id,
+            connectionId: null,
+            created: false,
+          });
     let retryConnections: readonly ListedConnection[] = [];
     let retryPullEnabled = false;
-    if (saved !== null && landed !== null) {
+    let readReusedLanding = false;
+    if (landed !== null) {
       setSaving(true);
       setRefused(null);
       const answer = await platformAnswer(
@@ -781,23 +872,42 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
       retryConnections = answer.value.connections;
       retryPullEnabled = answer.value.agent.pullProductionCalls;
     }
-    for (const [index, lane] of lanesToSave.entries()) {
-      if (index < firstUnsavedLane) continue;
-      const candidate = retellCandidateForLane(selectedRoutes, lane, retellRoute);
-      if (candidate === undefined) return;
-      const option = optionNamed(catalog, candidate);
-      if (option === undefined) return;
-      const pullsProduction =
-        plan?.pullWithConnection === true && lane === "phone";
-      const body = connectionBody(option, candidate, pullsProduction);
+    for (const [index, { body, pullsProduction }] of requestedLanes.entries()) {
+      if (readReusedLanding && landed !== null) {
+        setSaving(true);
+        setRefused(null);
+        const answer = await platformAnswer(
+          getAgent(
+            { agentId: landed.agentId, projectId },
+            { client: platformClient },
+          ),
+        );
+        setSaving(false);
+        if (!finishAnswer(answer)) return;
+        retryConnections = answer.value.connections;
+        retryPullEnabled = answer.value.agent.pullProductionCalls;
+        readReusedLanding = false;
+      }
       /*
        * A provider write can commit while its HTTP response is lost. On a
-       * retry, read the landed agent first and accept the exact lane already
-       * there instead of issuing the non-idempotent POST a second time.
+       * retry or reopen, accept the exact lane already there instead of
+       * issuing the non-idempotent POST a second time. `retellProgress` only
+       * explains partial work in the UI; the server read decides what exists.
        */
       const committed = retryConnections.find((one) =>
         sameConnection(one, body),
       );
+      if (committed !== undefined && landed !== null) {
+        onRecoveryNeeded({
+          agentId: landed.agentId,
+          platformAgentId: selectedRetellAgent.platformAgentId,
+        });
+        setRetellProgress({
+          signature: retellSaveSignature,
+          completedLanes: index + 1,
+          landed,
+        });
+      }
       if (
         committed !== undefined &&
         pullsProduction &&
@@ -819,24 +929,37 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
           landed,
         });
       }
-      const result =
-        committed !== undefined
-          ? {
-              agentId: landed?.agentId ?? committed.agentId,
-              connectionId: committed.id,
-              created: landed?.created ?? false,
-            }
-          : await saveConnection(
-              selectedRetellAgent.name,
-              body,
-              landed?.agentId,
-            );
+      let result: ConnectSheetResult | null;
+      if (committed !== undefined) {
+        result = {
+          agentId: landed?.agentId ?? committed.agentId,
+          connectionId: committed.id,
+          created: landed?.created ?? false,
+        };
+      } else {
+        // The request may commit even when its answer never reaches this tab.
+        // Keep the parent screen in recovery mode before the write begins so
+        // Close, retry, or a filtered list cannot turn that uncertainty into a
+        // second non-idempotent request.
+        onRecoveryNeeded({
+          agentId: landed?.agentId ?? null,
+          platformAgentId: selectedRetellAgent.platformAgentId,
+        });
+        result = await saveConnection(
+          selectedRetellAgent.name,
+          body,
+          landed?.agentId,
+        );
+      }
       if (result === null) return;
+      const landedBeforeThisLane = landed;
       landed = {
         ...result,
         agentId: landed === null ? result.agentId : landed.agentId,
         created: landed?.created ?? result.created,
       };
+      readReusedLanding =
+        landedBeforeThisLane === null && result.created === false;
       const progress = {
         signature: retellSaveSignature,
         completedLanes: index + 1,

--- a/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
@@ -1,146 +1,1640 @@
 "use client";
 
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  addConnection,
+  discoverAgents,
+  getAgent,
+  listConnectionOptions,
+  registerAgent,
+  startMonitoring,
+} from "@egma/platform-api/client";
+
 import { Button } from "@/components/ui/button";
-import { useEffect, useState } from "react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import {
+  RadioCardIndicator,
+  RadioGroup,
+  RadioGroupItem,
+} from "@/components/ui/radio-group";
+import { Select } from "@/components/ui/select";
 import {
   Sheet,
   SheetBody,
   SheetContent,
-  SheetDescription,
   SheetFooter,
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
-import { Loading, NotFound } from "@/ui/page-state.tsx";
+import type { Answer, Refusal } from "@/lib/api.ts";
+import {
+  modalityLabel,
+  type ListedAgentWithConnections,
+} from "@/lib/agents.ts";
+import {
+  optionNamed,
+  optionsForPlatform,
+  type ConnectionOption,
+  type ConnectionOptionCatalog,
+  type DiscoveredAgent,
+} from "@/lib/connection-options.ts";
+import {
+  agentSetupPlan,
+  previousAgentSetupStep,
+  retellAgentCanEnterPlan,
+  retellAgentsForPlan,
+  retellCandidateForLane,
+  retellCandidateValue,
+  retellCandidatesForPlan,
+  retellLanesInOrder,
+  RETELL_LANES,
+  RETELL_LANE_HELP,
+  RETELL_LANE_LABELS,
+  RETELL_LANE_QUESTION,
+  stepAfterRetellLanes,
+  type RetellLane,
+  stepAfterLiveKitTesting,
+  stepAfterLiveKitCredentials,
+  stepAfterPlatform,
+  stepAfterRetellAgent,
+  type AgentSetupGoal,
+  type AgentSetupPlatform,
+  type AgentSetupStep,
+  type LiveKitWorkerLanguage,
+  type RetellConnectionCandidate,
+} from "@/lib/agent-setup-flow.ts";
+import { platformAnswer, platformClient } from "@/lib/platform-client.ts";
+import { cn } from "@/lib/utils";
+import {
+  Field,
+  Help,
+  Problem,
+  Refused as FormRefused,
+} from "@/ui/form.tsx";
+import { useDraftNavigation } from "@/ui/draft-navigation.tsx";
+import { Empty, Failure, Loading, NotFound } from "@/ui/page-state.tsx";
+import { useUnsavedChanges } from "@/ui/settings-read.ts";
 
-import { CopyBlock } from "./copy-block.tsx";
+import { LiveKitTestingInstructions } from "./livekit-testing-instructions.tsx";
+import { LiveKitMonitoringInstructions } from "./livekit-monitoring-instructions.tsx";
+import {
+  ConnectionFields,
+  type Draft,
+} from "./[agentId]/connections/fields.tsx";
+
+export type ConnectSheetResult = {
+  readonly agentId: string;
+  readonly connectionId: string | null;
+  readonly created: boolean;
+};
+
+export type ConnectAgentGoal = AgentSetupGoal;
+export type ConnectAgentPlatform = AgentSetupPlatform;
+
+type ConnectionBody = NonNullable<
+  Parameters<typeof registerAgent>[0]["connection"]
+>;
+
+type RetellSaveProgress = {
+  readonly signature: string;
+  readonly completedLanes: number;
+  readonly landed: ConnectSheetResult;
+};
 
 type ConnectAgentSheetProps = {
+  readonly projectId: string;
+  readonly agents: readonly ListedAgentWithConnections[];
+  readonly agentId?: string;
+  readonly goal?: ConnectAgentGoal;
+  readonly platform?: ConnectAgentPlatform;
   readonly mayAuthor: boolean;
   readonly role: string | null;
   readonly onClose: () => void;
+  readonly onConnected: (result: ConnectSheetResult) => void;
 };
 
-function sharedHandoff(platformUrl: string): string {
-  return (
-  `Use ${platformUrl} as the Egma platform URL. ` +
-  "Start by running `egma` if available or `npx --yes @egma/cli` otherwise. " +
-  "Follow the coding-agent handoff. Use existing credentials. " +
-  "Ask the developer only for browser authorization, a missing credential, " +
-  "a choice that cannot be safely inferred, an unsafe conflict, or approval " +
-  "before a real phone run that may cost money."
-  );
-}
-
-export function agentSetupPrompts(platformUrl: string) {
-  const handoff = sharedHandoff(platformUrl);
-  return [
-    {
-      id: "simulation",
-      title: "Simulation",
-      value:
-        "Set up Egma simulation testing for this repository's voice agent end to end. " +
-        handoff,
-    },
-    {
-      id: "monitoring",
-      title: "Monitoring",
-      value:
-        "Set up Egma production monitoring for this repository's voice agent end to end. " +
-        handoff,
-    },
-    {
-      id: "both",
-      title: "Both",
-      value:
-        "Set up Egma simulation testing and production monitoring for this " +
-        "repository's voice agent end to end. " +
-        handoff,
-    },
-  ] as const;
-}
+const NEW_AGENT = "";
+const SHORTEST_KEY = 8;
+const PROJECT_CREDENTIALS = "livekit_room.project_credentials";
+const TOKEN_ENDPOINT = "livekit_room.customer_token_endpoint";
 
 /**
- * Hand setup to the coding agent that already owns the repository.
+ * What each modality is, said as the difference a person is choosing between.
  *
- * Old links can still select this sheet, but their query values do not narrow
- * the handoff: all three outcomes stay visible. The prompt carries this
- * platform address, and the coding agent discovers the repository, provider,
- * and existing credential state; this sheet performs no platform operation.
+ * Which of the two are offered is the catalog's answer and never this file's.
+ * What each one means is product language, and it is written once here so the
+ * card cannot say one thing while the surface after it says another.
  */
-export function ConnectAgentSheet({
-  mayAuthor,
-  role,
-  onClose,
-}: ConnectAgentSheetProps) {
-  const [platformUrl, setPlatformUrl] = useState<string | null>(null);
+const MODALITY_CHOICES: Readonly<
+  Record<"chat" | "voice", { readonly title: string; readonly description: string }>
+> = {
+  voice: {
+    title: "Voice",
+    description:
+      "Egma speaks to the agent in the room, the way a person reaches it. Your Python worker needs the Egma testing hook, which Egma shows you next.",
+  },
+  chat: {
+    title: "Chat",
+    description:
+      "Egma types to the agent and reads its words back. Fast, and it spends nothing on speech. Your worker needs a short setup, which Egma shows you next.",
+  },
+};
 
-  useEffect(() => setPlatformUrl(window.location.origin), []);
+function firstStep(
+  goal: AgentSetupGoal | undefined,
+  platform: AgentSetupPlatform | undefined,
+): AgentSetupStep {
+  if (goal !== undefined && platform !== undefined) {
+    return stepAfterPlatform(goal, platform);
+  }
+  return "goal";
+}
+
+function retellModality(
+  agent: DiscoveredAgent | undefined,
+): "chat" | "voice" | null {
+  return agent?.modality ?? null;
+}
+
+export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
+  const {
+    projectId,
+    agents,
+    agentId,
+    goal: initialGoal,
+    platform: initialPlatform,
+    mayAuthor,
+    role,
+    onClose,
+    onConnected,
+  } = props;
+  const draftNavigation = useDraftNavigation();
+
+  const [step, setStep] = useState<AgentSetupStep>(() =>
+    firstStep(initialGoal, initialPlatform),
+  );
+  const [goal, setGoal] = useState<AgentSetupGoal | "">(initialGoal ?? "");
+  const [platform, setPlatform] = useState<AgentSetupPlatform | "">(
+    initialPlatform ?? "",
+  );
+
+  const [catalog, setCatalog] = useState<ConnectionOptionCatalog | null>(null);
+  const [catalogRefused, setCatalogRefused] = useState<Refusal | null>(null);
+  const [catalogAttempt, setCatalogAttempt] = useState(0);
+  const listedKnown =
+    agentId === undefined || agentId === NEW_AGENT
+      ? undefined
+      : agents.find((one) => one.id === agentId);
+  const [known, setKnown] = useState<
+    Omit<ListedAgentWithConnections, "connections"> | null
+  >(() => listedKnown ?? null);
+  const [knownStatus, setKnownStatus] = useState<
+    "loading" | "ready" | "missing" | "failed"
+  >(() =>
+    agentId !== undefined && agentId !== NEW_AGENT && listedKnown === undefined
+      ? "loading"
+      : "ready",
+  );
+  const [knownRefused, setKnownRefused] = useState<Refusal | null>(null);
+  const [knownAttempt, setKnownAttempt] = useState(0);
+
+  const [apiKey, setApiKey] = useState("");
+  const [retellAgents, setRetellAgents] = useState<
+    readonly DiscoveredAgent[] | null
+  >(null);
+  const [retellAgentId, setRetellAgentId] = useState("");
+  const [retellRoute, setRetellRoute] = useState("");
+  // How the developer wants to test a voice agent: chat over text mode, or
+  // voice down a call. The modality question the flow leads with for a voice
+  // agent whose goal is a simulation.
+  /**
+   * The lanes ticked in the one question, in the order they were ticked.
+   *
+   * Several at once is the point: text and voice land as connections on **one**
+   * egma agent in one pass, so the same suite runs over both. Nothing starts
+   * ticked — one lane dials a real telephone.
+   */
+  const [lanes, setLanes] = useState<readonly RetellLane[]>([]);
+  const [discovering, setDiscovering] = useState(false);
+
+  const [livekitLanguage, setLivekitLanguage] = useState<
+    LiveKitWorkerLanguage | ""
+  >("");
+  const [livekitModality, setLivekitModality] = useState<"chat" | "voice" | "">(
+    "",
+  );
+  const [livekitAccess, setLivekitAccess] = useState(PROJECT_CREDENTIALS);
+  const [livekitAgentName, setLivekitAgentName] = useState("");
+  const [livekitConfig, setLivekitConfig] = useState<
+    Readonly<Record<string, string>>
+  >({});
+  const [livekitCredentials, setLivekitCredentials] = useState<
+    Readonly<Record<string, string>>
+  >({});
+
+  const [saving, setSaving] = useState(false);
+  const [refused, setRefused] = useState<Refusal | null>(null);
+  const [completed, setCompleted] = useState<ConnectSheetResult | null>(null);
+  const [retellProgress, setRetellProgress] =
+    useState<RetellSaveProgress | null>(null);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setGoal(initialGoal ?? "");
+    setPlatform(initialPlatform ?? "");
+    setStep(firstStep(initialGoal, initialPlatform));
+    setApiKey("");
+    setRetellAgents(null);
+    setRetellAgentId("");
+    setRetellRoute("");
+    setLanes([]);
+    setLivekitLanguage("");
+    setLivekitModality("");
+    setLivekitAccess(PROJECT_CREDENTIALS);
+    setLivekitAgentName("");
+    setLivekitConfig({});
+    setLivekitCredentials({});
+    setCompleted(null);
+    setRetellProgress(null);
+    setRefused(null);
+  }, [agentId, initialGoal, initialPlatform]);
+
+  useEffect(() => {
+    if (agentId === undefined || agentId === NEW_AGENT) {
+      setKnown(null);
+      setKnownStatus("ready");
+      setKnownRefused(null);
+      return undefined;
+    }
+    if (listedKnown !== undefined) {
+      setKnown(listedKnown);
+      setKnownStatus("ready");
+      setKnownRefused(null);
+      return undefined;
+    }
+    let current = true;
+    setKnown(null);
+    setKnownStatus("loading");
+    setKnownRefused(null);
+    void platformAnswer(
+      getAgent({ agentId, projectId }, { client: platformClient }),
+    ).then((answer) => {
+      if (!current) return;
+      if (answer.status === "signed-out") window.location.replace("/sign-in");
+      else if (answer.status === "ready") {
+        setKnown(answer.value.agent);
+        setKnownStatus("ready");
+      } else {
+        setKnownStatus(answer.status);
+        setKnownRefused(answer.refusal);
+      }
+    });
+    return () => {
+      current = false;
+    };
+  }, [agentId, knownAttempt, listedKnown, projectId]);
+
+  useEffect(() => {
+    let current = true;
+    setCatalog(null);
+    setCatalogRefused(null);
+    void platformAnswer(listConnectionOptions({ client: platformClient })).then(
+      (answer) => {
+        if (!current) return;
+        if (answer.status === "signed-out") {
+          window.location.replace("/sign-in");
+        } else if (answer.status === "ready") {
+          setCatalog(answer.value);
+        } else {
+          setCatalogRefused(answer.refusal);
+        }
+      },
+    );
+    return () => {
+      current = false;
+    };
+  }, [catalogAttempt]);
+
+  useEffect(() => {
+    const target =
+      bodyRef.current?.querySelector<HTMLElement>("[data-setup-heading]") ??
+      bodyRef.current?.querySelector<HTMLElement>(
+        "#livekit-monitoring-title",
+      );
+    target?.focus();
+  }, [step]);
+
+  const plan =
+    goal === "" || platform === "" ? null : agentSetupPlan(goal, platform);
+  const plannedRetellAgents =
+    plan === null ? [] : retellAgentsForPlan(plan, retellAgents);
+  const boundRetellPlatformAgentId =
+    agentId !== undefined && agentId !== NEW_AGENT
+      ? (known?.platformAgentId ?? null)
+      : null;
+  const visibleRetellAgents =
+    boundRetellPlatformAgentId === null
+      ? plannedRetellAgents
+      : plannedRetellAgents.filter(
+          (one) => one.platformAgentId === boundRetellPlatformAgentId,
+        );
+  const selectedRetellAgent = visibleRetellAgents.find(
+    (one) => one.platformAgentId === retellAgentId,
+  );
+  const selectedRoutes =
+    plan === null ? [] : retellCandidatesForPlan(plan, selectedRetellAgent);
+  // The phone chooser lists numbers and nothing else. The web-call candidate
+  // discovery also answers with carries no number, so it would sit here as a
+  // blank option and — being first — become the step's default, saving a web
+  // call where the person asked for a phone. It is picked by its own tick in
+  // the one question instead.
+  const voiceRoutes = selectedRoutes.filter(
+    (one) => one.connectionType === "phone_number",
+  );
+  const selectedVoiceRoute = voiceRoutes.find(
+    (one) => retellCandidateValue(one) === retellRoute,
+  );
+  /** The lanes picked, in reading order, whatever order they were ticked in. */
+  const pickedLanes = retellLanesInOrder(lanes);
+  /**
+   * Every lane the goal will save, and the candidate that saves it.
+   *
+   * A monitoring goal skips the question and saves the phone lane alone, which
+   * is what production pull needs. A simulation goal saves what was ticked.
+   */
+  const lanesToSave: readonly RetellLane[] =
+    plan?.asksHowToTest === true ? pickedLanes : ["phone"];
+  const retellSaveSignature = JSON.stringify([
+    retellAgentId,
+    lanesToSave,
+    retellRoute,
+  ]);
+
+  const livekitOptions =
+    platform === "livekit"
+      ? optionsForPlatform(catalog, "livekit").filter(
+          (one) => one.connectionType === "livekit_room",
+        )
+      : [];
+  /** The modalities this Egma offers on a LiveKit room, in the catalog's order. */
+  const livekitModalities = [
+    ...new Set(livekitOptions.map((one) => one.modality)),
+  ];
+  /** The access variants that speak the chosen modality — chat has exactly one. */
+  const livekitAccessOptions = livekitOptions.filter(
+    (one) => one.modality === livekitModality,
+  );
+  /*
+   * The pair decides the row, never the access variant alone.
+   *
+   * Chat and voice share `livekit_room.project_credentials`, so matching the
+   * variant would answer with whichever row the server listed first — and a
+   * chat walk would save a voice connection with nothing anywhere saying so.
+   */
+  const livekitOption = livekitAccessOptions.find(
+    (one) => one.accessVariant === livekitAccess,
+  );
+  const livekitFieldValue = (key: string): string =>
+    key === "agentName"
+      ? livekitAgentName
+      : (livekitConfig[key] ?? "");
+  const storedRetellKey =
+    agentId !== undefined &&
+    known?.monitoringKeyPresent === true;
+  const keyReady = storedRetellKey || apiKey.trim().length >= SHORTEST_KEY;
+  const livekitReady =
+    livekitOption !== undefined &&
+    livekitOption.fields
+      .filter((field) => field.required)
+      .every((field) => livekitFieldValue(field.key).trim() !== "") &&
+    livekitOption.credentialFields
+      .filter((field) => field.required)
+      .every(
+        (field) => (livekitCredentials[field.field]?.trim() ?? "") !== "",
+      ) &&
+    livekitAgentName.trim() !== "";
+
+  const changed =
+    apiKey !== "" ||
+    retellAgents !== null ||
+    livekitAgentName !== "" ||
+    Object.values(livekitConfig).some((value) => value !== "") ||
+    Object.values(livekitCredentials).some((value) => value !== "");
+  useUnsavedChanges(changed && !saving && !discovering, saving || discovering);
+
+  function transition(next: AgentSetupStep): void {
+    setRefused(null);
+    setStep(next);
+  }
+
+  function leave(): void {
+    if (completed !== null) {
+      onConnected(completed);
+      return;
+    }
+    draftNavigation.request(onClose);
+  }
+
+  function clearProviderAnswers(): void {
+    setApiKey("");
+    setRetellAgents(null);
+    setRetellAgentId("");
+    setRetellRoute("");
+    setLanes([]);
+    setLivekitLanguage("");
+    setLivekitModality("");
+    setLivekitAccess(PROJECT_CREDENTIALS);
+    setLivekitAgentName("");
+    setLivekitConfig({});
+    setLivekitCredentials({});
+    setCompleted(null);
+    setRetellProgress(null);
+    setRefused(null);
+  }
+
+  function chooseGoal(next: AgentSetupGoal): void {
+    if (next !== goal) clearProviderAnswers();
+    setGoal(next);
+  }
+
+  function choosePlatform(next: AgentSetupPlatform): void {
+    if (next !== platform) clearProviderAnswers();
+    setPlatform(next);
+  }
+
+  /*
+   * Chat is offered on project credentials and nowhere else, because that is
+   * the access variant where Egma dispatches the worker and can tell it this
+   * simulation is typed. Choosing chat therefore settles the way in as well,
+   * and the screen that would have asked is not drawn.
+   */
+  function chooseLiveKitModality(next: "chat" | "voice"): void {
+    if (next !== livekitModality) {
+      setLivekitConfig({});
+      setLivekitCredentials({});
+    }
+    if (next === "chat") setLivekitAccess(PROJECT_CREDENTIALS);
+    setLivekitModality(next);
+  }
+
+  function back(): void {
+    const previous = previousAgentSetupStep({
+      step,
+      goal,
+    });
+    if (previous === null) {
+      leave();
+      return;
+    }
+    transition(previous);
+  }
+
+  function finishAnswer<T>(
+    answer: Answer<T>,
+  ): answer is Extract<Answer<T>, { status: "ready" }> {
+    if (answer.status === "signed-out") {
+      window.location.replace("/sign-in");
+      return false;
+    }
+    if (answer.status !== "ready") {
+      setRefused(answer.refusal);
+      return false;
+    }
+    return true;
+  }
+
+  async function findRetellAgents(): Promise<void> {
+    if (discovering || !keyReady) return;
+    setDiscovering(true);
+    setRefused(null);
+    const credentials = apiKey.trim();
+    const answer = await platformAnswer(
+      discoverAgents(
+        {
+          projectId,
+          agentPlatform: "retell",
+          ...(storedRetellKey && agentId !== undefined
+            ? { agentId }
+            : { credentials: { apiKey: credentials } }),
+        },
+        { client: platformClient },
+      ),
+    );
+    setDiscovering(false);
+    if (!finishAnswer(answer)) return;
+    setRetellAgents(answer.value.agents);
+    setRetellAgentId("");
+    setRetellRoute("");
+    setLanes([]);
+    transition("retell-agent");
+  }
+
+  function connectionBody(
+    option: ConnectionOption,
+    candidate?: RetellConnectionCandidate,
+    pullProductionCalls = false,
+  ): ConnectionBody {
+    if (candidate !== undefined) {
+      return {
+        agentPlatform: option.agentPlatform,
+        connectionType: option.connectionType,
+        accessVariant: option.accessVariant,
+        modality: option.modality,
+        config: candidate.config,
+        platformAgentId: retellAgentId,
+        ...(storedRetellKey
+          ? {}
+          : { credentials: { apiKey: apiKey.trim() } }),
+        ...(pullProductionCalls ? { pullProductionCalls: true } : {}),
+      };
+    }
+
+    const config: Record<string, string> = {};
+    for (const field of option.fields) {
+      const value = livekitFieldValue(field.key).trim();
+      if (value !== "") config[field.key] = value;
+    }
+    const credentials: Record<string, string> = {};
+    for (const field of option.credentialFields) {
+      const value = livekitCredentials[field.field]?.trim() ?? "";
+      if (value !== "") credentials[field.field] = value;
+    }
+    return {
+      agentPlatform: option.agentPlatform,
+      connectionType: option.connectionType,
+      accessVariant: option.accessVariant,
+      modality: option.modality,
+      config,
+      ...(Object.keys(credentials).length === 0 ? {} : { credentials }),
+    };
+  }
+
+  async function saveConnection(
+    name: string,
+    body: ConnectionBody,
+    /**
+     * The agent an earlier lane in this same pass landed on, when there is one.
+     *
+     * It is what makes several lanes one agent: the first lane registers, and
+     * every lane after it is added to what came back.
+     */
+    landedOn?: string,
+  ): Promise<ConnectSheetResult | null> {
+    setSaving(true);
+    setRefused(null);
+
+    const onto = landedOn ?? agentId;
+    if (onto === undefined || onto === NEW_AGENT) {
+      const answer = await platformAnswer(
+        registerAgent(
+          {
+            projectId,
+            name,
+            agentPlatform:
+              body.agentPlatform === "retell" ? "retell" : "livekit",
+            connection: body,
+          },
+          { client: platformClient },
+        ),
+      );
+      setSaving(false);
+      if (!finishAnswer(answer)) return null;
+      return {
+        agentId: answer.value.agent.id,
+        connectionId: answer.value.connection?.id ?? null,
+        created: true,
+      };
+    }
+
+    const answer = await platformAnswer(
+      addConnection(
+        { agentId: onto, projectId, ...body },
+        { client: platformClient },
+      ),
+    );
+    setSaving(false);
+    if (!finishAnswer(answer)) return null;
+    return {
+      agentId: onto,
+      connectionId: answer.value.connection.id,
+      created: false,
+    };
+  }
+
+  async function resumeRetellMonitoring(): Promise<ConnectSheetResult | null> {
+    if (
+      agentId === undefined ||
+      agentId === NEW_AGENT ||
+      known?.platformAgentId === null ||
+      known?.platformAgentId === undefined
+    ) {
+      return null;
+    }
+
+    setSaving(true);
+    setRefused(null);
+    const answer = await platformAnswer(
+      startMonitoring(
+        {
+          projectId,
+          agentPlatform: "retell",
+          watch: [
+            {
+              agentId,
+              platformAgentId: known.platformAgentId,
+            },
+          ],
+        },
+        { client: platformClient },
+      ),
+    );
+    setSaving(false);
+    if (!finishAnswer(answer)) return null;
+
+    const watching = answer.value.watching.find(
+      (one) => one.agentId === agentId,
+    );
+    if (watching === undefined) {
+      const refusal = answer.value.refused.find(
+        (one) => one.platformAgentId === known.platformAgentId,
+      );
+      setRefused({
+        error: "monitoring_not_started",
+        message:
+          refusal?.message ??
+          "Egma did not start monitoring this agent. Try again.",
+      });
+      return null;
+    }
+
+    return { agentId, connectionId: null, created: false };
+  }
+
+  /**
+   * Every picked lane, written onto **one** egma agent, in one pass.
+   *
+   * The first lane registers the agent (or finds the one that is already
+   * there); every lane after it is an addition to *that* agent. Two egma agents
+   * for one Retell voice agent would split a team's results history in half,
+   * which is the failure this loop exists to prevent.
+   *
+   * A lane that will not save stops the pass and says so, rather than carrying
+   * on and leaving a half-connected agent nobody asked for.
+   */
+  async function finishRetellLanes(): Promise<void> {
+    if (goal === "" || selectedRetellAgent === undefined) return;
+    if (lanesToSave.length === 0) return;
+
+    const resumesStoredMonitoring =
+      goal !== "simulation" &&
+      storedRetellKey &&
+      agentId !== undefined &&
+      agentId !== NEW_AGENT &&
+      known?.platformAgentId === selectedRetellAgent.platformAgentId;
+    if (resumesStoredMonitoring) {
+      const resumed = await resumeRetellMonitoring();
+      if (resumed !== null) onConnected(resumed);
+      return;
+    }
+
+    const saved =
+      retellProgress?.signature === retellSaveSignature
+        ? retellProgress
+        : null;
+    let landed: ConnectSheetResult | null = saved?.landed ?? null;
+    const firstUnsavedLane = saved?.completedLanes ?? 0;
+    for (const [index, lane] of lanesToSave.entries()) {
+      if (index < firstUnsavedLane) continue;
+      const candidate = retellCandidateForLane(selectedRoutes, lane, retellRoute);
+      if (candidate === undefined) return;
+      const option = optionNamed(catalog, candidate);
+      if (option === undefined) return;
+      const result = await saveConnection(
+        selectedRetellAgent.name,
+        connectionBody(
+          option,
+          candidate,
+          // Production pull rides on the voice connection, and only once.
+          plan?.pullWithConnection === true && lane === "phone",
+        ),
+        landed?.agentId,
+      );
+      if (result === null) return;
+      landed = {
+        ...result,
+        agentId: landed === null ? result.agentId : landed.agentId,
+        created: landed?.created ?? result.created,
+      };
+      const progress = {
+        signature: retellSaveSignature,
+        completedLanes: index + 1,
+        landed,
+      } satisfies RetellSaveProgress;
+      setRetellProgress(progress);
+      setCompleted(landed);
+    }
+    if (landed !== null) {
+      setRetellProgress(null);
+      onConnected(landed);
+    }
+  }
+
+  async function finishLiveKit(): Promise<void> {
+    if (goal === "" || plan === null || livekitOption === undefined) return;
+    // Saved already, and this press is the way on: a Both walk that came back
+    // to this screen must not save a second connection to move forward.
+    if (completed !== null) {
+      const next = stepAfterLiveKitCredentials(plan);
+      if (next === null) onConnected(completed);
+      else transition(next);
+      return;
+    }
+    if (!livekitReady) return;
+    const result = await saveConnection(
+      livekitAgentName.trim(),
+      connectionBody(livekitOption),
+    );
+    if (result === null) return;
+    const next = stepAfterLiveKitCredentials(plan);
+    setCompleted(result);
+    transition(next);
+  }
+
+  async function continueFlow(): Promise<void> {
+    switch (step) {
+      case "goal":
+        if (goal !== "") transition("platform");
+        return;
+      case "platform":
+        if (goal !== "" && platform !== "") {
+          transition(stepAfterPlatform(goal, platform));
+        }
+        return;
+      case "retell-key":
+        await findRetellAgents();
+        return;
+      case "retell-agent": {
+        if (goal === "" || plan === null || selectedRetellAgent === undefined) {
+          return;
+        }
+        const next = stepAfterRetellAgent(plan);
+        // A goal that skips the question saves the phone lane, so it needs its
+        // first routed number chosen for it; the question's own walk waits.
+        if (next === "retell-phone") {
+          const first = voiceRoutes[0];
+          setRetellRoute(first === undefined ? "" : retellCandidateValue(first));
+        }
+        transition(next);
+        return;
+      }
+      case "retell-lanes": {
+        if (pickedLanes.length === 0) return;
+        const next = stepAfterRetellLanes(pickedLanes);
+        // The phone-number chooser appears only when Phone call is picked.
+        // Every other set of picks has nothing left to ask and saves here.
+        if (next === null) {
+          await finishRetellLanes();
+          return;
+        }
+        const first = voiceRoutes[0];
+        setRetellRoute(first === undefined ? "" : retellCandidateValue(first));
+        transition(next);
+        return;
+      }
+      case "retell-phone":
+        await finishRetellLanes();
+        return;
+      case "livekit-language":
+        if (livekitLanguage === "") return;
+        if (livekitLanguage === "javascript") {
+          leave();
+          return;
+        }
+        transition("livekit-modality");
+        return;
+      case "livekit-modality":
+        if (livekitModality !== "") transition("livekit-simulation");
+        return;
+      case "livekit-simulation":
+        await finishLiveKit();
+        return;
+      case "livekit-testing": {
+        const next = plan === null ? null : stepAfterLiveKitTesting(plan);
+        if (next !== null) {
+          transition(next);
+        } else if (completed === null) {
+          onClose();
+        } else {
+          onConnected(completed);
+        }
+        return;
+      }
+      case "livekit-monitoring":
+        if (livekitLanguage === "") return;
+        // Both starts with Monitoring so the language is known before any
+        // simulation connection can be written. JavaScript finishes here;
+        // Python continues into the supported, session-isolated test setup.
+        if (
+          goal === "both" &&
+          livekitLanguage === "python" &&
+          completed === null
+        ) {
+          transition("livekit-modality");
+          return;
+        }
+        if (completed === null) leave();
+        else onConnected(completed);
+        return;
+    }
+  }
+
+  function body(): ReactNode {
+    if (role === null) return <Loading what="what you can do here" />;
+    if (!mayAuthor) {
+      return (
+        <NotFound
+          message={
+            "Your " +
+            role +
+            " role cannot connect agents. Ask an organization admin to change your role, then try again."
+          }
+        />
+      );
+    }
+
+    const needsKnown = agentId !== undefined && agentId !== NEW_AGENT;
+    if (needsKnown && knownStatus === "loading") {
+      return <Loading what="this agent's saved setup" />;
+    }
+    if (needsKnown && knownStatus === "missing" && knownRefused !== null) {
+      return <NotFound message={knownRefused.message} />;
+    }
+    if (needsKnown && knownStatus === "failed" && knownRefused !== null) {
+      return (
+        <Failure
+          title="Egma could not load this agent's saved setup."
+          message={knownRefused.message}
+          onRetry={() => setKnownAttempt((current) => current + 1)}
+        />
+      );
+    }
+
+    const needsCatalog =
+      step === "livekit-modality" ||
+      step === "livekit-simulation" ||
+      step === "retell-phone" ||
+      // The one question can save on Continue when no phone lane was picked,
+      // and that needs the option catalog to name the rows it writes.
+      step === "retell-lanes";
+    if (needsCatalog && catalogRefused !== null) {
+      return (
+        <Failure
+          title="Egma could not describe the connection options."
+          message={catalogRefused.message}
+          onRetry={() => setCatalogAttempt((current) => current + 1)}
+        />
+      );
+    }
+    if (needsCatalog && catalog === null) {
+      return <Loading what="the connection options" />;
+    }
+
+    switch (step) {
+      case "goal":
+        return (
+          <div className="flex flex-col gap-5">
+            <StepIntro
+              title="What do you want Egma to do?"
+              description={
+                initialGoal === "monitoring"
+                  ? "Production monitoring is selected because you started from Traces. You can still change the goal."
+                  : undefined
+              }
+            />
+            <RadioGroup
+              className="gap-6"
+              aria-label="Setup goal"
+              value={goal}
+              onValueChange={(value) =>
+                chooseGoal(value as AgentSetupGoal)
+              }
+            >
+              <ChoiceCard
+                value="simulation"
+                title="Run simulations"
+                description="Test how the agent responds before production."
+              />
+              <ChoiceCard
+                value="monitoring"
+                title="Monitor production"
+                description="Monitor an agent in production"
+              />
+              <ChoiceCard
+                value="both"
+                title="Set up both"
+                description="Configure an agent for both testing and monitoring"
+              />
+            </RadioGroup>
+          </div>
+        );
+      case "platform":
+        return (
+          <div className="flex flex-col gap-5">
+            <StepIntro title="Choose your agent platform" />
+            <RadioGroup
+              className="gap-4"
+              aria-label="Agent platform"
+              value={platform}
+              onValueChange={(value) =>
+                choosePlatform(value as AgentSetupPlatform)
+              }
+            >
+              <ChoiceCard compact value="retell" title="Retell" />
+              <ChoiceCard compact value="livekit" title="LiveKit" />
+            </RadioGroup>
+          </div>
+        );
+      case "retell-key":
+        return (
+          <div className="flex flex-col gap-5">
+            <StepIntro
+              title="Connect your Retell account"
+              description="Enter your Retell API key. Egma uses it to find the agents in this account."
+            />
+            {storedRetellKey ? (
+              <InfoBox>
+                {"This agent already holds its Retell key (ending " +
+                  String(known?.monitoringApiKeyHint ?? "") +
+                  "). Egma will use it to find the account's agents."}
+              </InfoBox>
+            ) : (
+              <Field label="Retell API key*" htmlFor="retell-api-key">
+                <Input
+                  id="retell-api-key"
+                  aria-required="true"
+                  type="password"
+                  value={apiKey}
+                  autoComplete="off"
+                  spellCheck={false}
+                  onChange={(event) => {
+                    setApiKey(event.target.value);
+                    setRefused(null);
+                  }}
+                />
+              </Field>
+            )}
+          </div>
+        );
+      case "retell-agent":
+        return (
+          <div className="flex flex-col gap-5">
+            <StepIntro
+              title="Choose a Retell agent"
+              description="Egma found these agents in your Retell account."
+            />
+            {retellAgents !== null && visibleRetellAgents.length === 0 ? (
+              <Empty
+                title={
+                  boundRetellPlatformAgentId === null
+                    ? "No Retell agents found"
+                    : "Connected Retell agent not found"
+                }
+                lead={
+                  boundRetellPlatformAgentId === null
+                    ? "This Retell account does not contain a voice agent."
+                    : "Egma could not find the Retell agent already connected here in this account."
+                }
+              />
+            ) : (
+              <RadioGroup
+                aria-label="Retell agent"
+                value={retellAgentId}
+                onValueChange={(value) => {
+                  setRetellAgentId(value);
+                  setRetellRoute("");
+                  setLanes([]);
+                }}
+              >
+                {visibleRetellAgents.map((one) => {
+                  const modality = retellModality(one);
+                  const phones = one.connectionCandidates.filter(
+                    (candidate) => candidate.connectionType === "phone_number",
+                  ).length;
+                  const description =
+                    modality === "voice"
+                      ? "Voice agent · " +
+                        (phones === 0
+                          ? "no phone numbers available"
+                          : phones +
+                            (phones === 1
+                              ? " phone number available"
+                              : " phone numbers available"))
+                      : "No supported connection available";
+                  return (
+                    <ChoiceCard
+                      key={one.platformAgentId}
+                      value={one.platformAgentId}
+                      title={one.name || one.platformAgentId}
+                      description={description}
+                      disabled={
+                        plan === null || !retellAgentCanEnterPlan(plan, one)
+                      }
+                    />
+                  );
+                })}
+              </RadioGroup>
+            )}
+            <InfoBox>
+              {plan?.asksHowToTest === true
+                ? "Egma lists your Retell voice agents. You choose how to test the one you pick next."
+                : "Egma lists your Retell voice agents. Production monitoring needs one of the phone numbers routed to the agent you pick."}
+            </InfoBox>
+          </div>
+        );
+      case "retell-lanes":
+        return (
+          <div className="flex flex-col gap-5">
+            <StepIntro
+              title={RETELL_LANE_QUESTION}
+              description={
+                "Pick as many as you want. Each one is a connection on " +
+                String(selectedRetellAgent?.name ?? "this agent") +
+                ", and one test suite runs over all of them."
+              }
+            />
+            <fieldset className="m-0 flex min-w-0 flex-col gap-4 border-0 p-0">
+              <legend className="sr-only">{RETELL_LANE_QUESTION}</legend>
+              {RETELL_LANES.map((lane) => (
+                <div
+                  className="flex min-w-0 items-start gap-3 border border-border p-4"
+                  key={lane}
+                >
+                  <Checkbox
+                    aria-describedby={`retell-lane-${lane}-help`}
+                    checked={lanes.includes(lane)}
+                    disabled={retellProgress !== null}
+                    id={`retell-lane-${lane}`}
+                    onChange={(event) =>
+                      setLanes((held) =>
+                        event.target.checked
+                          ? [...held.filter((one) => one !== lane), lane]
+                          : held.filter((one) => one !== lane),
+                      )
+                    }
+                  />
+                  <span className="flex min-w-0 flex-col gap-1">
+                    {/*
+                      The visible copy stays visible and points at the control
+                      with `htmlFor`, which makes the whole line a target as
+                      well as naming the box.
+                    */}
+                    <label
+                      className="cursor-pointer text-sm font-medium text-foreground"
+                      htmlFor={`retell-lane-${lane}`}
+                    >
+                      {RETELL_LANE_LABELS[lane]}
+                    </label>
+                    <span
+                      className="text-sm text-faint"
+                      id={`retell-lane-${lane}-help`}
+                    >
+                      {RETELL_LANE_HELP[lane]}
+                    </span>
+                  </span>
+                </div>
+              ))}
+            </fieldset>
+            <InfoBox>
+              Text and voice land as connections on one agent, so the same tests
+              run across all of them. A phone run reaches your real tools.
+            </InfoBox>
+          </div>
+        );
+      case "retell-phone":
+        return (
+          <div className="flex flex-col gap-5">
+            <StepIntro
+              title="Choose a phone number"
+              description={
+                "Retell already routes these numbers to " +
+                String(selectedRetellAgent?.name ?? "this agent") +
+                ". Choose the one Egma should use."
+              }
+            />
+            <Field label="Phone number*" htmlFor="retell-phone-number">
+              <Select
+                id="retell-phone-number"
+                aria-required="true"
+                value={retellRoute}
+                disabled={retellProgress !== null}
+                onChange={(event) => setRetellRoute(event.target.value)}
+              >
+                {voiceRoutes.map((candidate) => (
+                  <option
+                    key={retellCandidateValue(candidate)}
+                    value={retellCandidateValue(candidate)}
+                  >
+                    {candidate.config.phoneNumber}
+                  </option>
+                ))}
+              </Select>
+            </Field>
+            <SummaryRows
+              rows={[
+                ["Retell agent", selectedRetellAgent?.name ?? ""],
+                [
+                  "Phone number",
+                  selectedVoiceRoute?.config.phoneNumber ?? "",
+                ],
+              ]}
+            />
+            <Help>
+              Egma reads this number from Retell. It does not change your Retell
+              routing.
+            </Help>
+          </div>
+        );
+      case "livekit-language":
+        return (
+          <div className="flex flex-col gap-5">
+            <StepIntro title="What language is your LiveKit worker?" />
+            <RadioGroup
+              className="gap-4"
+              aria-label="LiveKit worker language"
+              value={livekitLanguage}
+              onValueChange={(value) =>
+                setLivekitLanguage(value as LiveKitWorkerLanguage)
+              }
+            >
+              <ChoiceCard
+                compact
+                value="python"
+                title="Python"
+                description="Simulation testing and production monitoring are supported."
+              />
+              <ChoiceCard
+                compact
+                value="javascript"
+                title="JavaScript"
+                description="Production monitoring is supported. Simulation testing is not supported yet."
+              />
+            </RadioGroup>
+            {livekitLanguage === "javascript" ? (
+              <Help>
+                Egma cannot set up JavaScript testing yet because it cannot
+                isolate each test run from other LiveKit sessions. Use the
+                Monitoring goal to add JavaScript monitoring.
+              </Help>
+            ) : null}
+          </div>
+        );
+      case "livekit-modality":
+        return (
+          <div className="flex flex-col gap-5">
+            <StepIntro
+              title="How do you want to test this agent?"
+              description="Choose one way to test this agent in this setup."
+            />
+            <RadioGroup
+              className="gap-6"
+              aria-label="Simulation modality"
+              value={livekitModality}
+              onValueChange={(value) =>
+                chooseLiveKitModality(value as "chat" | "voice")
+              }
+            >
+              {livekitModalities.map((one) => (
+                <ChoiceCard
+                  key={one}
+                  value={one}
+                  title={MODALITY_CHOICES[one].title}
+                  description={MODALITY_CHOICES[one].description}
+                />
+              ))}
+            </RadioGroup>
+          </div>
+        );
+      case "livekit-testing":
+        return livekitModality === "" ? null : (
+          <LiveKitTestingInstructions modality={livekitModality} />
+        );
+      case "livekit-simulation":
+        return (
+          <LiveKitSimulationStep
+            option={livekitOption}
+            access={livekitAccess}
+            chooseAccess={livekitAccessOptions.length > 1}
+            agentName={livekitAgentName}
+            draft={{
+              config: livekitConfig,
+              credentials: livekitCredentials,
+            }}
+            disabled={completed !== null}
+            onAccessChange={(value) => {
+              setLivekitAccess(value);
+              setLivekitConfig({});
+              setLivekitCredentials({});
+            }}
+            onAgentNameChange={setLivekitAgentName}
+            onDraftChange={(next) => {
+              setLivekitConfig(next.config);
+              setLivekitCredentials(next.credentials);
+            }}
+          />
+        );
+      case "livekit-monitoring":
+        return (
+          <div className="flex flex-col gap-5">
+            <LiveKitMonitoringInstructions
+              projectId={projectId}
+              language={livekitLanguage}
+              onLanguageChange={setLivekitLanguage}
+            />
+            {goal === "both" && livekitLanguage === "javascript" ? (
+              <Help>
+                Monitoring is supported for JavaScript and finishes here.
+                Testing remains unsupported because Egma cannot isolate each
+                JavaScript test run from other LiveKit sessions.
+              </Help>
+            ) : null}
+          </div>
+        );
+    }
+  }
+
+  const primaryLabel =
+    step === "goal" ||
+    step === "platform" ||
+    step === "retell-agent" ||
+    step === "livekit-modality"
+      ? "Continue"
+      : step === "livekit-language"
+        ? livekitLanguage === "javascript"
+          ? "Return to agents"
+          : "Continue"
+        : step === "retell-lanes"
+          ? // Picking the phone lane carries on to the number chooser; every
+            // other set of picks has nothing left to ask and saves here.
+            pickedLanes.includes("phone")
+            ? "Continue"
+            : saving
+              ? "Setting up…"
+              : "Set up simulation"
+          : step === "retell-key"
+            ? discovering
+              ? "Finding agents…"
+              : "Find agents"
+            : step === "retell-phone"
+              ? saving
+                ? "Finishing…"
+                : goal === "simulation"
+                  ? "Set up simulation"
+                  : goal === "monitoring"
+                    ? "Start monitoring"
+                    : "Set up both"
+              : step === "livekit-simulation"
+                ? saving
+                  ? "Saving…"
+                  : completed === null
+                    ? "Continue to testing"
+                    : "Continue"
+                : step === "livekit-monitoring" && goal === "both"
+                  ? livekitLanguage === "javascript"
+                    ? "Finish monitoring"
+                    : "Continue to simulation"
+                  : "Return to agents";
+
+  const primaryDisabled =
+    saving ||
+    discovering ||
+    (step === "goal" && goal === "") ||
+    (step === "platform" && platform === "") ||
+    (step === "retell-key" && !keyReady) ||
+    (step === "retell-agent" && selectedRetellAgent === undefined) ||
+    // Nothing picked yet, or a set that saves here picked before the catalog
+    // it writes from arrived.
+    (step === "retell-lanes" &&
+      (pickedLanes.length === 0 ||
+        (!pickedLanes.includes("phone") && catalog === null))) ||
+    (step === "retell-phone" &&
+      (selectedVoiceRoute === undefined || catalog === null)) ||
+    (step === "livekit-language" && livekitLanguage === "") ||
+    (step === "livekit-modality" && livekitModality === "") ||
+    (step === "livekit-simulation" && completed === null && !livekitReady) ||
+    (step === "livekit-monitoring" && livekitLanguage === "");
+
+  const needsKnown = agentId !== undefined && agentId !== NEW_AGENT;
+  const usable =
+    role !== null && mayAuthor && (!needsKnown || knownStatus === "ready");
 
   return (
     <Sheet
       open
       onOpenChange={(next) => {
-        if (!next) onClose();
+        if (next) return;
+        leave();
       }}
     >
-      <SheetContent aria-describedby="connect-agent-description">
-        <SheetHeader>
-          <SheetTitle>Connect an agent</SheetTitle>
-          <SheetDescription id="connect-agent-description">
-            Copy one prompt into the coding agent that is working in your
-            repository.
-          </SheetDescription>
-        </SheetHeader>
-
-        <SheetBody>
-          {role === null || platformUrl === null ? (
-            <Loading what="what you can do here" />
-          ) : !mayAuthor ? (
-            <NotFound
-              message={
-                "Your " +
-                role +
-                " role cannot connect agents. Ask an organization admin to change your role, then try again."
-              }
-            />
-          ) : (
-            <div className="flex flex-col gap-5">
-              <p className="m-0 text-sm leading-(--line-normal) text-muted-foreground">
-                Choose the outcome you want. The coding agent will inspect the
-                repository and follow the complete setup.
-              </p>
-
-              <div className="flex flex-col gap-4">
-                {agentSetupPrompts(platformUrl).map((prompt) => (
-                  <section
-                    className="flex flex-col gap-3 border border-border p-4"
-                    aria-labelledby={`connect-prompt-${prompt.id}`}
-                    key={prompt.id}
-                  >
-                    <h3
-                      className="m-0 text-base font-medium text-foreground"
-                      id={`connect-prompt-${prompt.id}`}
-                    >
-                      {prompt.title}
-                    </h3>
-                    <CopyBlock
-                      value={prompt.value}
-                      copyLabel={`${prompt.id} prompt`}
-                    />
-                  </section>
-                ))}
+      <SheetContent aria-describedby={undefined}>
+        <form
+          className="contents"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void continueFlow();
+          }}
+        >
+          <SheetHeader>
+            <SheetTitle>Set up an agent</SheetTitle>
+          </SheetHeader>
+          <SheetBody ref={bodyRef}>
+            {refused === null ? null : (
+              <FormRefused message={refused.message} />
+            )}
+            {retellProgress === null ? null : (
+              <div role="status">
+                <Help>
+                  Egma saved {retellProgress.completedLanes} of{" "}
+                  {lanesToSave.length} connections. Retry to continue with the
+                  remaining setup, or close to return to the saved agent.
+                </Help>
               </div>
-            </div>
-          )}
-        </SheetBody>
-
-        <SheetFooter className="border-t border-border pt-5">
-          <Button type="button" size="lg" variant="secondary" onClick={onClose}>
-            Close
-          </Button>
-        </SheetFooter>
+            )}
+            {body()}
+          </SheetBody>
+          <SheetFooter className="border-t border-border pt-5 [&>div:first-child]:w-full [&>div:first-child]:justify-between">
+            {usable ? (
+              <>
+                {step === "livekit-testing" ? null : (
+                  <Button
+                    type="button"
+                    size="lg"
+                    variant="secondary"
+                    disabled={saving || discovering}
+                    onClick={
+                      step === "goal" || retellProgress !== null
+                        ? leave
+                        : back
+                    }
+                  >
+                    {step === "goal"
+                      ? "Cancel"
+                      : retellProgress !== null
+                        ? "Close"
+                        : "Back"}
+                  </Button>
+                )}
+                <Button
+                  type="submit"
+                  size="lg"
+                  disabled={primaryDisabled}
+                  busy={saving || discovering}
+                >
+                  {primaryLabel}
+                </Button>
+              </>
+            ) : (
+              <Button type="button" size="lg" variant="secondary" onClick={leave}>
+                Close
+              </Button>
+            )}
+          </SheetFooter>
+        </form>
       </SheetContent>
     </Sheet>
+  );
+}
+
+function StepIntro({
+  title,
+  description,
+}: {
+  readonly title: string;
+  readonly description?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <h3
+        className="m-0 text-lg leading-(--line-tight) font-medium text-foreground"
+        data-setup-heading
+        tabIndex={-1}
+      >
+        {title}
+      </h3>
+      {description === undefined ? null : (
+        <p className="m-0 text-sm leading-(--line-normal) text-muted-foreground">
+          {description}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ChoiceCard({
+  value,
+  title,
+  description,
+  disabled = false,
+  compact = false,
+}: {
+  readonly value: string;
+  readonly title: string;
+  readonly description?: string;
+  readonly disabled?: boolean;
+  readonly compact?: boolean;
+}) {
+  return (
+    <RadioGroupItem
+      className={
+        compact
+          ? "group min-h-(--control-lg) items-center px-4 py-2"
+          : "group"
+      }
+      shape="card"
+      value={value}
+      disabled={disabled}
+    >
+      <RadioCardIndicator className={cn(!compact && "mt-1")} />
+      <span className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="text-base leading-(--line-normal) text-foreground">
+          {title}
+        </span>
+        {description === undefined ? null : (
+          <span className="text-sm leading-(--line-normal) text-faint">
+            {description}
+          </span>
+        )}
+      </span>
+    </RadioGroupItem>
+  );
+}
+
+function InfoBox({
+  title,
+  children,
+}: {
+  readonly title?: string;
+  readonly children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-2 border-l-(length:--active-edge-width) border-brand bg-surface-soft p-4">
+      {title === undefined ? null : (
+        <p className="m-0 text-sm font-medium text-foreground">{title}</p>
+      )}
+      <p className="m-0 text-sm leading-(--line-normal) text-muted-foreground">
+        {children}
+      </p>
+    </div>
+  );
+}
+
+function SummaryRows({
+  rows,
+}: {
+  readonly rows: readonly (readonly [string, string])[];
+}) {
+  return (
+    <dl className="m-0 flex flex-col border border-border">
+      {rows.map(([term, detail]) => (
+        <div
+          className="flex items-center justify-between gap-4 border-b border-border px-4 py-3 last:border-b-0"
+          key={term}
+        >
+          <dt className="text-sm text-faint">{term}</dt>
+          <dd className="m-0 text-sm text-foreground">{detail}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function LiveKitSimulationStep({
+  option,
+  access,
+  chooseAccess,
+  agentName,
+  draft,
+  disabled,
+  onAccessChange,
+  onAgentNameChange,
+  onDraftChange,
+}: {
+  readonly option: ConnectionOption | undefined;
+  readonly access: string;
+  /**
+   * Whether the chosen modality has more than one way in.
+   *
+   * Voice has two, and which one this is changes what the form asks for. Chat
+   * has one — Egma has to dispatch the worker to tell it the simulation is
+   * typed — so there is nothing to choose and no control that pretends there
+   * is.
+   */
+  readonly chooseAccess: boolean;
+  readonly agentName: string;
+  readonly draft: Draft;
+  readonly disabled: boolean;
+  readonly onAccessChange: (value: string) => void;
+  readonly onAgentNameChange: (value: string) => void;
+  readonly onDraftChange: (draft: Draft) => void;
+}) {
+  const endpoint = access === TOKEN_ENDPOINT;
+  const presentedOption =
+    option === undefined
+      ? undefined
+      : {
+          ...option,
+          fields: option.fields
+            .filter((field) => field.key !== "agentName")
+            .map((field) =>
+              field.key === "url"
+                ? { ...field, label: "WebSocket URL" }
+                : field,
+            ),
+          credentialFields: option.credentialFields.map((field) => {
+            if (field.field === "apiKey") {
+              return { ...field, label: "API key" };
+            }
+            if (field.field === "apiSecret") {
+              return { ...field, label: "API secret" };
+            }
+            if (field.field === "headers") {
+              return {
+                ...field,
+                help:
+                  "Enter a non-empty JSON object that maps each header name to a non-empty string value.",
+              };
+            }
+            return field;
+          }),
+        };
+  return (
+    <div className="flex flex-col gap-5">
+      <StepIntro
+        title={
+          option === undefined
+            ? "Connect LiveKit for simulations"
+            : `Connect LiveKit ${modalityLabel(option.modality)} for simulations`
+        }
+        description={
+          endpoint
+            ? "Egma requests a short-lived room token from your endpoint for every simulation."
+            : undefined
+        }
+      />
+      {chooseAccess ? (
+        <Field label="Connection type*" htmlFor="livekit-connection-type">
+          <Select
+            id="livekit-connection-type"
+            aria-required="true"
+            value={access}
+            disabled={disabled}
+            onChange={(event) => onAccessChange(event.target.value)}
+          >
+            <option value={PROJECT_CREDENTIALS}>Project credentials</option>
+            <option value={TOKEN_ENDPOINT}>Token endpoint</option>
+          </Select>
+        </Field>
+      ) : null}
+
+      <Field
+        label="LiveKit agent name*"
+        htmlFor="livekit-agent-name"
+        hint={
+          endpoint
+            ? "This names the agent in Egma. Your token endpoint decides which deployed worker joins the room."
+            : "Enter the exact agent name shown in your LiveKit Cloud dashboard."
+        }
+      >
+        <Input
+          id="livekit-agent-name"
+          aria-required="true"
+          value={agentName}
+          placeholder="your-livekit-agent-name"
+          disabled={disabled}
+          autoComplete="off"
+          spellCheck={false}
+          onChange={(event) => onAgentNameChange(event.target.value)}
+        />
+      </Field>
+      {presentedOption === undefined ? (
+        <Problem>Egma could not find this LiveKit connection method.</Problem>
+      ) : (
+        <ConnectionFields
+          option={presentedOption}
+          draft={draft}
+          onChange={onDraftChange}
+          credentialsEditable
+          disabled={disabled}
+          configPlaceholders={{
+            url: "wss://your-project.livekit.cloud",
+            tokenEndpoint: "https://api.example.com/livekit/token",
+            metadata: '{"tenant":"acme"}',
+          }}
+          credentialPlaceholders={{
+            headers: '{"Authorization":"Bearer your-token"}',
+          }}
+        />
+      )}
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
@@ -471,7 +471,11 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
     livekitAgentName !== "" ||
     Object.values(livekitConfig).some((value) => value !== "") ||
     Object.values(livekitCredentials).some((value) => value !== "");
-  useUnsavedChanges(changed && !saving && !discovering, saving || discovering);
+  const savedLiveKitConnection = platform === "livekit" && completed !== null;
+  useUnsavedChanges(
+    !savedLiveKitConnection && changed && !saving && !discovering,
+    saving || discovering,
+  );
 
   function transition(next: AgentSetupStep): void {
     setRefused(null);

--- a/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
@@ -30,6 +30,7 @@ import {
 import type { Answer, Refusal } from "@/lib/api.ts";
 import {
   modalityLabel,
+  type ListedConnection,
   type ListedAgentWithConnections,
 } from "@/lib/agents.ts";
 import {
@@ -101,6 +102,27 @@ type RetellSaveProgress = {
   readonly completedLanes: number;
   readonly landed: ConnectSheetResult;
 };
+
+/** Whether a read-back connection is the exact lane this setup tried to save. */
+function sameConnection(
+  stored: ListedConnection,
+  requested: ConnectionBody,
+): boolean {
+  const requestedConfig = requested.config ?? {};
+  const storedEntries = Object.entries(stored.config);
+  const requestedEntries = Object.entries(requestedConfig);
+  return (
+    stored.agentPlatform === requested.agentPlatform &&
+    stored.connectionType === requested.connectionType &&
+    stored.accessVariant === requested.accessVariant &&
+    stored.modality === requested.modality &&
+    storedEntries.length === requestedEntries.length &&
+    requestedEntries.every(
+      ([key, value]) =>
+        typeof value === "string" && stored.config[key] === value,
+    )
+  );
+}
 
 type ConnectAgentSheetProps = {
   readonly projectId: string;
@@ -295,6 +317,25 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
     };
   }, [agentId, knownAttempt, listedKnown, projectId]);
 
+  /*
+   * An existing agent keeps the provider it was registered on. Capability
+   * links carry that provider for a fast path, but the saved agent is the
+   * authority when a copied or stale link disagrees.
+   */
+  useEffect(() => {
+    if (
+      agentId === undefined ||
+      agentId === NEW_AGENT ||
+      knownStatus !== "ready" ||
+      known === null ||
+      platform === known.agentPlatform
+    ) {
+      return;
+    }
+    setPlatform(known.agentPlatform);
+    setStep(firstStep(initialGoal, known.agentPlatform));
+  }, [agentId, initialGoal, known, knownStatus, platform]);
+
   useEffect(() => {
     let current = true;
     setCatalog(null);
@@ -459,6 +500,7 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
   }
 
   function choosePlatform(next: AgentSetupPlatform): void {
+    if (known !== null && next !== known.agentPlatform) return;
     if (next !== platform) clearProviderAnswers();
     setPlatform(next);
   }
@@ -704,22 +746,51 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
         : null;
     let landed: ConnectSheetResult | null = saved?.landed ?? null;
     const firstUnsavedLane = saved?.completedLanes ?? 0;
+    let retryConnections: readonly ListedConnection[] = [];
+    let retryPullEnabled = false;
+    if (saved !== null && landed !== null) {
+      setSaving(true);
+      setRefused(null);
+      const answer = await platformAnswer(
+        getAgent(
+          { agentId: landed.agentId, projectId },
+          { client: platformClient },
+        ),
+      );
+      setSaving(false);
+      if (!finishAnswer(answer)) return;
+      retryConnections = answer.value.connections;
+      retryPullEnabled = answer.value.agent.pullProductionCalls;
+    }
     for (const [index, lane] of lanesToSave.entries()) {
       if (index < firstUnsavedLane) continue;
       const candidate = retellCandidateForLane(selectedRoutes, lane, retellRoute);
       if (candidate === undefined) return;
       const option = optionNamed(catalog, candidate);
       if (option === undefined) return;
-      const result = await saveConnection(
-        selectedRetellAgent.name,
-        connectionBody(
-          option,
-          candidate,
-          // Production pull rides on the voice connection, and only once.
-          plan?.pullWithConnection === true && lane === "phone",
-        ),
-        landed?.agentId,
+      const pullsProduction =
+        plan?.pullWithConnection === true && lane === "phone";
+      const body = connectionBody(option, candidate, pullsProduction);
+      /*
+       * A provider write can commit while its HTTP response is lost. On a
+       * retry, read the landed agent first and accept the exact lane already
+       * there instead of issuing the non-idempotent POST a second time.
+       */
+      const committed = retryConnections.find((one) =>
+        sameConnection(one, body),
       );
+      const result =
+        committed !== undefined && (!pullsProduction || retryPullEnabled)
+          ? {
+              agentId: landed?.agentId ?? committed.agentId,
+              connectionId: committed.id,
+              created: landed?.created ?? false,
+            }
+          : await saveConnection(
+              selectedRetellAgent.name,
+              body,
+              landed?.agentId,
+            );
       if (result === null) return;
       landed = {
         ...result,
@@ -950,8 +1021,12 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
                 choosePlatform(value as AgentSetupPlatform)
               }
             >
-              <ChoiceCard compact value="retell" title="Retell" />
-              <ChoiceCard compact value="livekit" title="LiveKit" />
+              {known === null || known.agentPlatform === "retell" ? (
+                <ChoiceCard compact value="retell" title="Retell" />
+              ) : null}
+              {known === null || known.agentPlatform === "livekit" ? (
+                <ChoiceCard compact value="livekit" title="LiveKit" />
+              ) : null}
             </RadioGroup>
           </div>
         );

--- a/apps/web/app/projects/[projectId]/agents/livekit-monitoring-instructions.tsx
+++ b/apps/web/app/projects/[projectId]/agents/livekit-monitoring-instructions.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import Link from "next/link";
+
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import type { LiveKitWorkerLanguage } from "@/lib/agent-setup-flow.ts";
+
+import { CopyBlock } from "./copy-block.tsx";
+
+// The repository's package manager resolves the latest SDK. The source URL is
+// unpinned for the same reason the public integration skill is unpinned: the
+// installed CLI owns the current LiveKit source contract.
+const PYTHON_INSTALL =
+  "pip install 'egma @ git+https://github.com/egma-ai/egma.git#subdirectory=sdks/python'";
+const PYTHON_HOOK = `from egma import monitor_livekit
+
+async def entrypoint(ctx):
+    monitor_livekit(ctx)
+    await ctx.connect()
+    session = AgentSession(...)
+    await session.start(...)`;
+const JAVASCRIPT_INSTALL = "npm install @egma/livekit";
+const JAVASCRIPT_HOOK = `import { monitorLiveKit } from "@egma/livekit";
+
+export async function entrypoint(ctx: JobContext) {
+  monitorLiveKit(ctx);
+  await ctx.connect();
+  const session = new voice.AgentSession(...);
+  await session.start(...);
+}`;
+const EGMA_URL_PLACEHOLDER = "<your-public-egma-url>";
+const API_KEY_PLACEHOLDER = "<your-project-api-key>";
+
+function environmentValues(egmaUrl: string): string {
+  return `EGMA_URL=${egmaUrl}\nEGMA_API_KEY=${API_KEY_PLACEHOLDER}`;
+}
+
+function WorkerSteps({
+  language,
+}: {
+  readonly language: LiveKitWorkerLanguage;
+}) {
+  const steps = [
+    {
+      title: "Install the Egma SDK",
+      value:
+        language === "python" ? PYTHON_INSTALL : JAVASCRIPT_INSTALL,
+      copyLabel: `${language} install command`,
+    },
+    {
+      title: "Make the hook the first line of entrypoint",
+      value: language === "python" ? PYTHON_HOOK : JAVASCRIPT_HOOK,
+      copyLabel: `${language} monitoring code`,
+    },
+    {
+      title: "Set the environment values",
+      value: environmentValues(EGMA_URL_PLACEHOLDER),
+      copyLabel: "environment values",
+    },
+  ] as const;
+
+  return (
+    <ol className="m-0 flex list-none flex-col gap-5 p-0">
+      {steps.map((step, index) => (
+        <li className="flex gap-3" key={step.title}>
+          <span className="w-(--space-5) flex-none text-sm leading-(--line-normal) text-foreground tabular-nums">
+            {index + 1}
+          </span>
+          <div className="flex min-w-0 flex-1 flex-col gap-2">
+            <p className="m-0 text-sm leading-(--line-normal) font-medium text-foreground">
+              {step.title}
+            </p>
+            <CopyBlock value={step.value} copyLabel={step.copyLabel} />
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+/**
+ * The LiveKit monitoring work the web can explain but cannot perform.
+ *
+ * The customer owns the worker and its deployment. This component therefore
+ * makes no write and never claims that Monitoring is configured. A real
+ * production trace is the only confirmation.
+ */
+export function LiveKitMonitoringInstructions({
+  projectId,
+  language,
+  onLanguageChange,
+}: {
+  readonly projectId: string;
+  readonly language: LiveKitWorkerLanguage | "";
+  readonly onLanguageChange: (language: LiveKitWorkerLanguage) => void;
+}) {
+  return (
+    <section className="flex flex-col gap-5" aria-labelledby="livekit-monitoring-title">
+      <div className="flex flex-col gap-2">
+        <h3
+          className="m-0 text-lg leading-(--line-tight) font-medium text-foreground"
+          data-setup-heading
+          id="livekit-monitoring-title"
+          tabIndex={-1}
+        >
+          Add monitoring to your LiveKit agent
+        </h3>
+      </div>
+
+      <Tabs
+        className="flex flex-col gap-3"
+        value={language}
+        onValueChange={(value) =>
+          onLanguageChange(value as LiveKitWorkerLanguage)
+        }
+      >
+        <p
+          className="m-0 text-sm leading-(--line-normal) font-medium text-foreground"
+          id="livekit-worker-language"
+        >
+          What language is your LiveKit worker?
+        </p>
+        <TabsList aria-labelledby="livekit-worker-language">
+          <TabsTrigger value="python">Python</TabsTrigger>
+          <TabsTrigger value="javascript">JavaScript</TabsTrigger>
+        </TabsList>
+        {language === "" ? null : (
+          <>
+            <TabsContent className="pt-3" value="python">
+              <WorkerSteps language="python" />
+            </TabsContent>
+            <TabsContent className="pt-3" value="javascript">
+              <WorkerSteps language="javascript" />
+            </TabsContent>
+          </>
+        )}
+      </Tabs>
+      {language === "" ? null : (
+        <p className="m-0 text-sm leading-(--line-normal) text-muted-foreground">
+          Create a project key in{" "}
+          <Link
+            className="text-foreground underline underline-offset-2 pointer-hover:text-brand"
+            href={`/projects/${encodeURIComponent(projectId)}/settings/keys`}
+          >
+            API keys
+          </Link>
+          , then replace {API_KEY_PLACEHOLDER}. Set {EGMA_URL_PLACEHOLDER} to the
+          public Egma API URL that your deployed LiveKit worker can reach.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/app/projects/[projectId]/agents/livekit-testing-instructions.tsx
+++ b/apps/web/app/projects/[projectId]/agents/livekit-testing-instructions.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { CopyBlock } from "./copy-block.tsx";
+
+export const TESTING_SETUP_INSTALL =
+  "pip install 'egma @ git+https://github.com/egma-ai/egma.git#subdirectory=sdks/python'";
+
+export const VOICE_SETUP_SNIPPET = `from egma import mockable
+
+agent = ...
+session = AgentSession(...)
+await mockable(agent, ctx, session)
+await session.start(...)`;
+
+export const CHAT_SETUP_SNIPPET = `from livekit.agents import room_io
+from egma import mockable
+
+agent = ...
+session = AgentSession(...)
+await mockable(agent, ctx, session)
+
+chat = ctx.job.room.name.startswith("egma-sim-chat-")
+options = (
+    room_io.RoomOptions(
+        audio_input=False,
+        audio_output=False,
+        text_output=room_io.TextOutputOptions(sync_transcription=False),
+    )
+    if chat
+    else room_io.RoomOptions()
+)
+await session.start(agent=agent, room=ctx.room, room_options=options)`;
+
+const PROMPT_START = `Set up Egma simulation testing for this repository's Python LiveKit worker.
+
+Start by running \`egma livekit\` if it is available, or \`npx --yes @egma/cli livekit\` otherwise, and follow its current Python testing contract.
+
+Use the repository's existing dependency file and package manager to install the latest Egma Python SDK from \`egma @ git+https://github.com/egma-ai/egma.git#subdirectory=sdks/python\`. Do not pin a version, tag, or commit.
+
+In the job entrypoint, import mockable from egma. After the initial agent and AgentSession exist, and before AgentSession.start, call await mockable(agent, ctx, session).`;
+
+const PROMPT_END = `Register the worker under one exact name, with agent_name in its WorkerOptions, and tell me the name it registers under.
+
+Preserve the production voice path, run the repository's focused checks, change nothing else, and leave every environment file unread.`;
+
+export const VOICE_SETUP_PROMPT = `${PROMPT_START}
+
+${PROMPT_END}`;
+
+export const CHAT_SETUP_PROMPT = `${PROMPT_START}
+
+For rooms whose name starts with "egma-sim-chat-", pass room options to AgentSession.start with audio input off, audio output off, and transcription sync off. Keep the worker's existing room options for every other room.
+
+Do not start any independent audio publisher, such as background audio, while chat is true.
+
+${PROMPT_END}`;
+
+type LiveKitTestingInstructionsProps = {
+  readonly modality: "chat" | "voice";
+};
+
+/**
+ * The LiveKit testing work the web can explain but cannot perform.
+ *
+ * The customer owns the worker and its deployment. This component makes no
+ * write and never claims that testing is ready. The first simulation is the
+ * confirmation that the source integration works.
+ */
+export function LiveKitTestingInstructions({
+  modality,
+}: LiveKitTestingInstructionsProps) {
+  const chat = modality === "chat";
+  const steps = [
+    {
+      title: "Give this to your coding agent",
+      value: chat ? CHAT_SETUP_PROMPT : VOICE_SETUP_PROMPT,
+      copyLabel: "coding-agent prompt",
+    },
+    {
+      title: "Install the latest Egma SDK",
+      value: TESTING_SETUP_INSTALL,
+      copyLabel: "install command",
+    },
+    {
+      title: "Apply the Python testing contract",
+      value: chat ? CHAT_SETUP_SNIPPET : VOICE_SETUP_SNIPPET,
+      copyLabel: "Python testing code",
+    },
+  ] as const;
+
+  return (
+    <section
+      className="flex flex-col gap-5"
+      aria-labelledby="livekit-testing-title"
+    >
+      <div className="flex flex-col gap-2">
+        <h3
+          className="m-0 text-lg leading-(--line-tight) font-medium text-foreground"
+          data-setup-heading
+          id="livekit-testing-title"
+          tabIndex={-1}
+        >
+          Add simulation testing to your LiveKit agent
+        </h3>
+        <p className="m-0 text-sm leading-(--line-normal) text-muted-foreground">
+          {chat
+            ? "A Python worker needs the Egma testing hook, silent chat-room options, and a registered dispatch name. JavaScript workers support monitoring, but not Egma simulation testing."
+            : "A Python worker needs the Egma testing hook and a registered dispatch name. JavaScript workers support monitoring, but not Egma simulation testing."}
+        </p>
+      </div>
+
+      <ol className="m-0 flex list-none flex-col gap-5 p-0">
+        {steps.map((step, index) => (
+          <li className="flex gap-3" key={step.title}>
+            <span className="w-(--space-5) flex-none text-sm leading-(--line-normal) text-foreground tabular-nums">
+              {index + 1}
+            </span>
+            <div className="flex min-w-0 flex-1 flex-col gap-2">
+              <p className="m-0 text-sm leading-(--line-normal) font-medium text-foreground">
+                {step.title}
+              </p>
+              <CopyBlock value={step.value} copyLabel={step.copyLabel} />
+            </div>
+          </li>
+        ))}
+      </ol>
+      <p className="m-0 text-sm leading-(--line-normal) text-muted-foreground">
+        Production rooms keep the worker&apos;s existing behavior. Egma cannot
+        see this change from here. The first simulation confirms it.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/app/projects/[projectId]/agents/screen.tsx
+++ b/apps/web/app/projects/[projectId]/agents/screen.tsx
@@ -43,6 +43,7 @@ import {
   ConnectAgentSheet,
   type ConnectAgentGoal,
   type ConnectAgentPlatform,
+  type RetellRecovery,
 } from "./connect-sheet.tsx";
 import { ConnectionSheet } from "./connection-sheet.tsx";
 import { MockToolsSheet } from "./mock-tools-sheet.tsx";
@@ -164,6 +165,9 @@ export function AgentsScreen({
   const [renaming, setRenaming] = useState<ListedAgentWithConnections | null>(null);
   /** The agent whose mocked world is being explained and ticked. */
   const [mocking, setMocking] = useState<ListedAgentWithConnections | null>(null);
+  /** A Retell write whose answer may have been lost, kept across sheet Close. */
+  const [retellRecovery, setRetellRecovery] =
+    useState<RetellRecovery | null>(null);
 
   const carried = after !== null && after.project === projectId ? after.page : null;
 
@@ -172,6 +176,7 @@ export function AgentsScreen({
 
   useEffect(() => {
     showing.current = projectId;
+    setRetellRecovery(null);
     setAfter(null);
     setMoreRefused(null);
     setLoadingMore(false);
@@ -623,8 +628,24 @@ export function AgentsScreen({
           {...(sheet.platform === undefined ? {} : { platform: sheet.platform })}
           mayAuthor={mayAuthor}
           role={role}
-          onClose={close}
+          retellRecovery={retellRecovery}
+          onRecoveryNeeded={(next) =>
+            setRetellRecovery((current) =>
+              next.agentId === null &&
+              current?.platformAgentId === next.platformAgentId
+                ? current
+                : next,
+            )
+          }
+          onClose={() => {
+            close();
+            // A write can commit after the browser loses its answer. Refresh
+            // the list before the next setup opens so it can reconcile from
+            // the saved agent instead of trusting sheet-local retry state.
+            if (retellRecovery !== null) refresh();
+          }}
           onConnected={() => {
+            setRetellRecovery(null);
             /*
              * **A save closes onto the list, and nothing navigates.**
              *

--- a/apps/web/app/projects/[projectId]/agents/screen.tsx
+++ b/apps/web/app/projects/[projectId]/agents/screen.tsx
@@ -39,7 +39,11 @@ import {
   monitoringCapabilityOf,
   simulationCapabilityOf,
 } from "./agent-details-sheet.tsx";
-import { ConnectAgentSheet } from "./connect-sheet.tsx";
+import {
+  ConnectAgentSheet,
+  type ConnectAgentGoal,
+  type ConnectAgentPlatform,
+} from "./connect-sheet.tsx";
 import { ConnectionSheet } from "./connection-sheet.tsx";
 import { MockToolsSheet } from "./mock-tools-sheet.tsx";
 import { RenameAgentSheet } from "./rename-sheet.tsx";
@@ -82,7 +86,12 @@ import { RenameAgentSheet } from "./rename-sheet.tsx";
 
 /** The panel a route insists on, whatever the query string says. */
 export type ForcedSheet =
-  | { readonly kind: "connect" }
+  | {
+      readonly kind: "connect";
+      readonly agentId?: string;
+      readonly goal?: ConnectAgentGoal;
+      readonly platform?: ConnectAgentPlatform;
+    }
   | { readonly kind: "agent"; readonly agentId: string }
   | { readonly kind: "connection"; readonly agentId: string; readonly connectionId: string };
 
@@ -607,9 +616,27 @@ export function AgentsScreen({
 
       {sheet?.kind === "connect" ? (
         <ConnectAgentSheet
+          projectId={projectId}
+          agents={items}
+          {...(sheet.agentId === undefined ? {} : { agentId: sheet.agentId })}
+          {...(sheet.goal === undefined ? {} : { goal: sheet.goal })}
+          {...(sheet.platform === undefined ? {} : { platform: sheet.platform })}
           mayAuthor={mayAuthor}
           role={role}
           onClose={close}
+          onConnected={() => {
+            /*
+             * **A save closes onto the list, and nothing navigates.**
+             *
+             * There is no agent page to land on any more: the row is the agent,
+             * and the row this save just wrote is right there behind the panel.
+             * `replace` rather than `push`, because the address behind is the
+             * panel that was just finished with — Back should be the list it
+             * was opened from, not the form opening again.
+             */
+            router.replace(home);
+            refresh();
+          }}
         />
       ) : null}
 
@@ -762,7 +789,14 @@ function openSheet(
   const agentId = query.get("agent");
   const connectionId = query.get("connection");
   if (kind === "connect") {
-    return { kind: "connect" };
+    const goal = connectGoal(query.get("goal"));
+    const platform = connectPlatform(query.get("platform"));
+    return {
+      kind: "connect",
+      ...(agentId === null ? {} : { agentId }),
+      ...(goal === undefined ? {} : { goal }),
+      ...(platform === undefined ? {} : { platform }),
+    };
   }
   if (kind === "agent" && agentId !== null) {
     return { kind: "agent", agentId };
@@ -771,4 +805,16 @@ function openSheet(
     return { kind: "connection", agentId, connectionId };
   }
   return null;
+}
+
+/** Only providers implemented by this setup flow can become sheet state. */
+function connectPlatform(value: string | null): ConnectAgentPlatform | undefined {
+  return value === "retell" || value === "livekit" ? value : undefined;
+}
+
+/** Only the three public setup goals can become sheet state. */
+function connectGoal(value: string | null): ConnectAgentGoal | undefined {
+  return value === "simulation" || value === "monitoring" || value === "both"
+    ? value
+    : undefined;
 }

--- a/apps/web/app/projects/[projectId]/monitoring/setup-path.ts
+++ b/apps/web/app/projects/[projectId]/monitoring/setup-path.ts
@@ -1,11 +1,21 @@
 import { projectPath } from "../../../../lib/project-context.ts";
 
 /**
- * The shared coding-agent handoff used by every Monitoring entry point.
+ * The shared agent-setup address used by every Monitoring entry point.
  *
- * The sheet always shows all three outcomes. Monitoring does not encode a
- * hidden selection or an old wizard step in its address.
+ * The Agents page owns the flow. Monitoring only states the user's goal and,
+ * when one is already known, the agent the flow should start from. The query
+ * is durable UI state: a copied link opens Connect agent with Monitoring
+ * selected.
  */
-export function monitoringSetupPath(projectId: string): string {
-  return `${projectPath(projectId, "agents")}?sheet=connect`;
+export function monitoringSetupPath(
+  projectId: string,
+  agentId?: string,
+): string {
+  const query = new URLSearchParams();
+  query.set("sheet", "connect");
+  if (agentId !== undefined) query.set("agent", agentId);
+  query.set("goal", "monitoring");
+
+  return `${projectPath(projectId, "agents")}?${query.toString()}`;
 }

--- a/apps/web/app/projects/[projectId]/monitoring/start/page.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/start/page.tsx
@@ -5,14 +5,23 @@ import { monitoringSetupPath } from "../setup-path.ts";
 /**
  * The old Start-monitoring address, kept as a forwarding deep link.
  *
- * **There is one setup handoff.** This route carries an old link to the three
- * current coding-agent prompts instead of restoring the retired wizard state.
+ * **There is one setup flow.** Agents owns Connect agent and the provider-
+ * specific Monitoring goal. This route carries an old link into that flow
+ * instead of rendering a second monitoring form.
+ *
+ * `?agent=` rides through. It still names the agent the setup flow should
+ * begin from; `goal=monitoring` states why the person entered the flow.
  */
 export default async function StartMonitoringPage({
   params,
+  searchParams,
 }: {
   readonly params: Promise<{ readonly projectId: string }>;
+  readonly searchParams: Promise<{
+    readonly agent?: string | readonly string[];
+  }>;
 }) {
-  const { projectId } = await params;
-  redirect(monitoringSetupPath(projectId));
+  const [{ projectId }, asked] = await Promise.all([params, searchParams]);
+  const agentId = typeof asked.agent === "string" ? asked.agent : undefined;
+  redirect(monitoringSetupPath(projectId, agentId));
 }

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/screen.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/screen.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../../../../lib/platform-client.ts";
 import { rowsIn, type ApiKeyList } from "../../../../../lib/settings.ts";
 import {
+  AGENT_PARAMETER,
   MONITOR_SHEET,
   SHEET_PARAMETER,
 } from "../../../../../lib/monitoring.ts";
@@ -546,21 +547,29 @@ export function TranscriptsScreen({
 
   /*
    * A copied legacy `sheet=monitor` link cannot reopen the retired picker.
-   * It forwards to the same Agents-owned handoff as the visible action. The
-   * handoff discovers the repository instead of restoring old wizard state.
+   * It forwards to the same Agents-owned flow as the visible action and keeps
+   * an agent the old link named.
    */
   const legacySetup = query.get(SHEET_PARAMETER) === MONITOR_SHEET;
+  const legacyAgentId = query.get(AGENT_PARAMETER);
   const replace = router.replace;
   useEffect(() => {
     if (!legacySetup) return;
-    replace(monitoringSetupPath(projectId));
-  }, [legacySetup, projectId, replace]);
+    replace(
+      monitoringSetupPath(
+        projectId,
+        legacyAgentId === null ? undefined : legacyAgentId,
+      ),
+    );
+  }, [legacyAgentId, legacySetup, projectId, replace]);
 
   /**
    * The one action this screen offers, and the same control wherever it sits.
    *
-   * **Agents owns setup.** This page opens the same three-prompt coding-agent
-   * handoff as every other setup entry point.
+   * **Agents owns setup.** This page only states the user's goal. The address
+   * opens Connect agent on Agents with Monitoring selected, so first setup and
+   * later setup use one provider-specific flow instead of two forms that can
+   * disagree.
    *
    * **One page for every role, and the control that changes data is disabled
    * rather than removed.** Setup requires `configure_monitoring`, which a

--- a/apps/web/lib/agent-setup-flow.ts
+++ b/apps/web/lib/agent-setup-flow.ts
@@ -1,0 +1,350 @@
+import type { DiscoverAgentsResponse } from "@egma/platform-api/client";
+
+/** The job a person asks the Connect agent flow to complete. */
+export type AgentSetupGoal = "simulation" | "monitoring" | "both";
+
+/** The two platforms the goal-first flow offers today. */
+export type AgentSetupPlatform = "retell" | "livekit";
+
+/** The language of the customer-owned LiveKit worker. */
+export type LiveKitWorkerLanguage = "python" | "javascript";
+
+/**
+ * One provider-specific execution plan behind the goal and platform questions.
+ *
+ * The sheet renders this answer. It does not decide provider capability in its
+ * branches. This is the state-machine seam: six inputs, six honest plans, and
+ * no generic "configured" state that means a different thing per provider.
+ */
+export type AgentSetupPlan = {
+  readonly goal: AgentSetupGoal;
+  readonly platform: AgentSetupPlatform;
+  /** Whether any supported branch of this flow can save a provider connection. */
+  readonly mayWriteConnection: boolean;
+  /** Whether the Retell connection save also turns on production pulling. */
+  readonly pullWithConnection: boolean;
+  /** Whether the UI shows LiveKit instructions without recording an on/off state. */
+  readonly monitoringInstructions: boolean;
+  /**
+   * Whether this plan asks the one question — how should Egma test this agent.
+   *
+   * A monitoring goal does not: it needs the voice connection for production
+   * pull and nothing else, so it walks straight to the number chooser exactly
+   * as it does today. Asking it "text, web call or phone?" would be a question
+   * whose answer it cannot use.
+   */
+  readonly asksHowToTest: boolean;
+};
+
+const PLANS: Readonly<
+  Record<AgentSetupPlatform, Readonly<Record<AgentSetupGoal, AgentSetupPlan>>>
+> = {
+  retell: {
+    simulation: {
+      goal: "simulation",
+      platform: "retell",
+      mayWriteConnection: true,
+      pullWithConnection: false,
+      monitoringInstructions: false,
+      asksHowToTest: true,
+    },
+    monitoring: {
+      goal: "monitoring",
+      platform: "retell",
+      /* The selected voice route is saved, and that same save starts pulling. */
+      mayWriteConnection: true,
+      pullWithConnection: true,
+      monitoringInstructions: false,
+      asksHowToTest: false,
+    },
+    both: {
+      goal: "both",
+      platform: "retell",
+      mayWriteConnection: true,
+      pullWithConnection: true,
+      monitoringInstructions: false,
+      // Both needs the voice connection for production pull, so it takes the
+      // number chooser without the question, exactly as Monitoring does.
+      asksHowToTest: false,
+    },
+  },
+  livekit: {
+    simulation: {
+      goal: "simulation",
+      platform: "livekit",
+      mayWriteConnection: true,
+      pullWithConnection: false,
+      monitoringInstructions: false,
+      asksHowToTest: false,
+    },
+    monitoring: {
+      goal: "monitoring",
+      platform: "livekit",
+      mayWriteConnection: false,
+      pullWithConnection: false,
+      monitoringInstructions: true,
+      asksHowToTest: false,
+    },
+    both: {
+      goal: "both",
+      platform: "livekit",
+      // Python continues into simulation setup; JavaScript finishes after
+      // monitoring because its test runs cannot yet be isolated.
+      mayWriteConnection: true,
+      pullWithConnection: false,
+      monitoringInstructions: true,
+      asksHowToTest: false,
+    },
+  },
+};
+
+export function agentSetupPlan(
+  goal: AgentSetupGoal,
+  platform: AgentSetupPlatform,
+): AgentSetupPlan {
+  return PLANS[platform][goal];
+}
+
+export type RetellDiscoveredAgent = DiscoverAgentsResponse["agents"][number];
+export type RetellConnectionCandidate =
+  RetellDiscoveredAgent["connectionCandidates"][number];
+
+/**
+ * Retell agents that can enter the selected plan.
+ *
+ * **Voice agents only.** Egma registers Retell voice agents, so discovery
+ * answers with those and this keeps the guarantee at the surface too: a
+ * chat-native agent is never offered, because no lane reaches one and the
+ * product would have nothing to ask about it.
+ */
+export function retellAgentsForPlan(
+  plan: AgentSetupPlan,
+  agents: readonly RetellDiscoveredAgent[] | null,
+): readonly RetellDiscoveredAgent[] {
+  if (plan.platform !== "retell" || !plan.mayWriteConnection) return [];
+  return agents?.filter((agent) => agent.modality === "voice") ?? [];
+}
+
+/** The selected agent's connection candidates that this plan can save. */
+export function retellCandidatesForPlan(
+  plan: AgentSetupPlan,
+  agent: RetellDiscoveredAgent | undefined,
+): readonly RetellConnectionCandidate[] {
+  if (plan.platform !== "retell" || agent === undefined) return [];
+  return agent.connectionCandidates;
+}
+
+/**
+ * The three lanes, and the one question that leads.
+ *
+ * They are the same three words the CLI says, because they are the same three
+ * lanes: each one is a connection, several may be picked, and every pick lands
+ * on **one** egma agent in one pass.
+ */
+export const RETELL_LANES = ["text", "web-call", "phone"] as const;
+export type RetellLane = (typeof RETELL_LANES)[number];
+
+export const RETELL_LANE_QUESTION = "How should Egma test this agent?";
+
+/** The word on screen for each lane. */
+export const RETELL_LANE_LABELS: Readonly<Record<RetellLane, string>> = {
+  text: "Text",
+  "web-call": "Web call",
+  phone: "Phone call",
+};
+
+/** One help line each, in what the lane tests rather than what it is made of. */
+export const RETELL_LANE_HELP: Readonly<Record<RetellLane, string>> = {
+  text: "Egma talks to the agent in text. No call is placed, and a run takes seconds.",
+  "web-call": "A voice call Egma places over the internet.",
+  phone:
+    "Egma dials the real number, so a run has true telephone latency and " +
+    "reaches your real tools.",
+};
+
+/** The connection type each lane is saved as. */
+export const RETELL_LANE_CONNECTION_TYPES: Readonly<Record<RetellLane, string>> = {
+  text: "retell_text_mode",
+  "web-call": "retell_web_call",
+  phone: "phone_number",
+};
+
+/**
+ * The picked lanes, in reading order, out of whatever order they were ticked
+ * in.
+ *
+ * Two people ticking the same three boxes in different orders must write the
+ * same three connections in the same order, or one project's connection names
+ * would depend on the order somebody clicked.
+ */
+export function retellLanesInOrder(
+  picked: readonly string[],
+): readonly RetellLane[] {
+  return RETELL_LANES.filter((lane) => picked.includes(lane));
+}
+
+/**
+ * The candidate that saves one lane, out of the ones discovery answered with.
+ *
+ * The phone lane is the one that needs saying which: a voice agent can have
+ * several routed numbers, and the chooser is where the person says which one.
+ * The other two lanes carry the vendor agent id and have exactly one candidate
+ * each.
+ */
+export function retellCandidateForLane(
+  candidates: readonly RetellConnectionCandidate[],
+  lane: RetellLane,
+  phoneNumberValue = "",
+): RetellConnectionCandidate | undefined {
+  const type = RETELL_LANE_CONNECTION_TYPES[lane];
+  if (lane !== "phone") {
+    return candidates.find((one) => one.connectionType === type);
+  }
+  const phones = candidates.filter((one) => one.connectionType === type);
+  if (phoneNumberValue === "") return phones[0];
+  return phones.find((one) => retellCandidateValue(one) === phoneNumberValue);
+}
+
+/** Whether this agent has the provider route the selected goal needs. */
+export function retellAgentCanEnterPlan(
+  plan: AgentSetupPlan,
+  agent: RetellDiscoveredAgent,
+): boolean {
+  if (plan.platform !== "retell" || !plan.mayWriteConnection) return false;
+  if (!plan.asksHowToTest) {
+    return agent.connectionCandidates.some(
+      (candidate) => candidate.connectionType === "phone_number",
+    );
+  }
+  return RETELL_LANES.some(
+    (lane) => retellCandidateForLane(agent.connectionCandidates, lane) !== undefined,
+  );
+}
+
+/** A stable form value for one discovered candidate. */
+export function retellCandidateValue(candidate: RetellConnectionCandidate): string {
+  if (candidate.connectionType === "phone_number") {
+    return `phone:${candidate.config.phoneNumber ?? ""}`;
+  }
+  return `${candidate.connectionType}:${candidate.config.retellAgentId ?? ""}`;
+}
+
+/** The visible desktop states in the approved setup flow. */
+export type AgentSetupStep =
+  | "goal"
+  | "platform"
+  | "retell-key"
+  | "retell-agent"
+  | "retell-lanes"
+  | "retell-phone"
+  | "livekit-language"
+  | "livekit-modality"
+  | "livekit-simulation"
+  | "livekit-testing"
+  | "livekit-monitoring";
+
+/**
+ * Provider capability decides the first provider-specific screen.
+ *
+ * LiveKit Simulation asks for the worker language, then the modality, before
+ * credentials. Monitoring and Both start with monitoring instructions, where
+ * the language choice decides whether Both can continue into Simulation.
+ */
+export function stepAfterPlatform(
+  goal: AgentSetupGoal,
+  platform: AgentSetupPlatform,
+): AgentSetupStep {
+  if (platform === "retell") return "retell-key";
+  // Monitoring asks for the worker language on its own instruction screen.
+  // Both starts there too, so JavaScript can finish Monitoring without first
+  // creating a simulation connection that the JavaScript SDK cannot isolate.
+  return goal === "simulation" ? "livekit-language" : "livekit-monitoring";
+}
+
+/**
+ * What follows a saved LiveKit simulation connection.
+ *
+ * Every Python worker needs the testing hook. Chat adds silent room handling.
+ * This is a screen and not a recorded state: Egma cannot see the source change
+ * from the web application, so the sheet claims no completion for it.
+ */
+export function stepAfterLiveKitCredentials(
+  _plan: AgentSetupPlan,
+): AgentSetupStep {
+  return "livekit-testing";
+}
+
+/** What follows the testing instructions, or `null` when the flow is done. */
+export function stepAfterLiveKitTesting(
+  _plan: AgentSetupPlan,
+): AgentSetupStep | null {
+  // A Both flow completes Monitoring before it starts Python simulation setup.
+  return null;
+}
+
+/**
+ * Where a chosen Retell agent leads.
+ *
+ * Straight to the one question — how should Egma test this agent — because the
+ * choice a person understands comes before any plumbing. Monitoring and Both
+ * need the voice connection for production pull, so they skip the question and
+ * go to the number chooser exactly as they do today.
+ */
+export function stepAfterRetellAgent(plan: AgentSetupPlan): AgentSetupStep {
+  return plan.asksHowToTest ? "retell-lanes" : "retell-phone";
+}
+
+/**
+ * Where the answer to the one question leads, or `null` when the flow can save
+ * now.
+ *
+ * **The phone-number chooser appears only when Phone call is picked.** A
+ * developer who picked only Text is never asked for a phone number: the fast
+ * lane has no needless steps, and there is nothing honest to ask about a number
+ * nothing will dial.
+ */
+export function stepAfterRetellLanes(
+  lanes: readonly RetellLane[],
+): AgentSetupStep | null {
+  return lanes.includes("phone") ? "retell-phone" : null;
+}
+
+/** The single Back graph shared by every rendering of the setup flow. */
+export function previousAgentSetupStep({
+  step,
+  goal,
+}: {
+  readonly step: AgentSetupStep;
+  readonly goal: AgentSetupGoal | "";
+}): AgentSetupStep | null {
+  switch (step) {
+    case "goal":
+      return null;
+    case "platform":
+      return "goal";
+    case "retell-key":
+    case "livekit-language":
+      return "platform";
+    case "livekit-modality":
+      // Both has already shown Monitoring and captured Python before it can
+      // enter simulation setup. Simulation-only captured Python on the
+      // language screen.
+      return goal === "both" ? "livekit-monitoring" : "livekit-language";
+    case "retell-agent":
+      return "retell-key";
+    case "retell-lanes":
+      return "retell-agent";
+    case "retell-phone":
+      // The phone chooser is reached through the one question when the goal is
+      // a simulation, and straight from the agent for the goals that skip it.
+      return goal === "simulation" ? "retell-lanes" : "retell-agent";
+    case "livekit-simulation":
+      return "livekit-modality";
+    case "livekit-testing":
+      // The connection is already persisted before this screen appears. Do
+      // not let Back cross that write and change the modality it describes.
+      return null;
+    case "livekit-monitoring":
+      return "platform";
+  }
+}

--- a/apps/web/lib/monitoring.ts
+++ b/apps/web/lib/monitoring.ts
@@ -1,6 +1,7 @@
 /**
  * The retired Monitoring-sheet query, read only so copied old links can be
- * forwarded to the Agents-owned three-prompt coding-agent handoff.
+ * forwarded to the Agents-owned goal-first setup flow.
  */
 export const SHEET_PARAMETER = "sheet";
 export const MONITOR_SHEET = "monitor";
+export const AGENT_PARAMETER = "agent";

--- a/apps/web/test/agent-capabilities.test.tsx
+++ b/apps/web/test/agent-capabilities.test.tsx
@@ -363,7 +363,7 @@ describe("Paper agent capability states", () => {
     expect(detail.getByText("No connections yet")).toBeDefined();
     expect(detail.getByRole("heading", { name: "Capabilities" })).toBeDefined();
     expect(detail.getByRole("link", { name: "Set up simulation" }).getAttribute("href")).toBe(
-      "/projects/prj_1/agents?sheet=connect",
+      "/projects/prj_1/agents?sheet=connect&agent=agt_details&goal=simulation&platform=retell",
     );
     expect(detail.getByRole("button", { name: "Stop monitoring" })).toBeDefined();
     expect(detail.getByRole("button", { name: "Done" })).toBeDefined();
@@ -417,7 +417,7 @@ describe("Paper agent capability states", () => {
     expect(
       detail.getByRole("link", { name: "View setup instructions" }).getAttribute("href"),
     ).toBe(
-      "/projects/prj_1/agents?sheet=connect",
+      "/projects/prj_1/agents?sheet=connect&agent=agt_livekit&goal=monitoring&platform=livekit",
     );
     expect(detail.queryByRole("button", { name: /(?:start|stop) monitoring/i })).toBeNull();
   });

--- a/apps/web/test/agent-setup-flow.test.ts
+++ b/apps/web/test/agent-setup-flow.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  agentSetupPlan,
+  previousAgentSetupStep,
+  retellAgentCanEnterPlan,
+  retellAgentsForPlan,
+  retellCandidateForLane,
+  retellCandidateValue,
+  retellCandidatesForPlan,
+  retellLanesInOrder,
+  RETELL_LANES,
+  RETELL_LANE_HELP,
+  RETELL_LANE_LABELS,
+  RETELL_LANE_QUESTION,
+  stepAfterLiveKitCredentials,
+  stepAfterLiveKitTesting,
+  stepAfterPlatform,
+  stepAfterRetellAgent,
+  stepAfterRetellLanes,
+  type RetellDiscoveredAgent,
+} from "../lib/agent-setup-flow.ts";
+
+const CHAT = {
+  platformAgentId: "chat_1",
+  name: "Chat support",
+  modality: "chat" as const,
+  connectionCandidates: [
+    {
+      agentPlatform: "retell" as const,
+      connectionType: "retell_chat_api" as const,
+      accessVariant: "retell_chat_api.api_key" as const,
+      modality: "chat" as const,
+      productLabel: "Retell chat",
+      config: { retellAgentId: "chat_1" },
+    },
+  ],
+};
+
+const VOICE = {
+  platformAgentId: "voice_1",
+  name: "Voice support",
+  modality: "voice" as const,
+  connectionCandidates: [
+    {
+      agentPlatform: "retell" as const,
+      connectionType: "phone_number" as const,
+      accessVariant: "phone_number.public_e164" as const,
+      modality: "voice" as const,
+      productLabel: "Retell phone",
+      config: { phoneNumber: "+14155550100" },
+    },
+    {
+      agentPlatform: "retell" as const,
+      connectionType: "phone_number" as const,
+      accessVariant: "phone_number.public_e164" as const,
+      modality: "voice" as const,
+      productLabel: "Retell phone",
+      config: { phoneNumber: "+14155550101" },
+    },
+  ],
+};
+
+const UNROUTED_VOICE = {
+  platformAgentId: "voice_2",
+  name: "Voice without a number",
+  modality: "voice" as const,
+  connectionCandidates: [],
+};
+
+/** A voice agent as discovery now describes one: text mode chat door, the
+ * web call, and one routed number — the choice the modality question spans. */
+const VOICE_WITH_ROUTES: RetellDiscoveredAgent = {
+  platformAgentId: "voice_3",
+  name: "Front desk",
+  modality: "voice" as const,
+  connectionCandidates: [
+    {
+      agentPlatform: "retell" as const,
+      connectionType: "retell_text_mode" as const,
+      accessVariant: "retell_text_mode.api_key" as const,
+      modality: "chat" as const,
+      productLabel: "Retell text mode",
+      config: { retellAgentId: "voice_3" },
+    },
+    {
+      agentPlatform: "retell" as const,
+      connectionType: "retell_web_call" as const,
+      accessVariant: "retell_web_call.api_key" as const,
+      modality: "voice" as const,
+      productLabel: "Retell web call",
+      config: { retellAgentId: "voice_3" },
+    },
+    {
+      agentPlatform: "retell" as const,
+      connectionType: "phone_number" as const,
+      accessVariant: "phone_number.public_e164" as const,
+      modality: "voice" as const,
+      productLabel: "Retell phone",
+      config: { phoneNumber: "+14155550109" },
+    },
+  ],
+};
+
+describe("the goal-first agent setup plan", () => {
+  it("keeps provider work honest for all six goal and platform pairs", () => {
+    expect(agentSetupPlan("simulation", "retell")).toMatchObject({
+      mayWriteConnection: true,
+      pullWithConnection: false,
+      asksHowToTest: true,
+    });
+    // Monitoring and Both need the voice connection for production pull, so
+    // they skip the one question exactly as they do today.
+    expect(agentSetupPlan("monitoring", "retell")).toMatchObject({
+      mayWriteConnection: true,
+      pullWithConnection: true,
+      asksHowToTest: false,
+    });
+    expect(agentSetupPlan("both", "retell")).toMatchObject({
+      mayWriteConnection: true,
+      pullWithConnection: true,
+      asksHowToTest: false,
+    });
+    expect(agentSetupPlan("simulation", "livekit")).toMatchObject({
+      mayWriteConnection: true,
+      monitoringInstructions: false,
+    });
+    expect(agentSetupPlan("monitoring", "livekit")).toMatchObject({
+      mayWriteConnection: false,
+      monitoringInstructions: true,
+    });
+    expect(agentSetupPlan("both", "livekit")).toMatchObject({
+      mayWriteConnection: true,
+      monitoringInstructions: true,
+    });
+  });
+
+  it("keeps every voice agent visible, including one with no routed number", () => {
+    const plan = agentSetupPlan("simulation", "retell");
+
+    expect(retellAgentsForPlan(plan, [VOICE, UNROUTED_VOICE])).toEqual([
+      VOICE,
+      UNROUTED_VOICE,
+    ]);
+  });
+
+  it("lets simulations use non-phone routes but requires a phone for production pull", () => {
+    const withoutPhone = {
+      ...VOICE_WITH_ROUTES,
+      connectionCandidates: VOICE_WITH_ROUTES.connectionCandidates.filter(
+        (candidate) => candidate.connectionType !== "phone_number",
+      ),
+    };
+
+    expect(
+      retellAgentCanEnterPlan(
+        agentSetupPlan("simulation", "retell"),
+        withoutPhone,
+      ),
+    ).toBe(true);
+    expect(
+      retellAgentCanEnterPlan(
+        agentSetupPlan("monitoring", "retell"),
+        withoutPhone,
+      ),
+    ).toBe(false);
+    expect(
+      retellAgentCanEnterPlan(agentSetupPlan("both", "retell"), withoutPhone),
+    ).toBe(false);
+    expect(
+      retellAgentCanEnterPlan(agentSetupPlan("monitoring", "retell"), VOICE),
+    ).toBe(true);
+  });
+
+  it("never offers a chat-native Retell agent, because Egma registers voice agents", () => {
+    // Egma registers Retell **voice** agents only. A chat-native agent is not
+    // a thing any lane reaches, so it is never in the picker.
+    const simulation = agentSetupPlan("simulation", "retell");
+    const both = agentSetupPlan("both", "retell");
+
+    expect(retellAgentsForPlan(simulation, [CHAT, VOICE])).toEqual([VOICE]);
+    expect(retellAgentsForPlan(both, [CHAT, VOICE])).toEqual([VOICE]);
+    expect(retellCandidateValue(VOICE.connectionCandidates[0]!)).toBe(
+      "phone:+14155550100",
+    );
+  });
+
+  it("gives the one question three lanes, each with its own help line", () => {
+    expect(RETELL_LANE_QUESTION).toBe("How should Egma test this agent?");
+    expect(RETELL_LANES).toEqual(["text", "web-call", "phone"]);
+    expect(RETELL_LANES.map((lane) => RETELL_LANE_LABELS[lane])).toEqual([
+      "Text",
+      "Web call",
+      "Phone call",
+    ]);
+    // One line each, and each says what the lane tests rather than what it is
+    // made of.
+    for (const lane of RETELL_LANES) {
+      expect(RETELL_LANE_HELP[lane].length).toBeGreaterThan(0);
+    }
+    expect(RETELL_LANE_HELP.text).toContain("seconds");
+    expect(RETELL_LANE_HELP["web-call"]).toContain("over the internet");
+    expect(RETELL_LANE_HELP.phone).toContain("real tools");
+  });
+
+  it("saves the picked lanes in reading order, whatever order they were ticked", () => {
+    // Two people ticking the same three boxes in different orders must write
+    // the same three connections in the same order.
+    expect(retellLanesInOrder(["phone", "text"])).toEqual(["text", "phone"]);
+    expect(retellLanesInOrder(["web-call", "text", "phone"])).toEqual([
+      "text",
+      "web-call",
+      "phone",
+    ]);
+    expect(retellLanesInOrder([])).toEqual([]);
+  });
+
+  it("maps every lane to the one candidate that saves it", () => {
+    const routes = retellCandidatesForPlan(
+      agentSetupPlan("simulation", "retell"),
+      VOICE_WITH_ROUTES,
+    );
+    // Every route discovery answered with is available: the lanes decide which
+    // ones are saved, not a modality filter.
+    expect(routes.map((one) => one.connectionType)).toEqual([
+      "retell_text_mode",
+      "retell_web_call",
+      "phone_number",
+    ]);
+
+    expect(retellCandidateForLane(routes, "text")?.connectionType).toBe(
+      "retell_text_mode",
+    );
+    expect(retellCandidateForLane(routes, "web-call")?.connectionType).toBe(
+      "retell_web_call",
+    );
+    expect(retellCandidateForLane(routes, "phone")?.connectionType).toBe(
+      "phone_number",
+    );
+    // The phone lane is the one that needs saying which, because a voice agent
+    // can have several routed numbers.
+    expect(
+      retellCandidateForLane(
+        VOICE.connectionCandidates,
+        "phone",
+        "phone:+14155550101",
+      )?.config.phoneNumber,
+    ).toBe("+14155550101");
+  });
+
+  it("asks for a phone number only when the phone lane is picked", () => {
+    // A developer who picked only Text is never asked for a phone number.
+    expect(stepAfterRetellLanes(["text"])).toBeNull();
+    expect(stepAfterRetellLanes(["web-call"])).toBeNull();
+    expect(stepAfterRetellLanes(["text", "web-call"])).toBeNull();
+    expect(stepAfterRetellLanes(["phone"])).toBe("retell-phone");
+    expect(stepAfterRetellLanes(["text", "web-call", "phone"])).toBe(
+      "retell-phone",
+    );
+  });
+
+  it("defines the approved screen graph without putting screen order in provider payloads", () => {
+    expect(stepAfterPlatform("simulation", "retell")).toBe("retell-key");
+    expect(stepAfterPlatform("monitoring", "retell")).toBe("retell-key");
+    expect(stepAfterPlatform("simulation", "livekit")).toBe(
+      "livekit-language",
+    );
+    expect(stepAfterPlatform("both", "livekit")).toBe(
+      "livekit-monitoring",
+    );
+    expect(stepAfterPlatform("monitoring", "livekit")).toBe(
+      "livekit-monitoring",
+    );
+    // The one question leads for a simulation. Monitoring and Both go straight
+    // to the number chooser, which is the connection production pull needs —
+    // so a monitoring-goal web user never sees the test question.
+    expect(stepAfterRetellAgent(agentSetupPlan("simulation", "retell"))).toBe(
+      "retell-lanes",
+    );
+    expect(stepAfterRetellAgent(agentSetupPlan("monitoring", "retell"))).toBe(
+      "retell-phone",
+    );
+    expect(stepAfterRetellAgent(agentSetupPlan("both", "retell"))).toBe(
+      "retell-phone",
+    );
+
+    expect(previousAgentSetupStep({ step: "platform", goal: "both" })).toBe(
+      "goal",
+    );
+    expect(
+      previousAgentSetupStep({ step: "retell-agent", goal: "both" }),
+    ).toBe("retell-key");
+    // The one question goes back to the agent picker.
+    expect(
+      previousAgentSetupStep({ step: "retell-lanes", goal: "simulation" }),
+    ).toBe("retell-agent");
+    // The phone step goes back to the one question for a simulation, and to
+    // the agent picker for the goals that skip it.
+    expect(
+      previousAgentSetupStep({ step: "retell-phone", goal: "simulation" }),
+    ).toBe("retell-lanes");
+    expect(
+      previousAgentSetupStep({ step: "retell-phone", goal: "both" }),
+    ).toBe("retell-agent");
+    expect(
+      previousAgentSetupStep({ step: "livekit-monitoring", goal: "both" }),
+    ).toBe("platform");
+    expect(
+      previousAgentSetupStep({
+        step: "livekit-monitoring",
+        goal: "monitoring",
+      }),
+    ).toBe("platform");
+  });
+
+  /**
+   * Language is known before any LiveKit simulation connection is written.
+   * Both asks on Monitoring first, so JavaScript finishes without creating a
+   * connection that would falsely claim session-isolated testing.
+   */
+  it("captures the LiveKit language before simulation and never crosses a saved connection on Back", () => {
+    const simulation = agentSetupPlan("simulation", "livekit");
+    const both = agentSetupPlan("both", "livekit");
+
+    expect(stepAfterLiveKitCredentials(simulation)).toBe("livekit-testing");
+    expect(stepAfterLiveKitCredentials(both)).toBe("livekit-testing");
+    expect(stepAfterLiveKitTesting(simulation)).toBeNull();
+    expect(stepAfterLiveKitTesting(both)).toBeNull();
+
+    expect(
+      previousAgentSetupStep({ step: "livekit-modality", goal: "simulation" }),
+    ).toBe("livekit-language");
+    expect(
+      previousAgentSetupStep({ step: "livekit-language", goal: "simulation" }),
+    ).toBe("platform");
+    expect(
+      previousAgentSetupStep({ step: "livekit-modality", goal: "both" }),
+    ).toBe("livekit-monitoring");
+    expect(
+      previousAgentSetupStep({ step: "livekit-simulation", goal: "simulation" }),
+    ).toBe("livekit-modality");
+    expect(
+      previousAgentSetupStep({ step: "livekit-testing", goal: "both" }),
+    ).toBeNull();
+    expect(
+      previousAgentSetupStep({
+        step: "livekit-monitoring",
+        goal: "both",
+      }),
+    ).toBe("platform");
+  });
+});

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -2136,6 +2136,94 @@ describe("goal-first agent setup", () => {
     ).toHaveLength(1);
   });
 
+  it("starts pulling on a committed phone lane instead of adding the phone again", async () => {
+    routed.search = "?sheet=connect&agent=agt_1";
+    sheetAnswers({
+      "/v1/agents/agt_1": [
+        {
+          status: 200,
+          body: {
+            agent: {
+              ...AGENT,
+              platformAgentId: "agent_voice_1",
+            },
+            connections: [],
+          },
+        },
+        {
+          status: 200,
+          body: {
+            agent: {
+              ...AGENT,
+              platformAgentId: "agent_voice_1",
+              pullProductionCalls: false,
+            },
+            connections: [
+              {
+                ...MEASURED_CONNECTION,
+                agentId: "agt_1",
+                config: { phoneNumber: "+14155550100" },
+              },
+            ],
+          },
+        },
+      ],
+      "/v1/agents:discover": { status: 200, body: voiceWithTextMode },
+      "/v1/agents/agt_1/connections": {
+        status: 503,
+        body: {
+          error: "response_lost",
+          message: "The phone may have been saved. Try again.",
+        },
+      },
+      "/v1/monitoring/start": {
+        status: 200,
+        body: {
+          watching: [
+            {
+              agentId: "agt_1",
+              platformAgentId: "agent_voice_1",
+            },
+          ],
+          refused: [],
+        },
+      },
+    });
+    render(<AgentsPage />);
+    await choose("Set up both", "Retell");
+    await findRetellAgents();
+    await pickRetellAgent("Front desk");
+
+    fireEvent.click(screen.getByRole("button", { name: "Set up both" }));
+    expect(
+      await screen.findByText("The phone may have been saved. Try again."),
+    ).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "Set up both" }));
+    await waitFor(() => {
+      expect(routed.replace).toHaveBeenCalledWith("/projects/prj_1/agents");
+    });
+    expect(
+      sent.filter(
+        (call) => call.method === "POST" && call.url.includes("/connections"),
+      ),
+    ).toHaveLength(1);
+    expect(
+      sent.filter(
+        (call) =>
+          call.method === "POST" &&
+          call.url.startsWith("/v1/monitoring/start"),
+      ),
+    ).toHaveLength(1);
+    expect(
+      sent.find((call) => call.url.startsWith("/v1/monitoring/start"))?.body,
+    ).toEqual({
+      agentPlatform: "retell",
+      apiKey: "retell-secret-A1B2C3D4WXYZ",
+      watch: [{ agentId: "agt_1", platformAgentId: "agent_voice_1" }],
+    });
+  });
+
   it("takes a Simulation voice agent to the phone picker only when Phone call is picked", async () => {
     sheetAnswers({
       "/v1/agents:discover": { status: 200, body: voiceWithTextMode },

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -3120,6 +3120,9 @@ describe("goal-first agent setup", () => {
     expect(document.body.textContent).toContain(
       "await mockable(agent, ctx, session)",
     );
+    const leaving = new Event("beforeunload", { cancelable: true });
+    window.dispatchEvent(leaving);
+    expect(leaving.defaultPrevented).toBe(false);
     expect(screen.queryByText("Close", { selector: "button" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Back" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Return to agents" }));

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -1417,7 +1417,7 @@ describe("goal-first agent setup", () => {
     ).toBeDefined();
   });
 
-  it("honors the provider lane carried by a capability link", async () => {
+  it("uses an existing agent's saved provider when a copied link disagrees", async () => {
     routed.search =
       "?sheet=connect&agent=agt_1&goal=monitoring&platform=livekit";
     sheetAnswers({
@@ -1429,13 +1429,47 @@ describe("goal-first agent setup", () => {
     render(<AgentsPage />);
 
     expect(
-      await screen.findByRole("heading", {
+      await screen.findByLabelText("Retell API key*"),
+    ).toBeDefined();
+    expect(
+      screen.queryByRole("heading", {
         name: "Add monitoring to your LiveKit agent",
       }),
-    ).toBeDefined();
-    expect(screen.queryByText("LiveKit · Monitoring")).toBeNull();
-    expect(screen.queryByLabelText("Retell API key*")).toBeNull();
+    ).toBeNull();
   });
+
+  it.each([
+    ["Retell", "retell", "LiveKit"],
+    ["LiveKit", "livekit", "Retell"],
+  ] as const)(
+    "offers only %s when an existing agent chooses a setup goal",
+    async (shown, agentPlatform, hidden) => {
+      routed.search = "?sheet=connect&agent=agt_1";
+      sheetAnswers({
+        "/v1/agents/agt_1": {
+          status: 200,
+          body: {
+            agent: { ...AGENT, agentPlatform },
+            connections: [],
+          },
+        },
+      });
+      render(<AgentsPage />);
+
+      fireEvent.click(
+        await screen.findByRole("radio", { name: /^Run simulations/ }),
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+      expect(
+        await screen.findByRole("heading", {
+          name: "Choose your agent platform",
+        }),
+      ).toBeDefined();
+      expect(screen.getByRole("radio", { name: shown })).toBeDefined();
+      expect(screen.queryByRole("radio", { name: hidden })).toBeNull();
+    },
+  );
 
   it("waits for an existing agent's saved setup and retries a failed read", async () => {
     routed.search =
@@ -1927,6 +1961,27 @@ describe("goal-first agent setup", () => {
           },
         },
       ],
+      "/v1/agents/agt_multi": {
+        status: 200,
+        body: {
+          agent: {
+            ...AGENT,
+            id: "agt_multi",
+            platformAgentId: "agent_voice_1",
+          },
+          connections: [
+            {
+              ...CONNECTION,
+              id: "con_text",
+              agentId: "agt_multi",
+              connectionType: "retell_text_mode",
+              accessVariant: "retell_text_mode.api_key",
+              modality: "chat",
+              config: { retellAgentId: "agent_voice_1" },
+            },
+          ],
+        },
+      },
     });
     render(<RegisterAgentPage />);
     await choose("Run simulations", "Retell");
@@ -1973,6 +2028,112 @@ describe("goal-first agent setup", () => {
       ),
     ).toHaveLength(1);
     expect(routed.replace).toHaveBeenCalledWith("/projects/prj_1/agents");
+  });
+
+  it("reads back a committed Retell lane instead of duplicating it after a lost response", async () => {
+    sheetAnswers({
+      "/v1/connection-options": {
+        status: 200,
+        body: {
+          items: [
+            ...TYPES.items,
+            {
+              ...TYPES.items[1],
+              connectionType: "retell_web_call",
+              accessVariant: "retell_web_call.api_key",
+              modality: "voice",
+              productLabel: "Retell web call",
+            },
+          ],
+        },
+      },
+      "/v1/agents:discover": { status: 200, body: voiceWithTextMode },
+      "/v1/agents": [
+        { status: 200, body: { agents: [], nextPageToken: null } },
+        {
+          status: 201,
+          body: {
+            result: "created",
+            agent: {
+              ...AGENT,
+              id: "agt_lost_response",
+              name: "Front desk",
+              platformAgentId: "agent_voice_1",
+            },
+            connection: {
+              ...CONNECTION,
+              id: "con_text",
+              connectionType: "retell_text_mode",
+            },
+          },
+        },
+        { status: 200, body: { agents: [LISTED_AGENT], nextPageToken: null } },
+      ],
+      "/v1/agents/agt_lost_response/connections": {
+        status: 503,
+        body: {
+          error: "response_lost",
+          message: "The connection may have been saved. Try again.",
+        },
+      },
+      "/v1/agents/agt_lost_response": {
+        status: 200,
+        body: {
+          agent: {
+            ...AGENT,
+            id: "agt_lost_response",
+            platformAgentId: "agent_voice_1",
+          },
+          connections: [
+            {
+              ...CONNECTION,
+              id: "con_text",
+              agentId: "agt_lost_response",
+              connectionType: "retell_text_mode",
+              accessVariant: "retell_text_mode.api_key",
+              modality: "chat",
+              config: { retellAgentId: "agent_voice_1" },
+            },
+            {
+              ...CONNECTION,
+              id: "con_web_committed",
+              agentId: "agt_lost_response",
+              connectionType: "retell_web_call",
+              accessVariant: "retell_web_call.api_key",
+              modality: "voice",
+              config: { retellAgentId: "agent_voice_1" },
+            },
+          ],
+        },
+      },
+    });
+    render(<RegisterAgentPage />);
+    await choose("Run simulations", "Retell");
+    await findRetellAgents();
+    await pickRetellAgent("Front desk");
+
+    fireEvent.click(screen.getByLabelText("Text"));
+    fireEvent.click(screen.getByLabelText("Web call"));
+    fireEvent.click(screen.getByRole("button", { name: "Set up simulation" }));
+
+    expect(
+      await screen.findByText("The connection may have been saved. Try again."),
+    ).toBeDefined();
+    expect(
+      sent.filter(
+        (call) => call.method === "POST" && call.url.includes("/connections"),
+      ),
+    ).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Set up simulation" }));
+    await waitFor(() => {
+      expect(routed.replace).toHaveBeenCalledWith("/projects/prj_1/agents");
+    });
+    expect(
+      sent.filter(
+        (call) => call.method === "POST" && call.url.includes("/connections"),
+      ),
+    ).toHaveLength(1);
   });
 
   it("takes a Simulation voice agent to the phone picker only when Phone call is picked", async () => {

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -10,6 +10,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import ConnectionDetailPage from "../app/projects/[projectId]/agents/[agentId]/connections/[connectionId]/page.tsx";
+import NewConnectionPage from "../app/projects/[projectId]/agents/[agentId]/connections/new/page.tsx";
 import RegisterAgentPage from "../app/projects/[projectId]/agents/new/page.tsx";
 import AgentsPage from "../app/projects/[projectId]/agents/page.tsx";
 import type { Me } from "../lib/me.ts";
@@ -1031,190 +1032,1846 @@ describe("reading an agent's reach from the list", () => {
 /* ------------------------------------------------------------------------ */
 
 /**
- * Connecting now hands the full job to the coding agent in the repository.
+ * The artifact's goal-first setup flow, driven through the real sheet.
  *
- * The web surface makes no provider choice and performs no setup write. It
- * offers the three public outcomes as complete prompts and stays useful when
- * an old link carries one goal or platform in its query.
+ * The goal comes before the provider. Provider capability then decides what
+ * Egma can complete in the UI and what it must explain for the customer to do.
  */
-describe("coding-agent setup handoff", () => {
-  const handoff =
-    `Use ${window.location.origin} as the Egma platform URL. ` +
-    "Start by running `egma` if available or `npx --yes @egma/cli` otherwise. " +
-    "Follow the coding-agent handoff. Use existing credentials. " +
-    "Ask the developer only for browser authorization, a missing credential, " +
-    "a choice that cannot be safely inferred, an unsafe conflict, or approval " +
-    "before a real phone run that may cost money.";
-  const prompts = {
-    simulation:
-      "Set up Egma simulation testing for this repository's voice agent end to end. " +
-      handoff,
-    monitoring:
-      "Set up Egma production monitoring for this repository's voice agent end to end. " +
-      handoff,
-    both:
-      "Set up Egma simulation testing and production monitoring for this repository's voice agent end to end. " +
-      handoff,
-  } as const;
+describe("goal-first agent setup", () => {
+  const retellDiscovery = {
+    agents: [
+      {
+        platformAgentId: "agent_voice_1",
+        name: "Appointment line",
+        modality: "voice",
+        connectionCandidates: [
+          {
+            agentPlatform: "retell",
+            connectionType: "retell_text_mode",
+            accessVariant: "retell_text_mode.api_key",
+            modality: "chat",
+            productLabel: "Retell text mode",
+            config: { retellAgentId: "agent_voice_1" },
+          },
+          {
+            agentPlatform: "retell",
+            connectionType: "phone_number",
+            accessVariant: "phone_number.public_e164",
+            modality: "voice",
+            productLabel: "Retell phone",
+            config: { phoneNumber: "+14155550100" },
+          },
+          {
+            agentPlatform: "retell",
+            connectionType: "phone_number",
+            accessVariant: "phone_number.public_e164",
+            modality: "voice",
+            productLabel: "Retell phone",
+            config: { phoneNumber: "+14155550199" },
+          },
+        ],
+      },
+    ],
+  };
 
-  function handoffAnswers(role = "member"): void {
+  const liveKitAgent = {
+    ...AGENT,
+    id: "agt_livekit",
+    name: "LiveKit front desk",
+    agentPlatform: "livekit",
+  };
+
+  const liveKitConnection = {
+    ...LIVEKIT_CONNECTION,
+    id: "con_livekit",
+    agentId: "agt_livekit",
+  };
+
+  function sheetAnswers(
+    extra: Record<string, Stubbed | readonly Stubbed[]> = {},
+  ): void {
     apiAnswers({
-      "/api/me": { status: 200, body: meWith(role) },
+      "/api/me": { status: 200, body: meWith("member") },
+      "/v1/connection-options": { status: 200, body: TYPES },
+      "/v1/agents": {
+        status: 200,
+        body: { agents: [], nextPageToken: null },
+      },
+      ...extra,
+    });
+  }
+
+  async function choose(
+    goal: "Run simulations" | "Monitor production" | "Set up both",
+    platform: "Retell" | "LiveKit",
+  ): Promise<void> {
+    fireEvent.click(
+      await screen.findByRole("radio", { name: new RegExp(`^${goal}`) }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(
+      await screen.findByRole("heading", {
+        name: "Choose your agent platform",
+      }),
+    ).toBeDefined();
+    fireEvent.click(screen.getByRole("radio", { name: platform }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+  }
+
+  async function findRetellAgents(): Promise<void> {
+    fireEvent.change(await screen.findByLabelText("Retell API key*"), {
+      target: { value: "retell-secret-A1B2C3D4WXYZ" },
+    });
+    expect(
+      screen.queryByRole("radio", { name: /^Appointment line/ }),
+    ).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Find agents" }));
+    expect(
+      await screen.findByRole("heading", { name: "Choose a Retell agent" }),
+    ).toBeDefined();
+  }
+
+  async function pickRetellAgent(name: string): Promise<void> {
+    fireEvent.click(
+      await screen.findByRole("radio", { name: new RegExp(`^${name}`) }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+  }
+
+  /** Choose the supported testing language, then the simulation modality. */
+  async function chooseLiveKitModality(name: "Chat" | "Voice"): Promise<void> {
+    expect(
+      await screen.findByRole("heading", {
+        name: "What language is your LiveKit worker?",
+      }),
+    ).toBeDefined();
+    fireEvent.click(screen.getByRole("radio", { name: /^Python/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(
+      await screen.findByRole("heading", {
+        name: "How do you want to test this agent?",
+      }),
+    ).toBeDefined();
+    fireEvent.click(screen.getByRole("radio", { name: new RegExp(`^${name}`) }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+  }
+
+  async function fillLiveKitSimulation(): Promise<void> {
+    expect(
+      await screen.findByRole("heading", {
+        name: "Connect LiveKit Voice for simulations",
+      }),
+    ).toBeDefined();
+    const connectionType = screen.getByRole("combobox", {
+      name: "Connection type*",
+    }) as HTMLSelectElement;
+    expect(connectionType.value).toBe("livekit_room.project_credentials");
+    expect(connectionType.getAttribute("aria-required")).toBe("true");
+    expect(
+      Array.from(connectionType.options).map((option) => option.text),
+    ).toEqual(["Project credentials", "Token endpoint"]);
+    expect(
+      screen.getByPlaceholderText("your-livekit-agent-name"),
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        "Enter the exact agent name shown in your LiveKit Cloud dashboard.",
+      ),
+    ).toBeDefined();
+    expect(
+      screen.getByPlaceholderText("wss://your-project.livekit.cloud"),
+    ).toBeDefined();
+    fireEvent.change(await screen.findByLabelText("LiveKit agent name*"), {
+      target: { value: "front-desk" },
+    });
+    fireEvent.change(screen.getByLabelText("WebSocket URL*"), {
+      target: { value: "wss://rooms.example.test" },
+    });
+    fireEvent.change(screen.getByLabelText("API key*"), {
+      target: { value: "livekit-key" },
+    });
+    fireEvent.change(screen.getByLabelText("API secret*"), {
+      target: { value: "livekit-secret" },
+    });
+  }
+
+  it("asks for the goal first, then offers Retell before LiveKit", async () => {
+    sheetAnswers();
+    render(<RegisterAgentPage />);
+
+    expect(
+      await screen.findByText("What do you want Egma to do?"),
+    ).toBeDefined();
+    expect(screen.queryByText("Setup · Goal")).toBeNull();
+    expect(
+      screen.getAllByRole("radio").map((choice) => choice.textContent),
+    ).toEqual([
+      "Run simulationsTest how the agent responds before production.",
+      "Monitor productionMonitor an agent in production",
+      "Set up bothConfigure an agent for both testing and monitoring",
+    ]);
+    expect(
+      screen.queryByRole("heading", { name: "Choose your agent platform" }),
+    ).toBeNull();
+    expect(screen.queryByLabelText("Retell API key*")).toBeNull();
+
+    const submit = screen.getByRole("button", { name: "Continue" });
+    expect((submit as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(
+      screen.getByRole("radio", { name: /^Run simulations/ }),
+    );
+    expect(
+      screen.queryByRole("heading", { name: "Choose your agent platform" }),
+    ).toBeNull();
+    fireEvent.click(submit);
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Choose your agent platform",
+      }),
+    ).toBeDefined();
+    expect(screen.queryByText("Setup · Platform")).toBeNull();
+    expect(screen.getAllByRole("radio").map((one) => one.textContent)).toEqual([
+      "Retell",
+      "LiveKit",
+    ]);
+    for (const provider of screen.getAllByRole("radio")) {
+      expect(provider.className).toContain("min-h-(--control-lg)");
+      expect(provider.className).not.toContain("min-h-[92px]");
+    }
+    expect(screen.queryByLabelText("Retell API key*")).toBeNull();
+    expect(screen.queryByLabelText("WebSocket URL*")).toBeNull();
+
+    fireEvent.click(screen.getByRole("radio", { name: "Retell" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(await screen.findByLabelText("Retell API key*")).toBeDefined();
+    expect(screen.queryByText("Retell · Connection")).toBeNull();
+    expect(screen.queryByText("Your key stays private.")).toBeNull();
+    expect(screen.queryByText(/Egma stores it securely/)).toBeNull();
+    expect(screen.queryByLabelText("WebSocket URL*")).toBeNull();
+  });
+
+  it("shows a Retell provider refusal and retries discovery without clearing the key", async () => {
+    const apiKey = "retell-provider-key-A1B2C3D4";
+    const providerMessage =
+      "Retell could not list phone numbers while its service was unavailable.";
+    const returnedAgentId = "agent_returned_after_retry";
+    const returnedAgentName = "Provider-returned appointment desk";
+    sheetAnswers({
+      "/v1/agents:discover": [
+        {
+          status: 503,
+          body: {
+            error: "provider_unavailable",
+            message: providerMessage,
+          },
+        },
+        {
+          status: 200,
+          body: {
+            agents: [
+              {
+                platformAgentId: returnedAgentId,
+                name: returnedAgentName,
+                modality: "voice",
+                connectionCandidates: [
+                  {
+                    agentPlatform: "retell",
+                    connectionType: "phone_number",
+                    accessVariant: "phone_number.public_e164",
+                    modality: "voice",
+                    productLabel: "Retell phone",
+                    config: { phoneNumber: "+14155550987" },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    });
+    render(<RegisterAgentPage />);
+    await choose("Run simulations", "Retell");
+
+    const key = await screen.findByLabelText("Retell API key*");
+    fireEvent.change(key, { target: { value: apiKey } });
+    fireEvent.click(screen.getByRole("button", { name: "Find agents" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toBe(providerMessage);
+    expect((key as HTMLInputElement).value).toBe(apiKey);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Find agents" }),
+    );
+    expect(
+      await screen.findByRole("radio", {
+        name: new RegExp(`^${returnedAgentName}`),
+      }),
+    ).toBeDefined();
+
+    const attempts = sent.filter((call) =>
+      call.url.startsWith("/v1/agents:discover"),
+    );
+    expect(attempts).toHaveLength(2);
+    expect(attempts.map((call) => call.url)).toEqual([
+      "/v1/agents:discover?projectId=prj_1",
+      "/v1/agents:discover?projectId=prj_1",
+    ]);
+    expect(attempts.map((call) => call.body)).toEqual([
+      {
+        agentPlatform: "retell",
+        credentials: { apiKey },
+      },
+      {
+        agentPlatform: "retell",
+        credentials: { apiKey },
+      },
+    ]);
+  });
+
+  it("protects a credential draft from Close, Escape, and Cancel", async () => {
+    sheetAnswers();
+    render(<RegisterAgentPage />);
+    await choose("Run simulations", "Retell");
+    fireEvent.change(await screen.findByLabelText("Retell API key*"), {
+      target: { value: "retell-secret-A1B2C3D4WXYZ" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    let warning = await screen.findByRole("dialog", {
+      name: "Leave without saving?",
+    });
+    fireEvent.click(within(warning).getByRole("button", { name: "Keep editing" }));
+    expect(await screen.findByLabelText("Retell API key*")).toBeDefined();
+
+    fireEvent.keyDown(
+      screen.getByRole("dialog", { name: "Set up an agent" }),
+      { key: "Escape" },
+    );
+    warning = await screen.findByRole("dialog", {
+      name: "Leave without saving?",
+    });
+    fireEvent.click(within(warning).getByRole("button", { name: "Keep editing" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    warning = await screen.findByRole("dialog", {
+      name: "Leave without saving?",
+    });
+    fireEvent.click(
+      within(warning).getByRole("button", { name: "Discard changes" }),
+    );
+
+    expect(routed.replace).toHaveBeenCalledWith("/projects/prj_1/agents");
+  });
+
+  it("moves radio focus with the goal selection", async () => {
+    sheetAnswers();
+    render(<RegisterAgentPage />);
+
+    const simulation = await screen.findByRole("radio", {
+      name: /^Run simulations/,
+    });
+    simulation.focus();
+    fireEvent.keyDown(simulation, { key: "ArrowRight" });
+
+    const monitoring = screen.getByRole("radio", { name: /^Monitor production/ });
+    await waitFor(() => expect(document.activeElement).toBe(monitoring));
+    expect(monitoring.getAttribute("aria-checked")).toBe("true");
+
+    fireEvent.keyDown(monitoring, { key: "End" });
+    const both = screen.getByRole("radio", { name: /^Set up both/ });
+    await waitFor(() => expect(document.activeElement).toBe(both));
+    expect(both.getAttribute("aria-checked")).toBe("true");
+
+    fireEvent.keyDown(both, { key: "Home" });
+    await waitFor(() => expect(document.activeElement).toBe(simulation));
+    expect(simulation.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("opens with Monitoring selected when another page states that goal", async () => {
+    routed.search = "?sheet=connect&goal=monitoring";
+    sheetAnswers();
+    render(<AgentsPage />);
+
+    const monitoring = await screen.findByRole("radio", {
+      name: /^Monitor production/,
+    });
+    expect(monitoring.getAttribute("aria-checked")).toBe("true");
+    expect(
+      screen.getByText(
+        "Production monitoring is selected because you started from Traces. You can still change the goal.",
+      ),
+    ).toBeDefined();
+    expect(
+      screen.queryByRole("heading", { name: "Choose your agent platform" }),
+    ).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(
+      await screen.findByRole("heading", {
+        name: "Choose your agent platform",
+      }),
+    ).toBeDefined();
+  });
+
+  it("honors the provider lane carried by a capability link", async () => {
+    routed.search =
+      "?sheet=connect&agent=agt_1&goal=monitoring&platform=livekit";
+    sheetAnswers({
+      "/v1/agents/agt_1": {
+        status: 200,
+        body: { agent: AGENT, connections: [] },
+      },
+    });
+    render(<AgentsPage />);
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Add monitoring to your LiveKit agent",
+      }),
+    ).toBeDefined();
+    expect(screen.queryByText("LiveKit · Monitoring")).toBeNull();
+    expect(screen.queryByLabelText("Retell API key*")).toBeNull();
+  });
+
+  it("waits for an existing agent's saved setup and retries a failed read", async () => {
+    routed.search =
+      "?sheet=connect&agent=agt_1&goal=monitoring&platform=retell";
+    sheetAnswers({
+      "/v1/agents/agt_1": [
+        {
+          status: 503,
+          body: {
+            error: "provider_unavailable",
+            message: "Egma could not read this agent. Try again.",
+          },
+        },
+        {
+          status: 200,
+          body: {
+            agent: {
+              ...AGENT,
+              monitoringKeyPresent: true,
+              monitoringApiKeyHint: "WXYZ",
+            },
+            connections: [],
+          },
+        },
+      ],
+    });
+    render(<AgentsPage />);
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Egma could not load this agent's saved setup.",
+      }),
+    ).toBeDefined();
+    expect(screen.queryByLabelText("Retell API key*")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(
+      await screen.findByText(/already holds its Retell key \(ending WXYZ\)/),
+    ).toBeDefined();
+    expect(screen.queryByLabelText("Retell API key*")).toBeNull();
+  });
+
+  it.each([
+    ["Monitoring", "monitoring", "Start monitoring"],
+    ["Both", "both", "Set up both"],
+  ] as const)("resumes Retell %s repeatedly without adding a connection", async (
+    _label,
+    goal,
+    action,
+  ) => {
+    routed.search =
+      `?sheet=connect&agent=agt_1&goal=${goal}&platform=retell`;
+    sheetAnswers({
+      "/v1/agents/agt_1": {
+        status: 200,
+        body: {
+          agent: {
+            ...AGENT,
+            platformAgentId: "agent_voice_1",
+            monitoringKeyPresent: true,
+            monitoringApiKeyHint: "WXYZ",
+            monitoringConfigured: true,
+            pullProductionCalls: false,
+          },
+          connections: [MEASURED_CONNECTION],
+        },
+      },
+      "/v1/agents:discover": { status: 200, body: retellDiscovery },
+      "/v1/monitoring/start": {
+        status: 200,
+        body: {
+          watching: [
+            {
+              agentId: "agt_1",
+              agentName: "Front desk",
+              platformAgentId: "agent_voice_1",
+              created: false,
+              pullProductionCalls: true,
+            },
+          ],
+          refused: [],
+        },
+      },
+    });
+    render(<AgentsPage />);
+
+    expect(
+      await screen.findByText(/already holds its Retell key \(ending WXYZ\)/),
+    ).toBeDefined();
+    expect(screen.queryByLabelText("Retell API key*")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Find agents" }));
+    expect(
+      await screen.findByRole("heading", { name: "Choose a Retell agent" }),
+    ).toBeDefined();
+    await pickRetellAgent("Appointment line");
+
+    expect(await screen.findByLabelText("Phone number*")).toBeDefined();
+    const start = screen.getByRole("button", { name: action });
+    for (let turn = 1; turn <= 2; turn += 1) {
+      fireEvent.click(start);
+      await waitFor(() => {
+        expect(
+          sent.filter((call) =>
+            call.url.startsWith("/v1/monitoring/start"),
+          ),
+        ).toHaveLength(turn);
+      });
+    }
+
+    const discovery = sent.find((call) =>
+      call.url.startsWith("/v1/agents:discover"),
+    );
+    expect(discovery?.body).toEqual({
+      agentPlatform: "retell",
+      agentId: "agt_1",
+    });
+    for (const resumed of sent.filter((call) =>
+      call.url.startsWith("/v1/monitoring/start"),
+    )) {
+      expect(resumed.body).toEqual({
+        agentPlatform: "retell",
+        watch: [
+          { agentId: "agt_1", platformAgentId: "agent_voice_1" },
+        ],
+      });
+    }
+    expect(
+      sent.some((call) =>
+        call.url.startsWith("/v1/agents/agt_1/connections"),
+      ),
+    ).toBe(false);
+  });
+
+  it("lists every voice agent, keeps a no-phone agent usable for simulations, and counts only phones", async () => {
+    // Egma registers Retell **voice** agents, so a chat-native agent is never
+    // in the picker: no lane reaches one.
+    const voiceAgents = Array.from({ length: 12 }, (_, index) => ({
+      platformAgentId: `agent_voice_${index + 1}`,
+      name: `Voice agent ${index + 1}`,
+      modality: "voice" as const,
+      connectionCandidates: [
+        {
+          agentPlatform: "retell" as const,
+          connectionType: "retell_text_mode" as const,
+          accessVariant: "retell_text_mode.api_key" as const,
+          modality: "chat" as const,
+          productLabel: "Retell text mode",
+          config: { retellAgentId: `agent_voice_${index + 1}` },
+        },
+        {
+          agentPlatform: "retell" as const,
+          connectionType: "retell_web_call" as const,
+          accessVariant: "retell_web_call.api_key" as const,
+          modality: "voice" as const,
+          productLabel: "Retell web call",
+          config: { retellAgentId: `agent_voice_${index + 1}` },
+        },
+        {
+          agentPlatform: "retell" as const,
+          connectionType: "phone_number" as const,
+          accessVariant: "phone_number.public_e164" as const,
+          modality: "voice" as const,
+          productLabel: "Retell phone",
+          config: { phoneNumber: `+1415555010${index}` },
+        },
+      ],
+    }));
+    sheetAnswers({
+      "/v1/agents:discover": {
+        status: 200,
+        body: {
+          agents: [
+            ...voiceAgents,
+            {
+              platformAgentId: "agent_chat_1",
+              name: "Chat agent 1",
+              modality: "chat",
+              connectionCandidates: [],
+            },
+            {
+              platformAgentId: "agent_voice_unrouted",
+              name: "Voice without a number",
+              modality: "voice",
+              connectionCandidates: [
+                {
+                  agentPlatform: "retell",
+                  connectionType: "retell_text_mode",
+                  accessVariant: "retell_text_mode.api_key",
+                  modality: "chat",
+                  productLabel: "Retell text mode",
+                  config: { retellAgentId: "agent_voice_unrouted" },
+                },
+                {
+                  agentPlatform: "retell",
+                  connectionType: "retell_web_call",
+                  accessVariant: "retell_web_call.api_key",
+                  modality: "voice",
+                  productLabel: "Retell web call",
+                  config: { retellAgentId: "agent_voice_unrouted" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    render(<RegisterAgentPage />);
+
+    await choose("Run simulations", "Retell");
+    await findRetellAgents();
+
+    expect(screen.getAllByRole("radio")).toHaveLength(13);
+    expect(
+      screen.getByRole("radio", {
+        name: /^Voice agent 12.*1 phone number available/,
+      }),
+    ).toBeDefined();
+    expect(screen.queryByRole("radio", { name: /^Chat agent 1/ })).toBeNull();
+    const unrouted = screen.getByRole("radio", {
+      name: /Voice without a number.*no phone numbers available/,
+    }) as HTMLButtonElement;
+    expect(unrouted.disabled).toBe(false);
+  });
+
+  it("disables a no-phone Retell agent when production monitoring needs a phone", async () => {
+    sheetAnswers({
+      "/v1/agents:discover": {
+        status: 200,
+        body: {
+          agents: [
+            {
+              platformAgentId: "agent_voice_unrouted",
+              name: "Voice without a number",
+              modality: "voice",
+              connectionCandidates: [
+                {
+                  agentPlatform: "retell",
+                  connectionType: "retell_text_mode",
+                  accessVariant: "retell_text_mode.api_key",
+                  modality: "chat",
+                  productLabel: "Retell text mode",
+                  config: { retellAgentId: "agent_voice_unrouted" },
+                },
+                {
+                  agentPlatform: "retell",
+                  connectionType: "retell_web_call",
+                  accessVariant: "retell_web_call.api_key",
+                  modality: "voice",
+                  productLabel: "Retell web call",
+                  config: { retellAgentId: "agent_voice_unrouted" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    render(<RegisterAgentPage />);
+
+    await choose("Monitor production", "Retell");
+    await findRetellAgents();
+
+    const unrouted = screen.getByRole("radio", {
+      name: /Voice without a number.*no phone numbers available/,
+    }) as HTMLButtonElement;
+    expect(unrouted.disabled).toBe(true);
+  });
+
+  it("asks one question, and a Text-only pick mints text mode and asks for no number", async () => {
+    sheetAnswers({
+      "/v1/agents:discover": { status: 200, body: retellDiscovery },
+      "/v1/agents": [
+        { status: 200, body: { agents: [], nextPageToken: null } },
+        {
+          status: 201,
+          body: {
+            result: "created",
+            agent: {
+              ...AGENT,
+              name: "Appointment line",
+              platformAgentId: "agent_voice_1",
+            },
+            connection: { ...CONNECTION, connectionType: "retell_text_mode" },
+          },
+        },
+        { status: 200, body: { agents: [LISTED_AGENT], nextPageToken: null } },
+      ],
+    });
+    render(<RegisterAgentPage />);
+    await choose("Run simulations", "Retell");
+
+    expect(screen.queryByLabelText("LiveKit agent name*")).toBeNull();
+    await findRetellAgents();
+    await pickRetellAgent("Appointment line");
+
+    // The one question leads, before any plumbing.
+    expect(
+      await screen.findByRole("heading", {
+        name: "How should Egma test this agent?",
+      }),
+    ).toBeDefined();
+    expect(screen.queryByLabelText("Phone number*")).toBeNull();
+
+    // Three lanes, each with its own help line.
+    expect(screen.getByText("Text")).toBeDefined();
+    expect(screen.getByText("Web call")).toBeDefined();
+    expect(screen.getByText("Phone call")).toBeDefined();
+
+    fireEvent.click(screen.getByLabelText("Text"));
+    const connect = screen.getByRole("button", { name: "Set up simulation" });
+    expect(connect.closest("[data-slot=sheet-footer]")).not.toBeNull();
+    fireEvent.click(connect);
+
+    await waitFor(() => {
+      expect(
+        sent.some((call) => call.url === "/v1/agents?projectId=prj_1"),
+      ).toBe(true);
+    });
+    const registration = sent.find(
+      (call) => call.url === "/v1/agents?projectId=prj_1",
+    );
+    // Text mints text mode against the voice agent it conducts in text — and
+    // the phone-number chooser never appeared, because Phone was not picked.
+    expect(registration?.body).toEqual({
+      name: "Appointment line",
+      agentPlatform: "retell",
+      connection: {
+        agentPlatform: "retell",
+        connectionType: "retell_text_mode",
+        accessVariant: "retell_text_mode.api_key",
+        modality: "chat",
+        config: { retellAgentId: "agent_voice_1" },
+        platformAgentId: "agent_voice_1",
+        credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+      },
+    });
+  });
+
+  /** A voice agent as discovery now describes one, text mode door and all. */
+  const voiceWithTextMode = {
+    agents: [
+      {
+        platformAgentId: "agent_voice_1",
+        name: "Front desk",
+        modality: "voice",
+        connectionCandidates: [
+          {
+            agentPlatform: "retell",
+            connectionType: "retell_text_mode",
+            accessVariant: "retell_text_mode.api_key",
+            modality: "chat",
+            productLabel: "Retell text mode",
+            config: { retellAgentId: "agent_voice_1" },
+          },
+          {
+            agentPlatform: "retell",
+            connectionType: "retell_web_call",
+            accessVariant: "retell_web_call.api_key",
+            modality: "voice",
+            productLabel: "Retell web call",
+            config: { retellAgentId: "agent_voice_1" },
+          },
+          {
+            agentPlatform: "retell",
+            connectionType: "phone_number",
+            accessVariant: "phone_number.public_e164",
+            modality: "voice",
+            productLabel: "Retell phone",
+            config: { phoneNumber: "+14155550100" },
+          },
+        ],
+      },
+    ],
+  };
+
+  it("leads a Simulation voice agent with the one question, and Text mints text mode", async () => {
+    sheetAnswers({
+      "/v1/agents:discover": { status: 200, body: voiceWithTextMode },
+      "/v1/agents": [
+        { status: 200, body: { agents: [], nextPageToken: null } },
+        {
+          status: 201,
+          body: {
+            result: "created",
+            agent: { ...AGENT, name: "Front desk", platformAgentId: "agent_voice_1" },
+            connection: { ...CONNECTION, connectionType: "retell_text_mode" },
+          },
+        },
+        { status: 200, body: { agents: [LISTED_AGENT], nextPageToken: null } },
+      ],
+    });
+    render(<RegisterAgentPage />);
+    await choose("Run simulations", "Retell");
+    await findRetellAgents();
+    await pickRetellAgent("Front desk");
+
+    // The one question leads, before any plumbing. A phone picker is not on
+    // screen yet, and it never will be for a pick that leaves Phone out.
+    expect(
+      await screen.findByRole("heading", {
+        name: "How should Egma test this agent?",
+      }),
+    ).toBeDefined();
+    expect(screen.queryByLabelText("Phone number*")).toBeNull();
+
+    fireEvent.click(screen.getByLabelText("Text"));
+    fireEvent.click(screen.getByRole("button", { name: "Set up simulation" }));
+
+    await waitFor(() => {
+      expect(
+        sent.some((call) => call.url === "/v1/agents?projectId=prj_1"),
+      ).toBe(true);
+    });
+    const registration = sent.find(
+      (call) => call.url === "/v1/agents?projectId=prj_1",
+    );
+    // Choosing text mints text mode with the same key, against the voice
+    // agent it conducts in text.
+    expect(registration?.body).toEqual({
+      name: "Front desk",
+      agentPlatform: "retell",
+      connection: {
+        agentPlatform: "retell",
+        connectionType: "retell_text_mode",
+        accessVariant: "retell_text_mode.api_key",
+        modality: "chat",
+        config: { retellAgentId: "agent_voice_1" },
+        platformAgentId: "agent_voice_1",
+        credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+      },
+    });
+  });
+
+  it("retries only the unsaved Retell lanes after a partial provider failure", async () => {
+    sheetAnswers({
+      "/v1/connection-options": {
+        status: 200,
+        body: {
+          items: [
+            ...TYPES.items,
+            {
+              ...TYPES.items[1],
+              connectionType: "retell_web_call",
+              accessVariant: "retell_web_call.api_key",
+              modality: "voice",
+              productLabel: "Retell web call",
+            },
+          ],
+        },
+      },
+      "/v1/agents:discover": { status: 200, body: voiceWithTextMode },
+      "/v1/agents": [
+        { status: 200, body: { agents: [], nextPageToken: null } },
+        {
+          status: 201,
+          body: {
+            result: "created",
+            agent: {
+              ...AGENT,
+              id: "agt_multi",
+              name: "Front desk",
+              platformAgentId: "agent_voice_1",
+            },
+            connection: {
+              ...CONNECTION,
+              id: "con_text",
+              connectionType: "retell_text_mode",
+            },
+          },
+        },
+        { status: 200, body: { agents: [LISTED_AGENT], nextPageToken: null } },
+      ],
+      "/v1/agents/agt_multi/connections": [
+        {
+          status: 503,
+          body: {
+            error: "provider_unavailable",
+            message: "Retell did not save the web call. Try again.",
+          },
+        },
+        {
+          status: 201,
+          body: {
+            connection: {
+              ...CONNECTION,
+              id: "con_web",
+              connectionType: "retell_web_call",
+            },
+          },
+        },
+      ],
+    });
+    render(<RegisterAgentPage />);
+    await choose("Run simulations", "Retell");
+    await findRetellAgents();
+    await pickRetellAgent("Front desk");
+
+    fireEvent.click(screen.getByLabelText("Text"));
+    fireEvent.click(screen.getByLabelText("Web call"));
+    fireEvent.click(screen.getByRole("button", { name: "Set up simulation" }));
+
+    expect(
+      await screen.findByText(/Egma saved 1 of 2 connections/),
+    ).toBeDefined();
+    expect((screen.getByLabelText("Text") as HTMLInputElement).disabled).toBe(
+      true,
+    );
+    expect(
+      (screen.getByLabelText("Web call") as HTMLInputElement).disabled,
+    ).toBe(true);
+    expect(screen.getByText("Close", { selector: "button" })).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Back" })).toBeNull();
+    expect(
+      await screen.findByText("Retell did not save the web call. Try again."),
+    ).toBeDefined();
+    expect(
+      sent.filter(
+        (call) => call.method === "POST" && call.url.includes("/connections"),
+      ),
+    ).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Set up simulation" }));
+    await waitFor(() => {
+      expect(
+        sent.filter(
+          (call) => call.method === "POST" && call.url.includes("/connections"),
+        ),
+      ).toHaveLength(2);
+    });
+    expect(
+      sent.filter(
+        (call) =>
+          call.method === "POST" &&
+          call.url === "/v1/agents?projectId=prj_1",
+      ),
+    ).toHaveLength(1);
+    expect(routed.replace).toHaveBeenCalledWith("/projects/prj_1/agents");
+  });
+
+  it("takes a Simulation voice agent to the phone picker only when Phone call is picked", async () => {
+    sheetAnswers({
+      "/v1/agents:discover": { status: 200, body: voiceWithTextMode },
+      "/v1/agents": [
+        { status: 200, body: { agents: [], nextPageToken: null } },
+        {
+          status: 201,
+          body: {
+            result: "created",
+            agent: { ...AGENT, name: "Front desk", platformAgentId: "agent_voice_1" },
+            connection: MEASURED_CONNECTION,
+          },
+        },
+        { status: 200, body: { agents: [LISTED_AGENT], nextPageToken: null } },
+      ],
+    });
+    render(<RegisterAgentPage />);
+    await choose("Run simulations", "Retell");
+    await findRetellAgents();
+    await pickRetellAgent("Front desk");
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "How should Egma test this agent?",
+      }),
+    ).toBeDefined();
+    fireEvent.click(screen.getByLabelText("Phone call"));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    // The phone chooser, which only the phone lane leads into.
+    const numbers = (await screen.findByLabelText(
+      "Phone number*",
+    )) as HTMLSelectElement;
+    // Discovery offers this voice agent a web-call candidate too, but it
+    // carries no number, so it stays out of the phone chooser rather than
+    // sitting in it as a blank option and, by sorting first, becoming the
+    // step's default. It is picked by its own tick in the one question.
+    expect([...numbers.options].map((one) => one.value)).toEqual([
+      "phone:+14155550100",
+    ]);
+    expect(numbers.value).toBe("phone:+14155550100");
+  });
+
+  it("uses one Retell key for Both and stores the selected voice route", async () => {
+    sheetAnswers({
+      "/v1/agents:discover": { status: 200, body: retellDiscovery },
+      "/v1/agents": [
+        { status: 200, body: { agents: [], nextPageToken: null } },
+        {
+          status: 201,
+          body: {
+            result: "created",
+            agent: {
+              ...AGENT,
+              name: "Appointment line",
+              platformAgentId: "agent_voice_1",
+              monitoringKeyPresent: true,
+              monitoringApiKeyHint: "WXYZ",
+              pullProductionCalls: true,
+            },
+            connection: MEASURED_CONNECTION,
+          },
+        },
+        { status: 200, body: { agents: [LISTED_AGENT], nextPageToken: null } },
+      ],
+    });
+    render(<RegisterAgentPage />);
+    await choose("Set up both", "Retell");
+    await findRetellAgents();
+    expect(screen.getByRole("radio", { name: /^Appointment line/ })).toBeDefined();
+    await pickRetellAgent("Appointment line");
+
+    const numbers = screen.getByLabelText(
+      "Phone number*",
+    ) as HTMLSelectElement;
+    expect([...numbers.options].map((one) => one.textContent)).toEqual([
+      "+14155550100",
+      "+14155550199",
+    ]);
+    fireEvent.change(numbers, { target: { value: "phone:+14155550199" } });
+    expect(screen.queryByLabelText("Retell API key*")).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Set up both",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        sent.some((call) => call.url === "/v1/agents?projectId=prj_1"),
+      ).toBe(true);
+    });
+    const registration = sent.find(
+      (call) => call.url === "/v1/agents?projectId=prj_1",
+    );
+    expect(registration?.body).toMatchObject({
+      name: "Appointment line",
+      agentPlatform: "retell",
+      connection: {
+        connectionType: "phone_number",
+        modality: "voice",
+        config: { phoneNumber: "+14155550199" },
+        platformAgentId: "agent_voice_1",
+        credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+        pullProductionCalls: true,
+      },
+    });
+    expect(
+      sent.filter((call) => call.url.startsWith("/v1/agents:discover")),
+    ).toHaveLength(1);
+    expect(
+      sent.some((call) => call.url.startsWith("/v1/monitoring/start")),
+    ).toBe(false);
+  });
+
+  it("never sees the test question when Monitoring is the goal", async () => {
+    // A monitoring-goal user skips the question, as before: production pull
+    // needs the voice connection and nothing else, so asking "text, web call
+    // or phone?" would be a question whose answer it cannot use.
+    sheetAnswers({
+      "/v1/agents:discover": { status: 200, body: retellDiscovery },
+    });
+    render(<RegisterAgentPage />);
+    await choose("Monitor production", "Retell");
+    await findRetellAgents();
+    await pickRetellAgent("Appointment line");
+
+    expect(await screen.findByLabelText("Phone number*")).toBeDefined();
+    expect(
+      screen.queryByRole("heading", {
+        name: "How should Egma test this agent?",
+      }),
+    ).toBeNull();
+  });
+
+  it("stores the selected Retell route and starts pulling when Monitoring is the goal", async () => {
+    sheetAnswers({
+      "/v1/agents:discover": { status: 200, body: retellDiscovery },
+      "/v1/agents": [
+        { status: 200, body: { agents: [], nextPageToken: null } },
+        {
+          status: 201,
+          body: {
+            result: "created",
+            agent: {
+              ...AGENT,
+              name: "Appointment line",
+              platformAgentId: "agent_voice_1",
+              monitoringKeyPresent: true,
+              monitoringApiKeyHint: "WXYZ",
+              pullProductionCalls: true,
+            },
+            connection: MEASURED_CONNECTION,
+          },
+        },
+        { status: 200, body: { agents: [LISTED_AGENT], nextPageToken: null } },
+      ],
+    });
+    render(<RegisterAgentPage />);
+    await choose("Monitor production", "Retell");
+    await findRetellAgents();
+    await pickRetellAgent("Appointment line");
+    expect(await screen.findByLabelText("Phone number*")).toBeDefined();
+
+    const start = screen.getByRole("button", { name: "Start monitoring" });
+    await waitFor(() => {
+      expect((start as HTMLButtonElement).disabled).toBe(false);
+    });
+    fireEvent.click(start);
+
+    await waitFor(() => {
+      expect(
+        sent.some((call) => call.url === "/v1/agents?projectId=prj_1"),
+      ).toBe(true);
+    });
+    const registration = sent.find(
+      (call) => call.url === "/v1/agents?projectId=prj_1",
+    );
+    expect(registration?.body).toEqual({
+      name: "Appointment line",
+      agentPlatform: "retell",
+      connection: {
+        agentPlatform: "retell",
+        connectionType: "phone_number",
+        accessVariant: "phone_number.public_e164",
+        modality: "voice",
+        config: { phoneNumber: "+14155550100" },
+        platformAgentId: "agent_voice_1",
+        credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+        pullProductionCalls: true,
+      },
+    });
+    expect(
+      sent.some((call) => call.url.startsWith("/v1/monitoring/start")),
+    ).toBe(false);
+  });
+
+  it("creates the LiveKit room connection, then shows the testing hook", async () => {
+    sheetAnswers({
+      "/v1/agents": [
+        { status: 200, body: { agents: [], nextPageToken: null } },
+        {
+          status: 201,
+          body: {
+            result: "created",
+            agent: liveKitAgent,
+            connection: liveKitConnection,
+          },
+        },
+        {
+          status: 200,
+          body: {
+            agents: [
+              { ...liveKitAgent, connections: [liveKitConnection] },
+            ],
+            nextPageToken: null,
+          },
+        },
+      ],
+    });
+    render(<RegisterAgentPage />);
+    await choose("Run simulations", "LiveKit");
+    await chooseLiveKitModality("Voice");
+    await fillLiveKitSimulation();
+
+    expect(
+      screen.queryByRole("heading", {
+        name: "Add monitoring to your LiveKit agent",
+      }),
+    ).toBeNull();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue to testing" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        sent.some((call) => call.url === "/v1/agents?projectId=prj_1"),
+      ).toBe(true);
+    });
+    expect(
+      await screen.findByRole("heading", {
+        name: "Add simulation testing to your LiveKit agent",
+      }),
+    ).toBeDefined();
+    expect(document.body.textContent).toContain(
+      "await mockable(agent, ctx, session)",
+    );
+    expect(screen.queryByRole("button", { name: "Back" })).toBeNull();
+    expect(routed.replace).not.toHaveBeenCalled();
+
+    const registration = sent.find(
+      (call) => call.url === "/v1/agents?projectId=prj_1",
+    );
+    expect(registration?.body).toEqual({
+      name: "front-desk",
+      agentPlatform: "livekit",
+      connection: {
+        agentPlatform: "livekit",
+        connectionType: "livekit_room",
+        accessVariant: "livekit_room.project_credentials",
+        modality: "voice",
+        config: {
+          url: "wss://rooms.example.test",
+          agentName: "front-desk",
+        },
+        credentials: {
+          apiKey: "livekit-key",
+          apiSecret: "livekit-secret",
+        },
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Return to agents" }));
+    expect(routed.replace).toHaveBeenCalledWith("/projects/prj_1/agents");
+  });
+
+  /**
+   * The choice a person understands comes before the plumbing it settles.
+   *
+   * Chat and voice are two different things to test, and which one this is
+   * decides what the credential screen may even offer — so a credential box on
+   * screen before the question has been answered would be asking for the
+   * wrong values half the time.
+   */
+  it("asks for the LiveKit worker language and modality before any credential box", async () => {
+    sheetAnswers();
+    render(<RegisterAgentPage />);
+    await choose("Run simulations", "LiveKit");
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "What language is your LiveKit worker?",
+      }),
+    ).toBeDefined();
+    expect(screen.getByRole("radio", { name: /^Python/ })).toBeDefined();
+    expect(screen.getByRole("radio", { name: /^JavaScript/ })).toBeDefined();
+    expect(screen.queryByLabelText("LiveKit agent name*")).toBeNull();
+
+    fireEvent.click(screen.getByRole("radio", { name: /^Python/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(
+      await screen.findByRole("heading", {
+        name: "How do you want to test this agent?",
+      }),
+    ).toBeDefined();
+    expect(
+      screen.getAllByRole("radio").map((choice) => choice.textContent),
+    ).toEqual([
+      expect.stringContaining("Voice"),
+      expect.stringContaining("Chat"),
+    ]);
+    expect(screen.queryByLabelText("LiveKit agent name*")).toBeNull();
+    expect(screen.queryByLabelText("WebSocket URL*")).toBeNull();
+    expect(screen.queryByLabelText("API key*")).toBeNull();
+    expect(
+      screen.queryByRole("combobox", { name: "Connection type*" }),
+    ).toBeNull();
+    expect(sent).toEqual([]);
+  });
+
+  it("does not create a simulation connection for a JavaScript LiveKit worker", async () => {
+    sheetAnswers();
+    render(<RegisterAgentPage />);
+    await choose("Run simulations", "LiveKit");
+
+    fireEvent.click(
+      await screen.findByRole("radio", { name: /^JavaScript/ }),
+    );
+
+    expect(document.body.textContent).toContain(
+      "Egma cannot set up JavaScript testing yet",
+    );
+    expect(document.body.textContent).toContain(
+      "cannot isolate each test run from other LiveKit sessions",
+    );
+    expect(
+      screen.getByRole("button", { name: "Return to agents" }),
+    ).toBeDefined();
+    expect(screen.queryByLabelText("LiveKit agent name*")).toBeNull();
+    expect(sent).toEqual([]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Return to agents" }));
+    expect(routed.replace).toHaveBeenCalledWith("/projects/prj_1/agents");
+    expect(sent).toEqual([]);
+  });
+
+  it("saves a LiveKit chat connection and offers no way in but project credentials", async () => {
+    sheetAnswers({
+      "/v1/agents": [
+        { status: 200, body: { agents: [], nextPageToken: null } },
+        {
+          status: 201,
+          body: {
+            result: "created",
+            agent: liveKitAgent,
+            connection: {
+              ...liveKitConnection,
+              modality: "chat",
+              productLabel: "LiveKit chat",
+            },
+          },
+        },
+        {
+          status: 200,
+          body: {
+            agents: [{ ...liveKitAgent, connections: [liveKitConnection] }],
+            nextPageToken: null,
+          },
+        },
+      ],
+    });
+    render(<RegisterAgentPage />);
+    await choose("Run simulations", "LiveKit");
+    await chooseLiveKitModality("Chat");
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Connect LiveKit Chat for simulations",
+      }),
+    ).toBeDefined();
+    // Egma has to dispatch the worker to tell it the simulation is typed, so
+    // there is one way in and nothing that pretends otherwise.
+    expect(
+      screen.queryByRole("combobox", { name: "Connection type*" }),
+    ).toBeNull();
+    expect(screen.queryByText("Token endpoint")).toBeNull();
+    expect(screen.queryByLabelText("Token endpoint*")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("LiveKit agent name*"), {
+      target: { value: "front-desk" },
+    });
+    fireEvent.change(screen.getByLabelText("WebSocket URL*"), {
+      target: { value: "wss://rooms.example.test" },
+    });
+    fireEvent.change(screen.getByLabelText("API key*"), {
+      target: { value: "livekit-key" },
+    });
+    fireEvent.change(screen.getByLabelText("API secret*"), {
+      target: { value: "livekit-secret" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue to testing" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        sent.some((call) => call.url === "/v1/agents?projectId=prj_1"),
+      ).toBe(true);
+    });
+    const registration = sent.find(
+      (call) => call.url === "/v1/agents?projectId=prj_1",
+    );
+    expect(registration?.body).toEqual({
+      name: "front-desk",
+      agentPlatform: "livekit",
+      connection: {
+        agentPlatform: "livekit",
+        connectionType: "livekit_room",
+        accessVariant: "livekit_room.project_credentials",
+        modality: "chat",
+        config: {
+          url: "wss://rooms.example.test",
+          agentName: "front-desk",
+        },
+        credentials: {
+          apiKey: "livekit-key",
+          apiSecret: "livekit-secret",
+        },
+      },
+    });
+    expect(
+      await screen.findByRole("heading", {
+        name: "Add simulation testing to your LiveKit agent",
+      }),
+    ).toBeDefined();
+    expect(document.body.textContent).toContain(
+      "await mockable(agent, ctx, session)",
+    );
+
+    // The setup Egma cannot perform, handed over after the connection exists.
+    expect(
+      await screen.findByRole("heading", {
+        name: "Add simulation testing to your LiveKit agent",
+      }),
+    ).toBeDefined();
+    expect(
+      screen.getAllByRole("button", { name: /^Copy / }),
+    ).toHaveLength(3);
+    const shown = document.body.textContent ?? "";
+    expect(shown).toContain(
+      'chat = ctx.job.room.name.startswith("egma-sim-chat-")',
+    );
+    expect(shown).toContain("TextOutputOptions(sync_transcription=False)");
+    expect(shown).not.toMatch(/chat (is )?(ready|configured|on)\b/i);
+    expect(shown).not.toContain("Verified");
+  });
+
+  /**
+   * The second modality on an agent Egma already holds.
+   *
+   * One vendor agent is one Egma agent, so the chat run and the voice run of
+   * the same test suite can be read side by side. A second registration here
+   * would split that history in half.
+   */
+  it("adds chat to an agent that already exists instead of minting a twin", async () => {
+    routed.search =
+      "?sheet=connect&agent=agt_livekit&goal=simulation&platform=livekit";
+    sheetAnswers({
+      "/v1/agents/agt_livekit": {
+        status: 200,
+        body: { agent: liveKitAgent, connections: [liveKitConnection] },
+      },
+      "/v1/agents/agt_livekit/connections": {
+        status: 201,
+        body: {
+          connection: {
+            ...liveKitConnection,
+            id: "con_livekit_chat",
+            modality: "chat",
+            productLabel: "LiveKit chat",
+          },
+        },
+      },
+    });
+    render(<AgentsPage />);
+
+    await chooseLiveKitModality("Chat");
+    fireEvent.change(await screen.findByLabelText("LiveKit agent name*"), {
+      target: { value: "front-desk" },
+    });
+    fireEvent.change(screen.getByLabelText("WebSocket URL*"), {
+      target: { value: "wss://rooms.example.test" },
+    });
+    fireEvent.change(screen.getByLabelText("API key*"), {
+      target: { value: "livekit-key" },
+    });
+    fireEvent.change(screen.getByLabelText("API secret*"), {
+      target: { value: "livekit-secret" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue to testing" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        sent.some((call) =>
+          call.url.startsWith("/v1/agents/agt_livekit/connections"),
+        ),
+      ).toBe(true);
+    });
+    expect(
+      sent.some((call) => call.url === "/v1/agents?projectId=prj_1"),
+    ).toBe(false);
+    const added = sent.find((call) =>
+      call.url.startsWith("/v1/agents/agt_livekit/connections"),
+    );
+    expect(added?.body).toEqual({
+      agentPlatform: "livekit",
+      connectionType: "livekit_room",
+      accessVariant: "livekit_room.project_credentials",
+      modality: "chat",
+      config: {
+        url: "wss://rooms.example.test",
+        agentName: "front-desk",
+      },
+      credentials: {
+        apiKey: "livekit-key",
+        apiSecret: "livekit-secret",
+      },
+    });
+    expect(
+      await screen.findByRole("heading", {
+        name: "Add simulation testing to your LiveKit agent",
+      }),
+    ).toBeDefined();
+  });
+
+  it("stores a LiveKit token endpoint without asking for the project secret", async () => {
+    sheetAnswers({
+      "/v1/agents": [
+        { status: 200, body: { agents: [], nextPageToken: null } },
+        {
+          status: 201,
+          body: {
+            result: "created",
+            agent: liveKitAgent,
+            connection: {
+              ...liveKitConnection,
+              accessVariant: "livekit_room.customer_token_endpoint",
+              productLabel: "LiveKit token endpoint",
+              config: {
+                url: "wss://rooms.example.test",
+                tokenEndpoint: "https://tokens.example.test/livekit",
+              },
+            },
+          },
+        },
+        {
+          status: 200,
+          body: {
+            agents: [
+              { ...liveKitAgent, connections: [liveKitConnection] },
+            ],
+            nextPageToken: null,
+          },
+        },
+      ],
+    });
+    render(<RegisterAgentPage />);
+    await choose("Run simulations", "LiveKit");
+    await chooseLiveKitModality("Voice");
+
+    fireEvent.change(
+      await screen.findByRole("combobox", { name: "Connection type*" }),
+      { target: { value: "livekit_room.customer_token_endpoint" } },
+    );
+    expect(
+      await screen.findByRole("heading", {
+        name: "Connect LiveKit Voice for simulations",
+      }),
+    ).toBeDefined();
+    expect(screen.getByLabelText("LiveKit agent name*")).toBeDefined();
+    expect(
+      screen.getByText(
+        "This names the agent in Egma. Your token endpoint decides which deployed worker joins the room.",
+      ),
+    ).toBeDefined();
+    expect(screen.queryByLabelText("API secret*")).toBeNull();
+    expect(
+      screen.getByPlaceholderText("wss://your-project.livekit.cloud"),
+    ).toBeDefined();
+    expect(
+      screen.getByPlaceholderText("https://api.example.com/livekit/token"),
+    ).toBeDefined();
+    expect(
+      screen.getByPlaceholderText('{"Authorization":"Bearer your-token"}'),
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        "Enter a non-empty JSON object that maps each header name to a non-empty string value.",
+      ),
+    ).toBeDefined();
+
+    fireEvent.change(screen.getByLabelText("WebSocket URL*"), {
+      target: { value: "wss://rooms.example.test" },
+    });
+    fireEvent.change(screen.getByLabelText("LiveKit agent name*"), {
+      target: { value: "appointment-scheduling-langsmith" },
+    });
+    fireEvent.change(screen.getByLabelText("Token endpoint*"), {
+      target: { value: "https://tokens.example.test/livekit" },
+    });
+    fireEvent.change(screen.getByLabelText("Auth headers*"), {
+      target: { value: '{"Authorization":"Bearer token"}' },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue to testing" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        sent.some((call) => call.url === "/v1/agents?projectId=prj_1"),
+      ).toBe(true);
+    });
+    const registration = sent.find(
+      (call) => call.url === "/v1/agents?projectId=prj_1",
+    );
+    expect(registration?.body).toEqual({
+      name: "appointment-scheduling-langsmith",
+      agentPlatform: "livekit",
+      connection: {
+        agentPlatform: "livekit",
+        connectionType: "livekit_room",
+        accessVariant: "livekit_room.customer_token_endpoint",
+        modality: "voice",
+        config: {
+          url: "wss://rooms.example.test",
+          tokenEndpoint: "https://tokens.example.test/livekit",
+        },
+        credentials: {
+          headers: '{"Authorization":"Bearer token"}',
+        },
+      },
+    });
+    expect(
+      await screen.findByRole("heading", {
+        name: "Add simulation testing to your LiveKit agent",
+      }),
+    ).toBeDefined();
+  });
+
+  it("shows only LiveKit Monitoring instructions and performs no write", async () => {
+    sheetAnswers();
+    render(<RegisterAgentPage />);
+    await choose("Monitor production", "LiveKit");
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Add monitoring to your LiveKit agent",
+      }),
+    ).toBeDefined();
+    expect(
+      screen.getByText("What language is your LiveKit worker?"),
+    ).toBeDefined();
+    expect(document.body.textContent).not.toContain("monitor_livekit(ctx)");
+    expect(
+      (screen.getByRole("button", {
+        name: "Return to agents",
+      }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Python" }));
+
+    const copy = document.body.textContent ?? "";
+    expect(copy).toContain("monitor_livekit(ctx)");
+    expect(copy.indexOf("monitor_livekit(ctx)")).toBeLessThan(
+      copy.indexOf("await ctx.connect()"),
+    );
+    expect(copy).toContain("await session.start(...)");
+    expect(copy).toContain("await ctx.connect()");
+    expect(copy).toContain("EGMA_URL=<your-public-egma-url>");
+    expect(copy).not.toContain("localhost");
+    expect(copy).toContain("EGMA_API_KEY=<your-project-api-key>");
+    expect(
+      screen.getByRole("link", { name: "API keys" }).getAttribute("href"),
+    ).toBe("/projects/prj_1/settings/keys");
+    expect(screen.queryByLabelText("Agent*")).toBeNull();
+    expect(screen.queryByLabelText("LiveKit agent name*")).toBeNull();
+    expect(screen.queryByLabelText("WebSocket URL*")).toBeNull();
+    expect(
+      screen.queryByText(/Enter the exact LiveKit agent name/),
+    ).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Return to agents" }),
+    ).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Save agent" })).toBeNull();
+    expect(sent).toEqual([]);
+  });
+
+  it("captures Python Monitoring first for Both, then sets up Simulation", async () => {
+    sheetAnswers({
+      "/v1/agents": [
+        { status: 200, body: { agents: [], nextPageToken: null } },
+        {
+          status: 201,
+          body: {
+            result: "created",
+            agent: liveKitAgent,
+            connection: liveKitConnection,
+          },
+        },
+      ],
+    });
+    render(<RegisterAgentPage />);
+    await choose("Set up both", "LiveKit");
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Add monitoring to your LiveKit agent",
+      }),
+    ).toBeDefined();
+    expect(document.body.textContent).not.toContain("monitor_livekit(ctx)");
+    fireEvent.click(screen.getByRole("tab", { name: "Python" }));
+    expect(document.body.textContent).toContain("monitor_livekit(ctx)");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue to simulation" }),
+    );
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "How do you want to test this agent?",
+      }),
+    ).toBeDefined();
+    fireEvent.click(screen.getByRole("radio", { name: /^Voice/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    await fillLiveKitSimulation();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue to testing" }),
+    );
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Add simulation testing to your LiveKit agent",
+      }),
+    ).toBeDefined();
+    expect(document.body.textContent).toContain(
+      "await mockable(agent, ctx, session)",
+    );
+    expect(screen.queryByText("Close", { selector: "button" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Back" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Return to agents" }));
+    expect(routed.replace).toHaveBeenCalledWith("/projects/prj_1/agents");
+    expect(
+      sent.some((call) => call.url.startsWith("/v1/monitoring/")),
+    ).toBe(false);
+  });
+
+  it("finishes JavaScript Monitoring for Both and leaves Testing unsupported", async () => {
+    sheetAnswers();
+    render(<RegisterAgentPage />);
+    await choose("Set up both", "LiveKit");
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Add monitoring to your LiveKit agent",
+      }),
+    ).toBeDefined();
+    expect(screen.queryByText("Install the Egma SDK")).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: "JavaScript" }));
+
+    const shown = document.body.textContent ?? "";
+    expect(shown).toContain("npm install @egma/livekit");
+    expect(shown).toContain("monitorLiveKit(ctx)");
+    expect(shown).toContain("Monitoring is supported for JavaScript");
+    expect(shown).toContain("Testing remains unsupported");
+    expect(
+      screen.getByRole("button", { name: "Finish monitoring" }),
+    ).toBeDefined();
+    expect(screen.queryByLabelText("LiveKit agent name*")).toBeNull();
+    expect(sent).toEqual([]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish monitoring" }));
+    expect(routed.replace).toHaveBeenCalledWith("/projects/prj_1/agents");
+    expect(sent).toEqual([]);
+  });
+
+  it("protects a Python LiveKit draft after going back and choosing JavaScript", async () => {
+    sheetAnswers();
+    render(<RegisterAgentPage />);
+    await choose("Set up both", "LiveKit");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Python" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue to simulation" }),
+    );
+    fireEvent.click(screen.getByRole("radio", { name: /^Voice/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    await fillLiveKitSimulation();
+
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    fireEvent.click(screen.getByRole("tab", { name: "JavaScript" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Finish monitoring" }),
+    );
+
+    const warning = await screen.findByRole("dialog", {
+      name: "Leave without saving?",
+    });
+    fireEvent.click(
+      within(warning).getByRole("button", { name: "Keep editing" }),
+    );
+    expect(
+      screen.getByRole("button", { name: "Finish monitoring" }),
+    ).toBeDefined();
+    expect(routed.replace).not.toHaveBeenCalled();
+    expect(sent).toEqual([]);
+  });
+
+  it("draws no setup form until it knows the person's role", async () => {
+    sheetAnswers();
+    render(<RegisterAgentPage />);
+
+    expect(
+      screen.getByRole("heading", { name: "Set up an agent" }),
+    ).toBeDefined();
+    expect(
+      screen.queryByText("What do you want Egma to do?"),
+    ).toBeNull();
+    expect(screen.queryByLabelText("Retell API key*")).toBeNull();
+    expect(screen.getAllByRole("button", { name: "Close" })).toHaveLength(2);
+
+    expect(
+      await screen.findByText("What do you want Egma to do?"),
+    ).toBeDefined();
+  });
+
+  it("explains that a viewer cannot use the setup flow", async () => {
+    apiAnswers({
+      "/api/me": { status: 200, body: meWith("viewer") },
+      "/v1/connection-options": { status: 200, body: TYPES },
       "/v1/agents": {
         status: 200,
         body: { agents: [], nextPageToken: null },
       },
     });
-  }
-
-  function requestedPaths(): readonly string[] {
-    return vi
-      .mocked(globalThis.fetch)
-      .mock.calls.map(([input]) => requestUrl(input as FetchInput));
-  }
-
-  it("keeps all three prompts visible when an old link carries one goal and platform", async () => {
-    routed.search =
-      "?sheet=connect&agent=agt_not_on_page&goal=monitoring&platform=livekit";
-    handoffAnswers();
-    render(<AgentsPage />);
-
-    const sheet = within(
-      await screen.findByRole("dialog", { name: "Connect an agent" }),
-    );
-
-    expect(
-      sheet
-        .getAllByRole("heading", { level: 3 })
-        .map((heading) => heading.textContent),
-    ).toEqual(["Simulation", "Monitoring", "Both"]);
-    expect(sheet.getByText(prompts.simulation)).toBeDefined();
-    expect(sheet.getByText(prompts.monitoring)).toBeDefined();
-    expect(sheet.getByText(prompts.both)).toBeDefined();
-    expect(
-      sheet.getAllByRole("button", { name: /^Copy .* prompt$/ }).map(
-        (button) => button.getAttribute("aria-label"),
-      ),
-    ).toEqual([
-      "Copy simulation prompt",
-      "Copy monitoring prompt",
-      "Copy both prompt",
-    ]);
-
-    expect(sheet.queryByRole("radio")).toBeNull();
-    expect(sheet.queryByRole("combobox")).toBeNull();
-    expect(sheet.queryByRole("textbox")).toBeNull();
-    expect(sheet.queryByRole("button", { name: "Continue" })).toBeNull();
-    expect(sheet.queryByText("Retell")).toBeNull();
-    expect(sheet.queryByText("LiveKit")).toBeNull();
-    expect(sheet.queryByText(/API key/u)).toBeNull();
-    expect(sheet.queryByText(/Press Enter/u)).toBeNull();
-
-    await waitFor(() =>
-      expect(requestedPaths()).toContain("/v1/agents?projectId=prj_1"),
-    );
-    expect(
-      requestedPaths().some(
-        (path) =>
-          path.includes("connection-options") ||
-          path.includes(":discover") ||
-          path.includes("/monitoring/") ||
-          path.includes("/v1/agents/agt_not_on_page"),
-      ),
-    ).toBe(false);
-    expect(sent).toEqual([]);
-  });
-
-  it("copies the exact prompt for each outcome and announces success", async () => {
-    const writeText = vi.fn(async (_value: string) => undefined);
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: { writeText },
-    });
-    handoffAnswers();
     render(<RegisterAgentPage />);
 
-    const sheet = within(
-      await screen.findByRole("dialog", { name: "Connect an agent" }),
-    );
-    const cases = [
-      ["simulation", prompts.simulation],
-      ["monitoring", prompts.monitoring],
-      ["both", prompts.both],
-    ] as const;
-
-    for (const [outcome, prompt] of cases) {
-      fireEvent.click(
-        sheet.getByRole("button", { name: `Copy ${outcome} prompt` }),
-      );
-      await waitFor(() => expect(writeText).toHaveBeenCalledWith(prompt));
-      expect(
-        sheet.getByRole("button", {
-          name: `${outcome.charAt(0).toUpperCase() + outcome.slice(1)} prompt copied`,
-        }),
-      ).toBeDefined();
-      expect(
-        sheet.getByText(
-          `${outcome.charAt(0).toUpperCase() + outcome.slice(1)} prompt copied.`,
-        ),
-      ).toBeDefined();
-    }
-
-    expect(writeText.mock.calls.map(([value]) => value)).toEqual([
-      prompts.simulation,
-      prompts.monitoring,
-      prompts.both,
-    ]);
-    expect(sent).toEqual([]);
-  });
-
-  it("keeps the prompt visible and announces a clipboard failure", async () => {
-    const writeText = vi.fn(async () => {
-      throw new Error("Clipboard permission was denied.");
-    });
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: { writeText },
-    });
-    handoffAnswers();
-    render(<RegisterAgentPage />);
-
-    const sheet = within(
-      await screen.findByRole("dialog", { name: "Connect an agent" }),
-    );
-    fireEvent.click(
-      sheet.getByRole("button", { name: "Copy monitoring prompt" }),
-    );
-
-    expect((await sheet.findByRole("alert")).textContent).toBe(
-      "Could not copy the monitoring prompt. Select the text and copy it manually.",
-    );
     expect(
-      sheet.getByRole("button", {
-        name: "Try to copy monitoring prompt again",
-      }),
-    ).toBeDefined();
-    expect(sheet.getByText(prompts.monitoring)).toBeDefined();
-    expect(sent).toEqual([]);
-  });
-
-  it("refuses a viewer who opens the setup URL directly", async () => {
-    routed.pathname = "/projects/prj_1/agents/new";
-    handoffAnswers("viewer");
-    render(<RegisterAgentPage />);
-
-    const sheet = within(
-      await screen.findByRole("dialog", { name: "Connect an agent" }),
-    );
-    expect(
-      sheet.getByText(
+      await screen.findByText(
         "Your viewer role cannot connect agents. Ask an organization admin to change your role, then try again.",
       ),
     ).toBeDefined();
+    expect(screen.queryByRole("radio")).toBeNull();
     expect(
-      sheet.queryByRole("button", { name: /^Copy .* prompt$/ }),
+      screen.queryByRole("button", { name: "Continue" }),
     ).toBeNull();
-    expect(sent).toEqual([]);
+    expect(screen.getAllByRole("button", { name: "Close" })).toHaveLength(2);
+  });
+
+  it("offers a retry when Egma cannot load the connection catalog", async () => {
+    sheetAnswers({
+      "/v1/connection-options": [
+        {
+          status: 500,
+          body: { error: "unreadable_answer", message: "Egma could not answer." },
+        },
+        { status: 200, body: TYPES },
+      ],
+    });
+    render(<RegisterAgentPage />);
+    await choose("Run simulations", "LiveKit");
+    fireEvent.click(
+      await screen.findByRole("radio", { name: /^Python/ }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(
+      await screen.findByText("Egma could not describe the connection options."),
+    ).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    // The modality choices are the catalog's, so this screen waits for it too.
+    expect(
+      await screen.findByRole("heading", {
+        name: "How do you want to test this agent?",
+      }),
+    ).toBeDefined();
+    fireEvent.click(screen.getByRole("radio", { name: /^Voice/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(
+      await screen.findByRole("heading", {
+        name: "Connect LiveKit Voice for simulations",
+      }),
+    ).toBeDefined();
+    expect(screen.getByLabelText("LiveKit agent name*")).toBeDefined();
   });
 });
 

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -2136,37 +2136,42 @@ describe("goal-first agent setup", () => {
     ).toHaveLength(1);
   });
 
-  it("starts pulling on a committed phone lane instead of adding the phone again", async () => {
+  it("keeps a committed phone lane through Close and resumes monitoring after reopen", async () => {
     routed.search = "?sheet=connect&agent=agt_1";
+    const emptyAgent = {
+      status: 200,
+      body: {
+        agent: {
+          ...AGENT,
+          platformAgentId: "agent_voice_1",
+        },
+        connections: [],
+      },
+    };
+    const committedAgent = {
+      status: 200,
+      body: {
+        agent: {
+          ...AGENT,
+          platformAgentId: "agent_voice_1",
+          pullProductionCalls: false,
+        },
+        connections: [
+          {
+            ...MEASURED_CONNECTION,
+            agentId: "agt_1",
+            config: { phoneNumber: "+14155550100" },
+          },
+        ],
+      },
+    };
     sheetAnswers({
       "/v1/agents/agt_1": [
-        {
-          status: 200,
-          body: {
-            agent: {
-              ...AGENT,
-              platformAgentId: "agent_voice_1",
-            },
-            connections: [],
-          },
-        },
-        {
-          status: 200,
-          body: {
-            agent: {
-              ...AGENT,
-              platformAgentId: "agent_voice_1",
-              pullProductionCalls: false,
-            },
-            connections: [
-              {
-                ...MEASURED_CONNECTION,
-                agentId: "agt_1",
-                config: { phoneNumber: "+14155550100" },
-              },
-            ],
-          },
-        },
+        emptyAgent,
+        emptyAgent,
+        committedAgent,
+        committedAgent,
+        committedAgent,
       ],
       "/v1/agents:discover": { status: 200, body: voiceWithTextMode },
       "/v1/agents/agt_1/connections": {
@@ -2176,20 +2181,29 @@ describe("goal-first agent setup", () => {
           message: "The phone may have been saved. Try again.",
         },
       },
-      "/v1/monitoring/start": {
-        status: 200,
-        body: {
-          watching: [
-            {
-              agentId: "agt_1",
-              platformAgentId: "agent_voice_1",
-            },
-          ],
-          refused: [],
+      "/v1/monitoring/start": [
+        {
+          status: 503,
+          body: {
+            error: "provider_unavailable",
+            message: "Monitoring did not start. Try again.",
+          },
         },
-      },
+        {
+          status: 200,
+          body: {
+            watching: [
+              {
+                agentId: "agt_1",
+                platformAgentId: "agent_voice_1",
+              },
+            ],
+            refused: [],
+          },
+        },
+      ],
     });
-    render(<AgentsPage />);
+    const firstOpen = render(<AgentsPage />);
     await choose("Set up both", "Retell");
     await findRetellAgents();
     await pickRetellAgent("Front desk");
@@ -2199,6 +2213,36 @@ describe("goal-first agent setup", () => {
       await screen.findByText("The phone may have been saved. Try again."),
     ).toBeDefined();
 
+    fireEvent.click(screen.getByRole("button", { name: "Set up both" }));
+    expect(
+      await screen.findByText("Monitoring did not start. Try again."),
+    ).toBeDefined();
+
+    const close = screen.getAllByRole("button", { name: "Close" }).at(-1);
+    if (close === undefined) {
+      throw new Error("the setup sheet has no close button");
+    }
+    fireEvent.click(close);
+    const warning = await screen.findByRole("dialog", {
+      name: "Leave without saving?",
+    });
+    fireEvent.click(
+      within(warning).getByRole("button", { name: "Discard changes" }),
+    );
+    await waitFor(() => {
+      expect(routed.replace).toHaveBeenCalledWith("/projects/prj_1/agents");
+    });
+    routed.search = "";
+    firstOpen.rerender(<AgentsPage />);
+    expect(
+      await screen.findByText("No agents in this project yet"),
+    ).toBeDefined();
+    routed.search = "?sheet=connect";
+    firstOpen.rerender(<AgentsPage />);
+
+    await choose("Set up both", "Retell");
+    await findRetellAgents();
+    await pickRetellAgent("Front desk");
     fireEvent.click(screen.getByRole("button", { name: "Set up both" }));
     await waitFor(() => {
       expect(routed.replace).toHaveBeenCalledWith("/projects/prj_1/agents");
@@ -2214,14 +2258,117 @@ describe("goal-first agent setup", () => {
           call.method === "POST" &&
           call.url.startsWith("/v1/monitoring/start"),
       ),
+    ).toHaveLength(2);
+    for (const start of sent.filter((call) =>
+      call.url.startsWith("/v1/monitoring/start"),
+    )) {
+      expect(start.body).toEqual({
+        agentPlatform: "retell",
+        apiKey: "retell-secret-A1B2C3D4WXYZ",
+        watch: [{ agentId: "agt_1", platformAgentId: "agent_voice_1" }],
+      });
+    }
+  });
+
+  it("recovers a new agent's committed phone from the refreshed list after Close", async () => {
+    routed.search = "?sheet=connect";
+    const recoveredAgent = {
+      ...AGENT,
+      id: "agt_recovered",
+      platformAgentId: "agent_voice_1",
+      connections: [
+        {
+          ...MEASURED_CONNECTION,
+          agentId: "agt_recovered",
+          config: { phoneNumber: "+14155550100" },
+        },
+      ],
+    };
+    sheetAnswers({
+      "/v1/agents": [
+        { status: 200, body: { agents: [], nextPageToken: null } },
+        {
+          status: 503,
+          body: {
+            error: "response_lost",
+            message: "The phone may have been saved. Try again.",
+          },
+        },
+        {
+          status: 200,
+          body: { agents: [], nextPageToken: null },
+        },
+        {
+          status: 200,
+          body: { agents: [recoveredAgent], nextPageToken: null },
+        },
+      ],
+      "/v1/agents:discover": { status: 200, body: voiceWithTextMode },
+      "/v1/agents/agt_recovered": {
+        status: 200,
+        body: {
+          agent: recoveredAgent,
+          connections: recoveredAgent.connections,
+        },
+      },
+      "/v1/monitoring/start": {
+        status: 200,
+        body: {
+          watching: [
+            {
+              agentId: "agt_recovered",
+              platformAgentId: "agent_voice_1",
+            },
+          ],
+          refused: [],
+        },
+      },
+    });
+    const firstOpen = render(<AgentsPage />);
+    await choose("Set up both", "Retell");
+    await findRetellAgents();
+    await pickRetellAgent("Front desk");
+
+    fireEvent.click(screen.getByRole("button", { name: "Set up both" }));
+    expect(
+      await screen.findByText("The phone may have been saved. Try again."),
+    ).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    const warning = await screen.findByRole("dialog", {
+      name: "Leave without saving?",
+    });
+    fireEvent.click(
+      within(warning).getByRole("button", { name: "Discard changes" }),
+    );
+    await waitFor(() => {
+      expect(routed.replace).toHaveBeenCalledWith("/projects/prj_1/agents");
+    });
+    routed.search = "";
+    firstOpen.rerender(<AgentsPage />);
+    expect(
+      await screen.findByText("No agents in this project yet"),
+    ).toBeDefined();
+    routed.search = "?sheet=connect";
+    firstOpen.rerender(<AgentsPage />);
+
+    await choose("Set up both", "Retell");
+    await findRetellAgents();
+    await pickRetellAgent("Front desk");
+    fireEvent.click(screen.getByRole("button", { name: "Set up both" }));
+    await waitFor(() => {
+      expect(routed.replace).toHaveBeenCalledWith("/projects/prj_1/agents");
+    });
+
+    expect(
+      sent.filter(
+        (call) => call.method === "POST" && call.url.startsWith("/v1/agents?"),
+      ),
     ).toHaveLength(1);
     expect(
-      sent.find((call) => call.url.startsWith("/v1/monitoring/start"))?.body,
-    ).toEqual({
-      agentPlatform: "retell",
-      apiKey: "retell-secret-A1B2C3D4WXYZ",
-      watch: [{ agentId: "agt_1", platformAgentId: "agent_voice_1" }],
-    });
+      sent.filter((call) =>
+        call.url.startsWith("/v1/monitoring/start"),
+      ),
+    ).toHaveLength(1);
   });
 
   it("takes a Simulation voice agent to the phone picker only when Phone call is picked", async () => {

--- a/apps/web/test/livekit-chat-instructions.test.tsx
+++ b/apps/web/test/livekit-chat-instructions.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CHAT_SETUP_PROMPT,
+  CHAT_SETUP_SNIPPET,
+  LiveKitTestingInstructions,
+  TESTING_SETUP_INSTALL,
+  VOICE_SETUP_PROMPT,
+  VOICE_SETUP_SNIPPET,
+} from "../app/projects/[projectId]/agents/livekit-testing-instructions.tsx";
+
+/**
+ * The code root, read off the runner rather than off this file's own URL.
+ *
+ * A jsdom test's `import.meta.url` is an `http:` address, which
+ * `fileURLToPath` refuses; Vitest still runs from the repository root, so that
+ * is what names the path here.
+ */
+const CODE_ROOT = process.cwd();
+
+afterEach(() => {
+  cleanup();
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: undefined,
+  });
+});
+
+describe("LiveKit testing instructions", () => {
+  it("hands over the complete chat setup and claims nothing about it", () => {
+    const { container } = render(
+      <LiveKitTestingInstructions modality="chat" />,
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Add simulation testing to your LiveKit agent",
+      }),
+    ).toBeTruthy();
+    expect(screen.getByText("Give this to your coding agent")).toBeTruthy();
+    expect(
+      screen.getByText("Install the latest Egma SDK"),
+    ).toBeTruthy();
+    expect(screen.getByText("Apply the Python testing contract")).toBeTruthy();
+    expect(screen.getAllByRole("button", { name: /^Copy / })).toHaveLength(3);
+
+    const copy = container.textContent ?? "";
+    expect(copy).toContain(
+      'chat = ctx.job.room.name.startswith("egma-sim-chat-")',
+    );
+    expect(copy).toContain("audio_input=False");
+    expect(copy).toContain("TextOutputOptions(sync_transcription=False)");
+    expect(copy).toContain("from egma import mockable");
+    expect(copy).toContain("await mockable(agent, ctx, session)");
+    expect(copy.indexOf("await mockable(agent, ctx, session)")).toBeLessThan(
+      copy.indexOf("await session.start"),
+    );
+    // The prompt carries the worker's name as well: dispatching by name is
+    // what puts the one agent under test in the marked room.
+    expect(copy).toContain("agent_name in its WorkerOptions");
+    expect(copy).toContain(TESTING_SETUP_INSTALL);
+    expect(copy).not.toMatch(/egma[>=~^]/);
+
+    // The mirror of the monitoring surface's promise: the web explains work it
+    // cannot perform, so it claims no completion for it.
+    expect(copy).not.toMatch(/chat (is )?(ready|configured|on)\b/i);
+    expect(copy).not.toContain("Verified");
+    expect(copy).toContain("Egma cannot see this change from here");
+  });
+
+  it("gives voice workers the testing hook without chat-only room changes", () => {
+    const { container } = render(
+      <LiveKitTestingInstructions modality="voice" />,
+    );
+
+    const copy = container.textContent ?? "";
+    expect(copy).toContain(VOICE_SETUP_PROMPT);
+    expect(copy).toContain(VOICE_SETUP_SNIPPET);
+    expect(copy).toContain("from egma import mockable");
+    expect(copy).toContain("await mockable(agent, ctx, session)");
+    expect(copy).toContain("agent_name in its WorkerOptions");
+    expect(copy).not.toContain("egma-sim-chat-");
+    expect(copy).not.toContain("independent audio publisher");
+  });
+
+  it("keeps the setup visible and explains a clipboard failure", async () => {
+    const writeText = vi.fn(async () => {
+      throw new Error("Clipboard permission was denied.");
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    render(<LiveKitTestingInstructions modality="chat" />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Copy coding-agent prompt" }),
+    );
+
+    expect((await screen.findByRole("alert")).textContent).toBe(
+      "Could not copy the coding-agent prompt. Select the text and copy it manually.",
+    );
+    expect(
+      screen.getByRole("button", {
+        name: "Try to copy coding-agent prompt again",
+      }),
+    ).toBeTruthy();
+    expect(document.body.textContent).toContain(CHAT_SETUP_PROMPT);
+  });
+
+  /**
+   * The reference and this surface are one piece of knowledge in two places.
+   *
+   * A coding agent reads the reference and a person reads this panel, and the
+   * day the two blocks differ is the day one of them puts the wrong lines in a
+   * worker. This is the only assertion in the web tests that reads a source
+   * file, and it is here rather than beside the sheet's tests for that reason.
+   */
+  it("follows the versioned LiveKit source contract", () => {
+    const contract = readFileSync(
+      path.join(
+        CODE_ROOT,
+        "apps",
+        "cli",
+        "src",
+        "commands",
+        "livekit.ts",
+      ),
+      "utf8",
+    );
+
+    expect(contract).toContain('chat_room_prefix: egma-sim-chat-');
+    expect(contract).toContain("python_testing_import: from egma import mockable");
+    expect(contract).toContain(
+      "python_testing_call: await mockable(agent, ctx, session)",
+    );
+    expect(contract).toContain(
+      "disable AgentSession audio input, audio output, and transcription sync",
+    );
+    expect(contract).toContain("do not start any independent audio publisher");
+    expect(contract).toContain("dispatch_name:");
+    expect(CHAT_SETUP_SNIPPET).toContain(
+      'ctx.job.room.name.startswith("egma-sim-chat-")',
+    );
+    expect(CHAT_SETUP_PROMPT).toContain("transcription sync off");
+    expect(CHAT_SETUP_PROMPT).toContain("await mockable(agent, ctx, session)");
+    expect(CHAT_SETUP_PROMPT).toContain("agent_name in its WorkerOptions");
+    expect(CHAT_SETUP_PROMPT).toContain("independent audio publisher");
+  });
+});

--- a/apps/web/test/livekit-monitoring-instructions.test.tsx
+++ b/apps/web/test/livekit-monitoring-instructions.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { LiveKitMonitoringInstructions } from "../app/projects/[projectId]/agents/livekit-monitoring-instructions.tsx";
+import type { LiveKitWorkerLanguage } from "../lib/agent-setup-flow.ts";
+
+afterEach(cleanup);
+
+function MonitoringInstructions() {
+  const [language, setLanguage] = useState<LiveKitWorkerLanguage | "">("");
+  return (
+    <LiveKitMonitoringInstructions
+      projectId="prj_1"
+      language={language}
+      onLanguageChange={setLanguage}
+    />
+  );
+}
+
+describe("LiveKit monitoring instructions", () => {
+  it("shows only the worker changes that the person must make", () => {
+    const { container } = render(<MonitoringInstructions />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Add monitoring to your LiveKit agent",
+      }),
+    ).toBeTruthy();
+    expect(screen.queryByText("Install the Egma SDK")).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Copy / })).toBeNull();
+    expect(screen.queryByRole("link", { name: "API keys" })).toBeNull();
+    expect(
+      screen.getByRole("tab", { name: "Python" }).getAttribute("aria-selected"),
+    ).toBe("false");
+    expect(
+      screen
+        .getByRole("tab", { name: "JavaScript" })
+        .getAttribute("aria-selected"),
+    ).toBe("false");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Python" }));
+
+    expect(screen.getByText("Install the Egma SDK")).toBeTruthy();
+    expect(
+      screen.getByText("Make the hook the first line of entrypoint"),
+    ).toBeTruthy();
+    expect(screen.getByText("Set the environment values")).toBeTruthy();
+    expect(
+      screen.getByText("What language is your LiveKit worker?"),
+    ).toBeTruthy();
+    expect(screen.getAllByRole("button", { name: /^Copy / })).toHaveLength(3);
+    expect(
+      screen.getByRole("tab", { name: "Python" }).getAttribute("aria-selected"),
+    ).toBe("true");
+    expect(screen.getByRole("tablist").getAttribute("data-variant")).toBe(
+      "default",
+    );
+
+    const copy = container.textContent ?? "";
+    expect(copy).toContain(
+      "pip install 'egma @ git+https://github.com/egma-ai/egma.git#subdirectory=sdks/python'",
+    );
+    expect(copy).not.toContain("egma>=");
+    expect(copy).toContain("from egma import monitor_livekit");
+    expect(copy.indexOf("monitor_livekit(ctx)")).toBeLessThan(
+      copy.indexOf("await ctx.connect()"),
+    );
+    expect(copy.indexOf("await ctx.connect()")).toBeLessThan(
+      copy.indexOf("await session.start(...)"),
+    );
+    expect(copy.indexOf("monitor_livekit(ctx)")).toBeLessThan(
+      copy.indexOf("await session.start(...)"),
+    );
+    expect(copy).toContain("EGMA_URL=<your-public-egma-url>");
+    expect(copy).toContain(
+      "the public Egma API URL that your deployed LiveKit worker can reach",
+    );
+    expect(copy).not.toContain("localhost");
+    expect(copy).toContain("EGMA_API_KEY=<your-project-api-key>");
+    expect(
+      screen.getByRole("link", { name: "API keys" }).getAttribute("href"),
+    ).toBe("/projects/prj_1/settings/keys");
+    expect(copy).not.toContain("Not verified yet");
+    expect(copy).not.toContain("Egma creates or matches the agent");
+    expect(copy).not.toContain("mockable");
+    expect(copy).not.toMatch(/monitoring (ready|configured|on)/i);
+  });
+
+  it("shows the JavaScript package and keeps the hook first", () => {
+    const { container } = render(<MonitoringInstructions />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "JavaScript" }));
+
+    const copy = container.textContent ?? "";
+    expect(
+      screen
+        .getByRole("tab", { name: "JavaScript" })
+        .getAttribute("aria-selected"),
+    ).toBe("true");
+    expect(screen.getAllByRole("button", { name: /^Copy / })).toHaveLength(3);
+    expect(copy).toContain("npm install @egma/livekit");
+    expect(copy).toContain(
+      'import { monitorLiveKit } from "@egma/livekit"',
+    );
+    expect(copy.indexOf("monitorLiveKit(ctx)")).toBeLessThan(
+      copy.indexOf("await ctx.connect()"),
+    );
+    expect(copy.indexOf("await ctx.connect()")).toBeLessThan(
+      copy.indexOf("await session.start(...)"),
+    );
+    expect(copy.indexOf("monitorLiveKit(ctx)")).toBeLessThan(
+      copy.indexOf("await session.start(...)"),
+    );
+    expect(copy).toContain("EGMA_URL=<your-public-egma-url>");
+    expect(copy).toContain("EGMA_API_KEY=<your-project-api-key>");
+    expect(copy).not.toContain("pip install");
+    expect(copy).not.toContain("monitor_livekit");
+    expect(copy).not.toContain("is available on npm");
+  });
+});

--- a/apps/web/test/monitor-agent-sheet.test.tsx
+++ b/apps/web/test/monitor-agent-sheet.test.tsx
@@ -86,7 +86,8 @@ function stub(): { readonly seen: Seen[] } {
 }
 
 const TRANSCRIPTS = "/projects/prj_2/monitoring/transcripts";
-const MONITORING_SETUP = "/projects/prj_2/agents?sheet=connect";
+const MONITORING_SETUP =
+  "/projects/prj_2/agents?sheet=connect&goal=monitoring";
 
 function at(address: string): void {
   globalThis.history.replaceState({}, "", address);
@@ -102,7 +103,7 @@ afterEach(() => {
 });
 
 describe("the Monitoring entry", () => {
-  it("opens the shared coding-agent handoff", async () => {
+  it("opens Connect agent with Monitoring selected", async () => {
     const { seen } = stub();
     render(<MonitoringTranscriptsPage />);
 
@@ -138,14 +139,14 @@ describe("the Monitoring entry", () => {
     ).toBeNull();
   });
 
-  it("forwards a copied legacy sheet query without restoring wizard state", async () => {
+  it("forwards a copied legacy sheet query and carries its agent", async () => {
     at(`${TRANSCRIPTS}?sheet=monitor&agent=agt_2`);
     stub();
     render(<MonitoringTranscriptsPage />);
 
     await waitFor(() => {
       expect(routed.replace).toHaveBeenCalledWith(
-        MONITORING_SETUP,
+        "/projects/prj_2/agents?sheet=connect&agent=agt_2&goal=monitoring",
       );
     });
     expect(screen.queryByRole("dialog", { name: "Monitor an agent" })).toBeNull();
@@ -156,8 +157,20 @@ describe("the retired Start-monitoring address", () => {
   it("forwards to the same shared flow", async () => {
     await StartMonitoringAlias({
       params: Promise.resolve({ projectId: "prj_2" }),
+      searchParams: Promise.resolve({}),
     });
 
     expect(routed.redirect).toHaveBeenCalledWith(MONITORING_SETUP);
+  });
+
+  it("carries an agent named by an old link", async () => {
+    await StartMonitoringAlias({
+      params: Promise.resolve({ projectId: "prj_2" }),
+      searchParams: Promise.resolve({ agent: "agt_2" }),
+    });
+
+    expect(routed.redirect).toHaveBeenCalledWith(
+      "/projects/prj_2/agents?sheet=connect&agent=agt_2&goal=monitoring",
+    );
   });
 });

--- a/apps/web/test/monitoring.test.tsx
+++ b/apps/web/test/monitoring.test.tsx
@@ -1013,7 +1013,7 @@ describe("what a quiet Monitoring page says", () => {
     expect(offered).toHaveLength(1);
     for (const one of offered) {
       expect(one.getAttribute("href")).toBe(
-        "/projects/prj_2/agents?sheet=connect",
+        "/projects/prj_2/agents?sheet=connect&goal=monitoring",
       );
     }
   });
@@ -1132,14 +1132,14 @@ describe("what a quiet Monitoring page says", () => {
  * A screen that grew a stop button would be that decision made by drift.
  */
 describe("the one monitoring action this screen carries", () => {
-  it("heads the page with it, and opens the shared handoff", async () => {
+  it("heads the page with it, and states the Monitoring goal in the address", async () => {
     stub({ rows: [ONE_ROW], keys: [key("prj_2")], graders: [grader("both")] });
     render(<MonitoringTranscriptsPage />);
 
     await screen.findByRole("table", { name: LIST.tableLabel });
     const action = screen.getByRole("link", { name: LIST.monitorAgent });
     expect(action.getAttribute("href")).toBe(
-      "/projects/prj_2/agents?sheet=connect",
+      "/projects/prj_2/agents?sheet=connect&goal=monitoring",
     );
     // And the old address is not what it points at any more.
     expect(action.getAttribute("href")).not.toContain("/monitoring/start");
@@ -1153,7 +1153,7 @@ describe("the one monitoring action this screen carries", () => {
     await screen.findByRole("table", { name: LIST.tableLabel });
     expect(
       screen.getByRole("link", { name: LIST.monitorAgent }).getAttribute("href"),
-    ).toBe("/projects/prj_2/agents?sheet=connect");
+    ).toBe("/projects/prj_2/agents?sheet=connect&goal=monitoring");
   });
 
   /**

--- a/docs/api/traces.mdx
+++ b/docs/api/traces.mdx
@@ -8,10 +8,9 @@ Traces are the storage record of a conversation. Egma accepts standard
 OTLP/HTTP from an agent process that already emits OpenTelemetry spans. LiveKit
 Agents should use `monitor_livekit(ctx)` from the Egma Python SDK or
 `monitorLiveKit(ctx)` from the Egma JavaScript SDK to create the required
-telemetry setup. Check that the JavaScript package is available on npm before
-you install it. Retell Monitoring polls Retell and writes normalized production
-traces without using this ingest endpoint. Use the read endpoints below for
-either source.
+telemetry setup. Retell Monitoring polls Retell and writes normalized
+production traces without using this ingest endpoint. Use the read endpoints
+below for either source.
 
 ---
 

--- a/docs/concepts/telemetry.mdx
+++ b/docs/concepts/telemetry.mdx
@@ -22,15 +22,15 @@ grader selects simulations only, so it does not grade production traffic.
 Production evidence reaches Egma in one of two ways, and which one depends on
 the agent platform.
 
-- **Retell is pulled.** Open **Agents → Connect an agent** and copy the
-  **Monitoring** or **Both** prompt into the coding agent that is working in
-  your repository. It uses the current CLI to select the exact Retell agent,
-  stores the key on that agent, and enables **pull production calls**. Egma
-  imports the previous 30 days and then polls about every 30 seconds. The
-  switch lives on the agent, so each agent is started and stopped on its own.
-  See [Retell](/integrations/retell).
+- **Retell is pulled.** Open **Agents → Connect an agent**, choose
+  **Monitoring** or **Both**, and then choose **Retell**. Enter one Retell
+  platform API key and select the exact Retell agent. Egma stores the key on
+  that agent, enables **pull production calls**, imports the previous 30 days,
+  and then polls about every 30 seconds. The switch lives on the agent, so each
+  agent is started and stopped on its own. See [Retell](/integrations/retell).
 - **LiveKit is pushed.** Install the Egma SDK for the worker's language. Call
-  `monitor_livekit(ctx)` in Python or `monitorLiveKit(ctx)` in JavaScript before
+  `monitor_livekit(ctx)` in Python or `monitorLiveKit(ctx)` in JavaScript as the
+  first statement of the job entrypoint, before `ctx.connect` and
   `AgentSession.start`. The worker sends OTLP to `POST /v1/traces`. There is
   nothing to switch on: the conversations appear as soon as the worker sends
   them.
@@ -75,13 +75,12 @@ OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer%20egma_your_project_key
 Install the Python SDK:
 
 ```bash
-pip install 'egma>=0.2.0'
+pip install 'egma @ git+https://github.com/egma-ai/egma.git#subdirectory=sdks/python'
 ```
 
 The helper reads the job's room name and keeps a simulation's spans out of
 Monitoring, so a test does not arrive here a second time as a production
-conversation. The `0.2.0` floor is what makes that hold on every LiveKit
-dispatch path. See [the Python SDK](/integrations/python-sdk#how-the-sdk-knows-it-is-in-a-simulation).
+conversation. See [the Python SDK](/integrations/python-sdk#how-the-sdk-knows-it-is-in-a-simulation).
 
 Set the Egma API origin and an existing project API key:
 

--- a/docs/integrations/javascript-sdk.mdx
+++ b/docs/integrations/javascript-sdk.mdx
@@ -23,10 +23,9 @@ verifies the telemetry seam before it supports a new LiveKit minor.
 
 ## Monitor production LiveKit agents
 
-Open **Agents → Connect an agent** and copy the **Monitoring** or **Both** prompt
-into the coding agent working in the repository. It installs the package,
-changes the worker, and uses the current CLI to create the key and environment
-handoff.
+Open **Agents → Connect an agent**, choose **Monitoring** or **Both**, and then
+choose **LiveKit**. The guided flow shows the JavaScript package, hook, and
+environment values that the worker needs.
 
 For a manual setup, create a project API key in **Settings → API keys**. Set the
 API origin and key where the worker runs:

--- a/docs/integrations/python-sdk.mdx
+++ b/docs/integrations/python-sdk.mdx
@@ -18,22 +18,19 @@ This solves a real problem: a simulation that reaches your real tools has real s
 ## Install
 
 ```bash
-pip install 'egma>=0.2.0'
+pip install 'egma @ git+https://github.com/egma-ai/egma.git#subdirectory=sdks/python'
 ```
 
 Or with uv:
 
 ```bash
-uv add 'egma>=0.2.0'
+uv add 'egma @ git+https://github.com/egma-ai/egma.git#subdirectory=sdks/python'
 ```
 
 Requires Python 3.11 or newer and `livekit-agents>=1.6.7,<1.7`.
 
-The floor is `0.2.0` because that is the first release in which both functions
-read the room's name. A LiveKit connection puts your worker in an Egma room along
-three dispatch paths; releases below the floor looked in dispatch metadata, where
-Egma no longer writes anything, so `0.2.0` is what makes mock tools and the
-monitoring guard work at all.
+Do not add an SDK version, tag, or commit. Let the repository's package manager
+resolve and lock the latest compatible SDK.
 
 <Note>
   The `livekit-agents` version is pinned to one minor version intentionally. Mock tools use LiveKit's testing API. Monitoring must also read LiveKit's current tracer provider because its public telemetry API has a setter but no getter. The fixture and live tests verify both seams before the supported range changes. See [Version pinning](#version-pinning) below.
@@ -41,10 +38,9 @@ monitoring guard work at all.
 
 ## Monitor production LiveKit agents
 
-Open **Agents → Connect an agent** and copy the **Monitoring** or **Both**
-prompt into the coding agent that is working in your repository. The prompt
-includes this Egma platform address. The coding agent installs the latest SDK,
-updates the worker, configures its deployment, and checks the result.
+Open **Agents → Connect an agent**, choose **Monitoring** or **Both**, and then
+choose **LiveKit**. The guided flow shows the Python SDK, hook, and environment
+values that the worker needs.
 
 The manual path is below. A LiveKit agent pushes its own spans, so there is
 nothing to switch on in the web application.
@@ -68,7 +64,7 @@ lk agent update-secrets --secrets-file=.env.monitoring
 
 For a new LiveKit Cloud deployment, use `lk agent create --secrets-file=.env.monitoring`. LiveKit Cloud encrypts these secrets, injects them as environment variables, and restarts the agent after an update. See [LiveKit's secrets guide](https://docs.livekit.io/deploy/agents/secrets/).
 
-Call `monitor_livekit` before `AgentSession.start`:
+Call `monitor_livekit` as the first statement of the job entrypoint, before `ctx.connect` and `AgentSession.start`:
 
 ```python
 from egma import monitor_livekit

--- a/docs/self-hosting.mdx
+++ b/docs/self-hosting.mdx
@@ -190,16 +190,19 @@ checked over the exact bytes Retell sent.
 
 ## Production Monitoring
 
-Open **Agents → Connect an agent** inside a project. Copy the **Monitoring** or
-**Both** prompt into the coding agent that is working in the voice-agent
-repository. The prompt includes this self-hosted platform address. The coding
-agent uses existing credentials, runs browser login when needed, and completes
-the Retell or LiveKit setup through the current CLI.
+Open **Agents → Connect an agent** inside a project. Choose **Monitoring** or
+**Both**, and then choose the agent platform.
+
+- **Retell:** enter a Retell API key, choose the matching Retell agent, and
+  start monitoring.
+- **LiveKit:** follow the guided worker instructions. Use this self-hosted API
+address for `EGMA_URL` and a project API key for `EGMA_API_KEY`.
 
 For a manual LiveKit setup, install the [Python SDK](/integrations/python-sdk)
 or [JavaScript SDK](/integrations/javascript-sdk) in the agent process. Set
 `EGMA_URL` to the API address and `EGMA_API_KEY` to a project key. Call
-`monitor_livekit(ctx)` in Python or `monitorLiveKit(ctx)` in JavaScript before
+`monitor_livekit(ctx)` in Python or `monitorLiveKit(ctx)` in JavaScript as the
+first statement of the job entrypoint, before `ctx.connect` and
 `AgentSession.start`.
 
 ```bash
@@ -232,31 +235,24 @@ The API applies database migrations during boot. Internal credentials and
 Docker volumes are preserved for normal upgrades from this baseline forward.
 Deployment credentials continue to come from the current `.env` file.
 
-### The SDK and this checkout move together
+### Keep the SDK and this checkout current
 
-Your simulator is built from this repository. The Egma Python SDK that runs
-inside a customer's LiveKit worker comes from PyPI and upgrades on its own
-schedule, so the two can drift apart in either direction.
+Your simulator is built from this repository. The Egma Python SDK in a
+customer's LiveKit worker is an unpinned source dependency. A lockfile can keep
+an older resolved commit, so refresh that dependency when you update Egma.
 
-Mock tools on every dispatch path need `egma>=0.2.0` in the worker **and** a
-simulator from this baseline or newer.
+Older workers looked for Egma in dispatch metadata. The current simulator
+writes nothing there, so such a worker never finds Egma and its real tools can
+run inside a simulation. Update the unpinned SDK dependency and its lockfile;
+do not repair this by pinning an older SDK release.
 
-A worker on an SDK below `0.2.0` looked for Egma in its dispatch metadata. The
-simulator writes nothing there any more — that channel is the customer's, whole
-— so such a worker never finds Egma at all. It is inert inside a real
-simulation: its real tools run against a live caller, and the simulation's
-coverage stamp is three empty lists. Nothing on Egma's side says why — from
-here it looks the same as a worker carrying no Egma SDK at all — so the worker's
-own debug log is where that shows. Raising its pin to `0.2.0` is the one fix,
-and it is the half you do not control.
-
-Upgrading the worker first loses nothing. The `egma-sim-` room-name prefix and
-the `egma-persona` participant identity are frozen contracts, so a `0.2.0`
-worker reads the same two strings whichever simulator it meets.
+The `egma-sim-` room-name prefix and the `egma-persona` participant identity
+are frozen contracts, so updating the worker first does not break an older
+simulator.
 
 An out-of-date worker does not fail loudly. The coverage stamp on the run is
-where it shows, so pull this repository on your own schedule rather than waiting
-for a run to complain.
+where it shows, so refresh the source dependency on your own schedule rather
+than waiting for a run to complain.
 
 <Warning>
   There is no in-place self-host upgrade from a build before the current

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -14,23 +14,20 @@ Calling one function never enables or changes the other.
 ## Install
 
 ```bash
-pip install 'egma>=0.2.0'
+pip install 'egma @ git+https://github.com/egma-ai/egma.git#subdirectory=sdks/python'
 ```
 
-`0.2.0` is the floor because it is the first release that knows a
-simulation by the room's name, and so the first that holds on every one of
-the three dispatch paths. An unpinned install can resolve to a release
-that looks in the dispatch metadata instead, where Egma no longer writes
-anything — inert inside a real simulation on all three.
+This source request has no version, tag, or commit. Let the repository's
+package manager resolve and lock the latest compatible SDK.
 
 For a LiveKit agent on Python 3.11 or newer.
 
 ## Production monitoring
 
-Open **Agents → Connect an agent** and copy the **Monitoring** or **Both**
-prompt into the coding agent that is working in your repository. It installs
-the latest SDK and completes these worker, key, and deployment steps. A LiveKit
-agent pushes its own spans, so there is nothing to switch on in Egma.
+Open **Agents → Connect an agent**, choose **Monitoring** or **Both**, and then
+choose **LiveKit**. The guided flow shows these worker, key, and deployment
+steps. A LiveKit agent pushes its own spans, so there is nothing to switch on
+in Egma.
 
 Set the Egma API origin and an existing project API key in the agent's
 environment:
@@ -56,7 +53,8 @@ lk agent update-secrets --secrets-file=.env.monitoring
 Use the same file with `lk agent create --secrets-file=.env.monitoring` for a
 new deployment. LiveKit Cloud restarts the agent after a secret update.
 
-Call `monitor_livekit` before `AgentSession.start`:
+Call `monitor_livekit` as the first statement of the job entrypoint, before
+`ctx.connect` and `AgentSession.start`:
 
 ```python
 from egma import monitor_livekit


### PR DESCRIPTION
## What changed

- restore the guided goal-first Connect an agent flow in the web UI
- preserve the raw, wizard-free CLI released as 0.3.1
- ask for Python or JavaScript before showing LiveKit Monitoring instructions
- let Python continue through Simulation, while JavaScript completes Monitoring and states that Testing is not yet supported
- restore Retell discovery, agent selection, simulation lanes, phone selection, and monitoring setup
- restore goal/platform deep links from Monitoring and agent capability screens
- align SDK and monitoring documentation with the restored web flow

## Safety

- no CLI or skill files changed
- JavaScript Both never creates a false Simulation connection
- unsaved credentials remain protected when a developer goes back and switches language
- partial Retell retries skip connections that were already saved

## Verification

- pnpm typecheck
- pnpm --filter @egma/web build
- full web unit suite: 32 files, 683 tests
- pnpm test:browser: 58 tests
- independent final UI and state-machine review: no remaining release blockers

CLI 0.3.1 was released first and remains the current npm latest.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790800212&installation_model_id=431960&pr_number=284&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F284&signature=04ea80f89382cb13d2210f01fa86c0c6560e74428861c80679ac65f4a1bd3842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores the goal-first guided web onboarding flow while retaining the existing CLI behavior.
- Adds provider-specific Retell discovery, connection selection, retry reconciliation, and monitoring setup.
- Adds language-aware LiveKit monitoring and supported Python simulation guidance.
- Restores setup deep links and aligns browser coverage and SDK documentation with the guided flow.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/agents/connect-sheet.tsx | Restores the guided provider setup state machine and now reconciles uncertain Retell writes across retries and sheet reopenings. |
| apps/web/app/projects/[projectId]/agents/screen.tsx | Wires query-driven setup state and parent-owned Retell recovery into the agents screen. |
| apps/web/lib/agent-setup-flow.ts | Defines goal, platform, language, modality, and Retell-lane transitions for the restored onboarding flow. |
| apps/web/app/projects/[projectId]/agents/livekit-monitoring-instructions.tsx | Provides language-specific LiveKit monitoring guidance used by onboarding. |
| apps/web/test/agents-pages.test.tsx | Covers provider normalization, stored credentials, Retell recovery, and LiveKit onboarding states. |
| apps/api/test/browser.test.ts | Updates the end-to-end product walk to exercise guided Retell and LiveKit setup through the browser. |
| apps/web/app/projects/[projectId]/monitoring/start/page.tsx | Preserves monitoring setup links by forwarding them into the restored agent onboarding flow. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  G[Choose setup goal] --> P[Choose saved or new provider]
  P -->|Retell| D[Discover Retell agents]
  D --> L[Choose simulation lanes or monitoring phone]
  L --> R[Register or reconcile connection]
  R --> M[Start production monitoring when requested]
  P -->|LiveKit| W[Choose worker language]
  W -->|JavaScript| J[Show monitoring instructions]
  W -->|Python| I[Show monitoring instructions]
  I --> C[Configure simulation connection]
  C --> T[Show testing integration]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix: clear saved LiveKit draft state"](https://github.com/egma-ai/egma/commit/5221ce129e48f7f0973b4b0416e9c2c2eaedfd0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58780275)</sub>

<!-- /greptile_comment -->