### PR TITLE
An archived agent releases its production watch

### DIFF
--- a/apps/api/src/routes/monitoring.ts
+++ b/apps/api/src/routes/monitoring.ts
@@ -493,14 +493,21 @@ export async function monitoringRoutes(
         }
         if (!lostToPullUniqueness(error)) throw error;
         // The database refused this one tick. The ticks beside it are
-        // untouched, and the sentence names the agent already watching.
+        // untouched, and the sentence names the agent already watching \u2014
+        // only an agent whose switch is actually on. The roster also holds
+        // switched-off agents that merely name the platform agent, and
+        // naming one of those would blame the very agent being started.
         const holder = known.get(one.platformAgentId);
+        const watcher =
+          holder !== undefined && holder.pullProductionCalls
+            ? holder.agentName
+            : "another agent";
         refused.push({
           platformAgentId: one.platformAgentId,
           reason: "contested",
           message:
             `${one.platformAgentId} is already watched by ` +
-            `\u201C${holder?.agentName ?? "another agent"}\u201D. One Egma agent ` +
+            `\u201C${watcher}\u201D. One Egma agent ` +
             "watches one Retell agent, so turn that agent's switch off " +
             "first, or start monitoring from it instead.",
         });

--- a/apps/api/test/monitoring-routes.test.ts
+++ b/apps/api/test/monitoring-routes.test.ts
@@ -6,6 +6,7 @@ import {
   disablePullProductionCalls,
   enablePullProductionCalls,
   readAgentPullState,
+  sealAgentMonitoringKey,
   type AuthContext,
 } from "@egma/db";
 import { afterEach, describe, expect, it } from "vitest";
@@ -464,6 +465,55 @@ describe("starting monitoring", () => {
     expect((await readAgentPullState(at(ada), second.id))?.pullProductionCalls).toBe(
       false,
     );
+  });
+
+  it("is not blocked by an archived agent that once watched the platform agent", async () => {
+    const retell = provider();
+    api = await createApi("monitoring_routes_archived_holder", {
+      retellFetch: retell.fetchImpl,
+    });
+    const ada = await signUp(api.app, "ada-archived-holder@acme.example", "Acme");
+    // Yesterday's agent watched agent_voice_1, and was archived with the
+    // switch still on.
+    const yesterday = await pulling(ada);
+    await archiveAgent(at(ada), yesterday);
+    // Today's agent is connected to the same Retell agent the way the connect
+    // flow leaves it — key sealed, switch off. Every screen reads this as
+    // "Production monitoring: Not configured".
+    const today = await createAgent(at(ada), {
+      agentPlatform: "retell",
+      name: "Front desk again",
+    });
+    await sealAgentMonitoringKey(at(ada), {
+      agentId: today.id,
+      agentPlatform: "retell",
+      platformAgentId: "agent_voice_1",
+      apiKey: RETELL_KEY,
+    });
+
+    const answered = await api.app.inject({
+      method: "POST",
+      url: `/v1/monitoring/start?projectId=${ada.projectId}`,
+      headers: { cookie: ada.cookie },
+      payload: {
+        agentPlatform: "retell",
+        apiKey: RETELL_KEY,
+        watch: [{ platformAgentId: "agent_voice_1", agentId: today.id }],
+      },
+    });
+
+    expect(answered.statusCode, answered.body).toBe(200);
+    const outcome = answered.json() as {
+      watching: { agentId: string }[];
+      refused: { message: string }[];
+    };
+    // An archived agent releases its watch the way it releases its name: the
+    // living agent starts, and nobody is told a dead row is watching.
+    expect(outcome.refused).toEqual([]);
+    expect(outcome.watching).toHaveLength(1);
+    expect(
+      (await readAgentPullState(at(ada), today.id))?.pullProductionCalls,
+    ).toBe(true);
   });
 
   /**

--- a/packages/db/migrations/0006_archived_agents_release_pull.sql
+++ b/packages/db/migrations/0006_archived_agents_release_pull.sql
@@ -1,0 +1,16 @@
+-- ARCHIVED AGENTS RELEASE THE PRODUCTION WATCH.
+--
+-- Archiving set only `archived_at`, so an agent archived with its pull
+-- switch on kept the one-watcher claim (`agent_pulled_platform_agent_unique`
+-- carries no archived condition) and kept being polled: a watcher no screen
+-- can list, refusing every living agent bound to the same platform agent —
+-- and the refusal named whichever active agent shared the platform id,
+-- usually the very agent being started.
+--
+-- The sweep turns those switches off, and must run before the constraint or
+-- an existing archived-and-on row fails the ALTER. The constraint then makes
+-- the state unrepresentable, so no future code path can mint another one.
+-- The sweep is a data mutation on rows nothing can reach, allowed plainly
+-- under "Before launch" in this directory's README.
+UPDATE "agent" SET "pull_production_calls" = false WHERE "archived_at" IS NOT NULL AND "pull_production_calls";--> statement-breakpoint
+ALTER TABLE "agent" ADD CONSTRAINT "agent_archived_releases_pull" CHECK ("agent"."pull_production_calls" = false or "agent"."archived_at" is null);

--- a/packages/db/migrations/meta/0006_snapshot.json
+++ b/packages/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,5582 @@
+{
+  "id": "b88b1193-2149-4e00-a732-633736e5be77",
+  "prevId": "e5756562-6b78-4f1f-853f-0a37a6bd0bde",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_id_prefix": {
+          "name": "account_id_prefix",
+          "value": "\"account\".\"id\" ~ '^acc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_id_prefix": {
+          "name": "session_id_prefix",
+          "value": "\"session\".\"id\" ~ '^ses_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_external_identity_unique": {
+          "name": "user_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_id_prefix": {
+          "name": "user_id_prefix",
+          "value": "\"user\".\"id\" ~ '^usr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verification_id_prefix": {
+          "name": "verification_id_prefix",
+          "value": "\"verification\".\"id\" ~ '^vrf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_suffix": {
+          "name": "display_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_organization_id_idx": {
+          "name": "api_key_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_organization_id_organization_id_fk": {
+          "name": "api_key_organization_id_organization_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "api_key_project_organization_fk": {
+          "name": "api_key_project_organization_fk",
+          "tableFrom": "api_key",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_hash_unique": {
+          "name": "api_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "api_key_id_prefix": {
+          "name": "api_key_id_prefix",
+          "value": "\"api_key\".\"id\" ~ '^key_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "api_key_scope_allowed": {
+          "name": "api_key_scope_allowed",
+          "value": "\"api_key\".\"scope\" in ('organization', 'project')"
+        },
+        "api_key_project_scope_agrees": {
+          "name": "api_key_project_scope_agrees",
+          "value": "(\"api_key\".\"scope\" = 'project') = (\"api_key\".\"project_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_created_by_user_id_fk": {
+          "name": "invitation_created_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_hash_unique": {
+          "name": "invitation_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_id_prefix": {
+          "name": "invitation_id_prefix",
+          "value": "\"invitation\".\"id\" ~ '^inv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "invitation_role_allowed": {
+          "name": "invitation_role_allowed",
+          "value": "\"invitation\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.membership": {
+      "name": "membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_organization_id_idx": {
+          "name": "membership_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "membership_organization_id_organization_id_fk": {
+          "name": "membership_organization_id_organization_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_user_id_user_id_fk": {
+          "name": "membership_user_id_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_created_by_user_id_fk": {
+          "name": "membership_created_by_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "membership_user_id_unique": {
+          "name": "membership_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "membership_organization_id_user_id_unique": {
+          "name": "membership_organization_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "membership_id_prefix": {
+          "name": "membership_id_prefix",
+          "value": "\"membership\".\"id\" ~ '^mbr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "membership_role_allowed": {
+          "name": "membership_role_allowed",
+          "value": "\"membership\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_external_identity_unique": {
+          "name": "organization_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_id_prefix": {
+          "name": "organization_id_prefix",
+          "value": "\"organization\".\"id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_residency": {
+          "name": "data_residency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_settings_organization_id_organization_id_fk": {
+          "name": "organization_settings_organization_id_organization_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_settings_organization_id_prefix": {
+          "name": "organization_settings_organization_id_prefix",
+          "value": "\"organization_settings\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_organization_id_idx": {
+          "name": "project_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"project\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_created_by_user_id_fk": {
+          "name": "project_created_by_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_organization_id_slug_unique": {
+          "name": "project_organization_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "slug"
+          ]
+        },
+        "project_id_organization_id_unique": {
+          "name": "project_id_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_id_prefix": {
+          "name": "project_id_prefix",
+          "value": "\"project\".\"id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "project_revision_prefix": {
+          "name": "project_revision_prefix",
+          "value": "\"project\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_code_expires_at_idx": {
+          "name": "device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_organization_id_organization_id_fk": {
+          "name": "device_code_organization_id_organization_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_project_organization_fk": {
+          "name": "device_code_project_organization_fk",
+          "tableFrom": "device_code",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_code_device_code_unique": {
+          "name": "device_code_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_code_user_code_unique": {
+          "name": "device_code_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_code_id_prefix": {
+          "name": "device_code_id_prefix",
+          "value": "\"device_code\".\"id\" ~ '^dvc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "device_code_status_allowed": {
+          "name": "device_code_status_allowed",
+          "value": "\"device_code\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "device_code_authorized_for_agrees": {
+          "name": "device_code_authorized_for_agrees",
+          "value": "(\"device_code\".\"organization_id\" is null) = (\"device_code\".\"project_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona": {
+      "name": "persona",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "persona_egma_provided_name_unique": {
+          "name": "persona_egma_provided_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"persona\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "persona_organization_id_project_id_idx": {
+          "name": "persona_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"persona\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "persona_organization_id_organization_id_fk": {
+          "name": "persona_organization_id_organization_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_current_version_id_persona_version_id_fk": {
+          "name": "persona_current_version_id_persona_version_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persona_created_by_user_id_fk": {
+          "name": "persona_created_by_user_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "persona_project_organization_fk": {
+          "name": "persona_project_organization_fk",
+          "tableFrom": "persona",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "persona_id_prefix": {
+          "name": "persona_id_prefix",
+          "value": "\"persona\".\"id\" ~ '^prs_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "persona_tenancy_is_whole_or_egmas": {
+          "name": "persona_tenancy_is_whole_or_egmas",
+          "value": "(\"persona\".\"organization_id\" is null) = (\"persona\".\"project_id\" is null)"
+        },
+        "persona_egma_provided_is_active": {
+          "name": "persona_egma_provided_is_active",
+          "value": "\"persona\".\"organization_id\" is not null or \"persona\".\"archived_at\" is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona_version": {
+      "name": "persona_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_name": {
+          "name": "identity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "personality": {
+          "name": "personality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "llm_provider": {
+          "name": "llm_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "llm_model": {
+          "name": "llm_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stt_provider": {
+          "name": "stt_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stt_model": {
+          "name": "stt_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tts_provider": {
+          "name": "tts_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tts_model": {
+          "name": "tts_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tts_voice_id": {
+          "name": "tts_voice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tts_speed": {
+          "name": "tts_speed",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "persona_version_persona_id_persona_id_fk": {
+          "name": "persona_version_persona_id_persona_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_version_created_by_user_id_fk": {
+          "name": "persona_version_created_by_user_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_version_persona_id_version_unique": {
+          "name": "persona_version_persona_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "persona_id",
+            "version"
+          ]
+        },
+        "persona_version_id_persona_id_unique": {
+          "name": "persona_version_id_persona_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "persona_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_version_id_prefix": {
+          "name": "persona_version_id_prefix",
+          "value": "\"persona_version\".\"id\" ~ '^prsv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "persona_version_identity_name_stated": {
+          "name": "persona_version_identity_name_stated",
+          "value": "btrim(\"persona_version\".\"identity_name\") <> ''"
+        },
+        "persona_version_personality_stated": {
+          "name": "persona_version_personality_stated",
+          "value": "btrim(\"persona_version\".\"personality\") <> ''"
+        },
+        "persona_version_language_stated": {
+          "name": "persona_version_language_stated",
+          "value": "btrim(\"persona_version\".\"language\") <> ''"
+        },
+        "persona_version_llm_provider_stated": {
+          "name": "persona_version_llm_provider_stated",
+          "value": "btrim(\"persona_version\".\"llm_provider\") <> ''"
+        },
+        "persona_version_llm_model_stated": {
+          "name": "persona_version_llm_model_stated",
+          "value": "btrim(\"persona_version\".\"llm_model\") <> ''"
+        },
+        "persona_version_stt_provider_stated": {
+          "name": "persona_version_stt_provider_stated",
+          "value": "btrim(\"persona_version\".\"stt_provider\") <> ''"
+        },
+        "persona_version_stt_model_stated": {
+          "name": "persona_version_stt_model_stated",
+          "value": "btrim(\"persona_version\".\"stt_model\") <> ''"
+        },
+        "persona_version_tts_provider_stated": {
+          "name": "persona_version_tts_provider_stated",
+          "value": "btrim(\"persona_version\".\"tts_provider\") <> ''"
+        },
+        "persona_version_tts_model_stated": {
+          "name": "persona_version_tts_model_stated",
+          "value": "btrim(\"persona_version\".\"tts_model\") <> ''"
+        },
+        "persona_version_tts_voice_id_stated": {
+          "name": "persona_version_tts_voice_id_stated",
+          "value": "btrim(\"persona_version\".\"tts_voice_id\") <> ''"
+        },
+        "persona_version_tts_speed_in_range": {
+          "name": "persona_version_tts_speed_in_range",
+          "value": "\"persona_version\".\"tts_speed\" >= 0.6 and \"persona_version\".\"tts_speed\" <= 1.5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_platform": {
+          "name": "agent_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_agent_id": {
+          "name": "platform_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monitoring_api_key": {
+          "name": "monitoring_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monitoring_api_key_hint": {
+          "name": "monitoring_api_key_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_production_calls": {
+          "name": "pull_production_calls",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_project_id_name_unique": {
+          "name": "agent_project_id_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_organization_id_project_id_idx": {
+          "name": "agent_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pulled_platform_agent_unique": {
+          "name": "agent_pulled_platform_agent_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent\".\"pull_production_calls\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_organization_id_organization_id_fk": {
+          "name": "agent_organization_id_organization_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_created_by_user_id_fk": {
+          "name": "agent_created_by_user_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_project_organization_fk": {
+          "name": "agent_project_organization_fk",
+          "tableFrom": "agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_id_project_id_unique": {
+          "name": "agent_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_id_prefix": {
+          "name": "agent_id_prefix",
+          "value": "\"agent\".\"id\" ~ '^agt_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "agent_platform_allowed": {
+          "name": "agent_platform_allowed",
+          "value": "\"agent\".\"agent_platform\" in ('retell', 'livekit')"
+        },
+        "agent_monitoring_key_hint_agrees": {
+          "name": "agent_monitoring_key_hint_agrees",
+          "value": "(\"agent\".\"monitoring_api_key\" is null) = (\"agent\".\"monitoring_api_key_hint\" is null)"
+        },
+        "agent_monitoring_key_needs_platform": {
+          "name": "agent_monitoring_key_needs_platform",
+          "value": "\"agent\".\"monitoring_api_key\" is null or \"agent\".\"agent_platform\" is not null"
+        },
+        "agent_pull_needs_binding": {
+          "name": "agent_pull_needs_binding",
+          "value": "\"agent\".\"pull_production_calls\" = false or (\"agent\".\"agent_platform\" is not null and \"agent\".\"platform_agent_id\" is not null and \"agent\".\"monitoring_api_key\" is not null)"
+        },
+        "agent_archived_releases_pull": {
+          "name": "agent_archived_releases_pull",
+          "value": "\"agent\".\"pull_production_calls\" = false or \"agent\".\"archived_at\" is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_type": {
+          "name": "connection_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topology": {
+          "name": "topology",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_variant": {
+          "name": "access_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mock_tools_enabled": {
+          "name": "mock_tools_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connection_agent_id_name_unique": {
+          "name": "connection_agent_id_name_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connection\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_agent_id_idx": {
+          "name": "connection_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connection\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connection_organization_id_organization_id_fk": {
+          "name": "connection_organization_id_organization_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_id_agent_id_fk": {
+          "name": "connection_agent_id_agent_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_created_by_user_id_fk": {
+          "name": "connection_created_by_user_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "connection_project_organization_fk": {
+          "name": "connection_project_organization_fk",
+          "tableFrom": "connection",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_project_fk": {
+          "name": "connection_agent_project_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connection_id_agent_id_unique": {
+          "name": "connection_id_agent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "agent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "connection_id_prefix": {
+          "name": "connection_id_prefix",
+          "value": "\"connection\".\"id\" ~ '^con_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "connection_type_allowed": {
+          "name": "connection_type_allowed",
+          "value": "\"connection\".\"connection_type\" in ('retell_chat_api', 'retell_text_mode', 'retell_web_call', 'phone_number', 'livekit_room')"
+        },
+        "connection_access_variant_allowed": {
+          "name": "connection_access_variant_allowed",
+          "value": "\"connection\".\"access_variant\" in ('retell_chat_api.api_key', 'retell_text_mode.api_key', 'retell_web_call.api_key', 'phone_number.public_e164', 'livekit_room.project_credentials', 'livekit_room.customer_token_endpoint')"
+        },
+        "connection_modality_allowed": {
+          "name": "connection_modality_allowed",
+          "value": "\"connection\".\"modality\" in ('voice', 'chat')"
+        },
+        "connection_topology_allowed": {
+          "name": "connection_topology_allowed",
+          "value": "\"connection\".\"topology\" in ('agent-dials-out', 'hosted-broker', 'egma-dials-in')"
+        },
+        "connection_credentials_hint_agrees": {
+          "name": "connection_credentials_hint_agrees",
+          "value": "(\"connection\".\"credentials\" is null) = (\"connection\".\"credentials_hint\" is null)"
+        },
+        "connection_mock_tools_lanes": {
+          "name": "connection_mock_tools_lanes",
+          "value": "\"connection\".\"mock_tools_enabled\" = false\n        or \"connection\".\"connection_type\" in ('retell_text_mode', 'retell_web_call')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.monitoring_state": {
+      "name": "monitoring_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scan_kind": {
+          "name": "scan_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scan_from": {
+          "name": "scan_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scan_through": {
+          "name": "scan_through",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pagination_key": {
+          "name": "pagination_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pagination_trail": {
+          "name": "pagination_trail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "completed_through": {
+          "name": "completed_through",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_poll_at": {
+          "name": "next_poll_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regular_floor_at": {
+          "name": "regular_floor_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_generation": {
+          "name": "import_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_started_at": {
+          "name": "failure_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_kind": {
+          "name": "last_error_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_received_at": {
+          "name": "last_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "monitoring_state_due_idx": {
+          "name": "monitoring_state_due_idx",
+          "columns": [
+            {
+              "expression": "next_poll_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "monitoring_state_project_idx": {
+          "name": "monitoring_state_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "monitoring_state_organization_id_organization_id_fk": {
+          "name": "monitoring_state_organization_id_organization_id_fk",
+          "tableFrom": "monitoring_state",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "monitoring_state_project_organization_fk": {
+          "name": "monitoring_state_project_organization_fk",
+          "tableFrom": "monitoring_state",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "monitoring_state_agent_project_fk": {
+          "name": "monitoring_state_agent_project_fk",
+          "tableFrom": "monitoring_state",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "monitoring_state_agent_unique": {
+          "name": "monitoring_state_agent_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "monitoring_state_id_prefix": {
+          "name": "monitoring_state_id_prefix",
+          "value": "\"monitoring_state\".\"id\" ~ '^mst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "monitoring_state_scan_kind_allowed": {
+          "name": "monitoring_state_scan_kind_allowed",
+          "value": "\"monitoring_state\".\"scan_kind\" in ('historical_import', 'regular')"
+        },
+        "monitoring_state_scan_agrees": {
+          "name": "monitoring_state_scan_agrees",
+          "value": "(\"monitoring_state\".\"scan_kind\" is null and \"monitoring_state\".\"scan_from\" is null and \"monitoring_state\".\"scan_through\" is null and \"monitoring_state\".\"pagination_key\" is null) or (\"monitoring_state\".\"scan_kind\" is not null and \"monitoring_state\".\"scan_from\" is not null and \"monitoring_state\".\"scan_through\" is not null)"
+        },
+        "monitoring_state_lease_agrees": {
+          "name": "monitoring_state_lease_agrees",
+          "value": "(\"monitoring_state\".\"lease_owner\" is null) = (\"monitoring_state\".\"lease_expires_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.retell_call_retry": {
+      "name": "retell_call_retry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_call_id": {
+          "name": "provider_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_kind": {
+          "name": "error_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_generation": {
+          "name": "import_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retell_call_retry_due_idx": {
+          "name": "retell_call_retry_due_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"retell_call_retry\".\"next_attempt_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retell_call_retry_organization_id_organization_id_fk": {
+          "name": "retell_call_retry_organization_id_organization_id_fk",
+          "tableFrom": "retell_call_retry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retell_call_retry_project_organization_fk": {
+          "name": "retell_call_retry_project_organization_fk",
+          "tableFrom": "retell_call_retry",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retell_call_retry_agent_project_fk": {
+          "name": "retell_call_retry_agent_project_fk",
+          "tableFrom": "retell_call_retry",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "retell_call_retry_project_call_unique": {
+          "name": "retell_call_retry_project_call_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "provider_call_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "retell_call_retry_id_prefix": {
+          "name": "retell_call_retry_id_prefix",
+          "value": "\"retell_call_retry\".\"id\" ~ '^rcr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "retell_call_retry_one_schedule": {
+          "name": "retell_call_retry_one_schedule",
+          "value": "(\"retell_call_retry\".\"next_attempt_at\" is null) <> (\"retell_call_retry\".\"expires_at\" is null)"
+        },
+        "retell_call_retry_attempts_bounded": {
+          "name": "retell_call_retry_attempts_bounded",
+          "value": "\"retell_call_retry\".\"attempts\" between 1 and 4"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader_definition": {
+      "name": "grader_definition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_editable": {
+          "name": "scope_editable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_definition_version": {
+          "name": "current_definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grader_definition_predefined_name_unique": {
+          "name": "grader_definition_predefined_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"grader_definition\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grader_definition_organization_id_idx": {
+          "name": "grader_definition_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grader_definition_organization_id_organization_id_fk": {
+          "name": "grader_definition_organization_id_organization_id_fk",
+          "tableFrom": "grader_definition",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_definition_current_version_fk": {
+          "name": "grader_definition_current_version_fk",
+          "tableFrom": "grader_definition",
+          "tableTo": "grader_definition_version",
+          "columnsFrom": [
+            "id",
+            "current_definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grader_definition_id_prefix": {
+          "name": "grader_definition_id_prefix",
+          "value": "\"grader_definition\".\"id\" ~ '^grl_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader_definition_version": {
+      "name": "grader_definition_version",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parameter_contract": {
+          "name": "parameter_contract",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modalities": {
+          "name": "modalities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_model": {
+          "name": "judge_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grader_definition_version_definition_id_grader_definition_id_fk": {
+          "name": "grader_definition_version_definition_id_grader_definition_id_fk",
+          "tableFrom": "grader_definition_version",
+          "tableTo": "grader_definition",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "grader_definition_version_definition_id_version_pk": {
+          "name": "grader_definition_version_definition_id_version_pk",
+          "columns": [
+            "definition_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grader_definition_version_definition_id_prefix": {
+          "name": "grader_definition_version_definition_id_prefix",
+          "value": "\"grader_definition_version\".\"definition_id\" ~ '^grl_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_definition_version_version_is_positive": {
+          "name": "grader_definition_version_version_is_positive",
+          "value": "\"grader_definition_version\".\"version\" >= 1"
+        },
+        "grader_definition_version_type_allowed": {
+          "name": "grader_definition_version_type_allowed",
+          "value": "\"grader_definition_version\".\"type\" in ('llm_as_judge', 'code')"
+        },
+        "grader_definition_version_modalities_allowed": {
+          "name": "grader_definition_version_modalities_allowed",
+          "value": "\"grader_definition_version\".\"modalities\" in (\n        '[\"chat\"]'::jsonb,\n        '[\"voice\"]'::jsonb,\n        '[\"chat\", \"voice\"]'::jsonb,\n        '[\"voice\", \"chat\"]'::jsonb\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_grader": {
+      "name": "project_grader",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grader_definition_id": {
+          "name": "grader_definition_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parameter_values": {
+          "name": "parameter_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_threshold": {
+          "name": "pass_threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_grader_active_definition_unique": {
+          "name": "project_grader_active_definition_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grader_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_grader\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_grader_organization_id_project_id_idx": {
+          "name": "project_grader_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"project_grader\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_grader_definition_id_idx": {
+          "name": "project_grader_definition_id_idx",
+          "columns": [
+            {
+              "expression": "grader_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_grader_organization_id_organization_id_fk": {
+          "name": "project_grader_organization_id_organization_id_fk",
+          "tableFrom": "project_grader",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_grader_grader_definition_id_grader_definition_id_fk": {
+          "name": "project_grader_grader_definition_id_grader_definition_id_fk",
+          "tableFrom": "project_grader",
+          "tableTo": "grader_definition",
+          "columnsFrom": [
+            "grader_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_grader_project_organization_fk": {
+          "name": "project_grader_project_organization_fk",
+          "tableFrom": "project_grader",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_grader_id_prefix": {
+          "name": "project_grader_id_prefix",
+          "value": "\"project_grader\".\"id\" ~ '^grd_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "project_grader_scope_is_closed_object": {
+          "name": "project_grader_scope_is_closed_object",
+          "value": "jsonb_typeof(\"project_grader\".\"scope\") is not distinct from 'object'\n        and (\"project_grader\".\"scope\" - array['simulations', 'production']::text[])\n          is not distinct from '{}'::jsonb\n        and \"project_grader\".\"scope\" ?& array['simulations', 'production']::text[]\n        and jsonb_typeof(\"project_grader\".\"scope\"->'simulations') is not distinct from 'array'\n        and (\n          \"project_grader\".\"scope\"->'production' = 'null'::jsonb\n          or jsonb_typeof(\"project_grader\".\"scope\"->'production') is not distinct from 'object'\n        )"
+        },
+        "project_grader_pass_threshold_is_normalized": {
+          "name": "project_grader_pass_threshold_is_normalized",
+          "value": "\"project_grader\".\"pass_threshold\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mock_tool": {
+      "name": "mock_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delay_milliseconds": {
+          "name": "delay_milliseconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mock_tool_project_id_tool_name_unique": {
+          "name": "mock_tool_project_id_tool_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mock_tool\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mock_tool_organization_id_project_id_idx": {
+          "name": "mock_tool_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"mock_tool\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_tool_organization_id_organization_id_fk": {
+          "name": "mock_tool_organization_id_organization_id_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_created_by_user_id_fk": {
+          "name": "mock_tool_created_by_user_id_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mock_tool_project_organization_fk": {
+          "name": "mock_tool_project_organization_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mock_tool_id_project_id_unique": {
+          "name": "mock_tool_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mock_tool_id_prefix": {
+          "name": "mock_tool_id_prefix",
+          "value": "\"mock_tool\".\"id\" ~ '^mck_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "mock_tool_delay_within_budget": {
+          "name": "mock_tool_delay_within_budget",
+          "value": "\"mock_tool\".\"delay_milliseconds\" between 0 and 30000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mock_tool_agent": {
+      "name": "mock_tool_agent",
+      "schema": "",
+      "columns": {
+        "mock_tool_id": {
+          "name": "mock_tool_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mock_tool_agent_agent_id_idx": {
+          "name": "mock_tool_agent_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_tool_agent_mock_tool_id_mock_tool_id_fk": {
+          "name": "mock_tool_agent_mock_tool_id_mock_tool_id_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "mock_tool",
+          "columnsFrom": [
+            "mock_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_agent_id_agent_id_fk": {
+          "name": "mock_tool_agent_agent_id_agent_id_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_mock_tool_project_fk": {
+          "name": "mock_tool_agent_mock_tool_project_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "mock_tool",
+          "columnsFrom": [
+            "mock_tool_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_agent_project_fk": {
+          "name": "mock_tool_agent_agent_project_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mock_tool_agent_pk": {
+          "name": "mock_tool_agent_pk",
+          "columns": [
+            "mock_tool_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "mock_tool_agent_mock_tool_id_position_unique": {
+          "name": "mock_tool_agent_mock_tool_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mock_tool_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mock_tool_agent_mock_tool_id_prefix": {
+          "name": "mock_tool_agent_mock_tool_id_prefix",
+          "value": "\"mock_tool_agent\".\"mock_tool_id\" ~ '^mck_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test": {
+      "name": "test",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_organization_id_project_id_idx": {
+          "name": "test_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"test\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_suite_id_id_idx": {
+          "name": "test_suite_id_id_idx",
+          "columns": [
+            {
+              "expression": "suite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"test\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_organization_id_organization_id_fk": {
+          "name": "test_organization_id_organization_id_fk",
+          "tableFrom": "test",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_current_version_id_test_version_id_fk": {
+          "name": "test_current_version_id_test_version_id_fk",
+          "tableFrom": "test",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_created_by_user_id_fk": {
+          "name": "test_created_by_user_id_fk",
+          "tableFrom": "test",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_project_organization_fk": {
+          "name": "test_project_organization_fk",
+          "tableFrom": "test",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_suite_project_fk": {
+          "name": "test_suite_project_fk",
+          "tableFrom": "test",
+          "tableTo": "test_suite",
+          "columnsFrom": [
+            "suite_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_id_project_id_unique": {
+          "name": "test_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_id_prefix": {
+          "name": "test_id_prefix",
+          "value": "\"test\".\"id\" ~ '^tst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_revision_prefix": {
+          "name": "test_revision_prefix",
+          "value": "\"test\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_persona": {
+      "name": "test_persona",
+      "schema": "",
+      "columns": {
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "test_persona_persona_id_idx": {
+          "name": "test_persona_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_persona_test_version_id_test_version_id_fk": {
+          "name": "test_persona_test_version_id_test_version_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_persona_persona_id_persona_id_fk": {
+          "name": "test_persona_persona_id_persona_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_persona_pk": {
+          "name": "test_persona_pk",
+          "columns": [
+            "test_version_id",
+            "persona_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "test_persona_version_id_position_unique": {
+          "name": "test_persona_version_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_version_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_persona_test_version_id_prefix": {
+          "name": "test_persona_test_version_id_prefix",
+          "value": "\"test_persona\".\"test_version_id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_suite": {
+      "name": "test_suite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_suite_organization_id_project_id_idx": {
+          "name": "test_suite_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"test_suite\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_suite_organization_id_organization_id_fk": {
+          "name": "test_suite_organization_id_organization_id_fk",
+          "tableFrom": "test_suite",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_suite_created_by_user_id_fk": {
+          "name": "test_suite_created_by_user_id_fk",
+          "tableFrom": "test_suite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_suite_project_organization_fk": {
+          "name": "test_suite_project_organization_fk",
+          "tableFrom": "test_suite",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_suite_id_project_id_unique": {
+          "name": "test_suite_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_suite_id_prefix": {
+          "name": "test_suite_id_prefix",
+          "value": "\"test_suite\".\"id\" ~ '^ste_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_suite_name_is_not_blank": {
+          "name": "test_suite_name_is_not_blank",
+          "value": "btrim(\"test_suite\".\"name\") <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_version": {
+      "name": "test_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_version_test_id_test_id_fk": {
+          "name": "test_version_test_id_test_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_version_created_by_user_id_fk": {
+          "name": "test_version_created_by_user_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_version_test_id_version_unique": {
+          "name": "test_version_test_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_id",
+            "version"
+          ]
+        },
+        "test_version_id_test_id_unique": {
+          "name": "test_version_id_test_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "test_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_version_id_prefix": {
+          "name": "test_version_id_prefix",
+          "value": "\"test_version\".\"id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run": {
+      "name": "run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_via": {
+          "name": "triggered_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_snapshot": {
+          "name": "connection_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mock_tool_snapshot": {
+          "name": "mock_tool_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_mock_agent_version": {
+          "name": "temp_mock_agent_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_mock_agent_version_cleanup": {
+          "name": "temp_mock_agent_version_cleanup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mock_metadata": {
+          "name": "mock_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_simulation_count": {
+          "name": "expected_simulation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_count": {
+          "name": "completed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_count": {
+          "name": "canceled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_organization_id_id_idx": {
+          "name": "run_organization_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_organization_id_project_id_id_idx": {
+          "name": "run_organization_id_project_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_agent_id_idx": {
+          "name": "run_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_suite_id_idx": {
+          "name": "run_suite_id_idx",
+          "columns": [
+            {
+              "expression": "suite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_mock_tools_cleanup_owed_idx": {
+          "name": "run_mock_tools_cleanup_owed_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"run\".\"temp_mock_agent_version_cleanup\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_organization_id_organization_id_fk": {
+          "name": "run_organization_id_organization_id_fk",
+          "tableFrom": "run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_triggered_by_user_id_fk": {
+          "name": "run_triggered_by_user_id_fk",
+          "tableFrom": "run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_project_organization_fk": {
+          "name": "run_project_organization_fk",
+          "tableFrom": "run",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_suite_project_fk": {
+          "name": "run_suite_project_fk",
+          "tableFrom": "run",
+          "tableTo": "test_suite",
+          "columnsFrom": [
+            "suite_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "run_agent_project_fk": {
+          "name": "run_agent_project_fk",
+          "tableFrom": "run",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_connection_agent_fk": {
+          "name": "run_connection_agent_fk",
+          "tableFrom": "run",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "run_id_project_id_unique": {
+          "name": "run_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "run_id_prefix": {
+          "name": "run_id_prefix",
+          "value": "\"run\".\"id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_status_allowed": {
+          "name": "run_status_allowed",
+          "value": "\"run\".\"status\" in ('pending', 'running', 'completed', 'canceled')"
+        },
+        "run_triggered_via_allowed": {
+          "name": "run_triggered_via_allowed",
+          "value": "\"run\".\"triggered_via\" in ('manual')"
+        },
+        "run_expects_at_least_one_simulation": {
+          "name": "run_expects_at_least_one_simulation",
+          "value": "\"run\".\"expected_simulation_count\" > 0"
+        },
+        "run_counts_written_together": {
+          "name": "run_counts_written_together",
+          "value": "((\"run\".\"completed_count\" is null) = (\"run\".\"failed_count\" is null))\n        and ((\"run\".\"failed_count\" is null) = (\"run\".\"canceled_count\" is null))\n        and ((\"run\".\"canceled_count\" is null) = (\"run\".\"finished_at\" is null))"
+        },
+        "run_counts_are_counts": {
+          "name": "run_counts_are_counts",
+          "value": "(\"run\".\"completed_count\" is null)\n        or (\"run\".\"completed_count\" >= 0 and \"run\".\"failed_count\" >= 0\n          and \"run\".\"canceled_count\" >= 0)"
+        },
+        "run_finished_is_terminal": {
+          "name": "run_finished_is_terminal",
+          "value": "\"run\".\"finished_at\" is null or \"run\".\"status\" in ('completed', 'canceled')"
+        },
+        "run_completed_is_finished": {
+          "name": "run_completed_is_finished",
+          "value": "\"run\".\"status\" <> 'completed' or \"run\".\"finished_at\" is not null"
+        },
+        "run_started_when_left_pending": {
+          "name": "run_started_when_left_pending",
+          "value": "case\n        when \"run\".\"status\" = 'pending' then \"run\".\"started_at\" is null\n        when \"run\".\"status\" in ('running', 'completed') then \"run\".\"started_at\" is not null\n        else true\n      end"
+        },
+        "run_agent_version_is_a_version": {
+          "name": "run_agent_version_is_a_version",
+          "value": "\"run\".\"agent_version\" is null or \"run\".\"agent_version\" >= 0"
+        },
+        "run_temp_mock_agent_version_is_a_version": {
+          "name": "run_temp_mock_agent_version_is_a_version",
+          "value": "\"run\".\"temp_mock_agent_version\" is null\n        or \"run\".\"temp_mock_agent_version\" >= 0"
+        },
+        "run_temp_mock_agent_version_owes_cleanup": {
+          "name": "run_temp_mock_agent_version_owes_cleanup",
+          "value": "\"run\".\"temp_mock_agent_version\" is null\n        or \"run\".\"temp_mock_agent_version_cleanup\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run_event": {
+      "name": "run_event",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_event_organization_id_organization_id_fk": {
+          "name": "run_event_organization_id_organization_id_fk",
+          "tableFrom": "run_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_project_organization_fk": {
+          "name": "run_event_project_organization_fk",
+          "tableFrom": "run_event",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_run_project_fk": {
+          "name": "run_event_run_project_fk",
+          "tableFrom": "run_event",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_simulation_run_fk": {
+          "name": "run_event_simulation_run_fk",
+          "tableFrom": "run_event",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "run_id"
+          ],
+          "columnsTo": [
+            "id",
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_event_pk": {
+          "name": "run_event_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "run_event_run_id_prefix": {
+          "name": "run_event_run_id_prefix",
+          "value": "\"run_event\".\"run_id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_event_kind_allowed": {
+          "name": "run_event_kind_allowed",
+          "value": "\"run_event\".\"kind\" in ('run', 'simulation')"
+        },
+        "run_event_seq_counts_from_one": {
+          "name": "run_event_seq_counts_from_one",
+          "value": "\"run_event\".\"seq\" >= 1"
+        },
+        "run_event_run_shape": {
+          "name": "run_event_run_shape",
+          "value": "\"run_event\".\"kind\" <> 'run'\n        or (\"run_event\".\"simulation_id\" is null\n          and \"run_event\".\"reason\" is null\n          and \"run_event\".\"status\" in ('pending', 'running', 'completed', 'canceled'))"
+        },
+        "run_event_simulation_shape": {
+          "name": "run_event_simulation_shape",
+          "value": "\"run_event\".\"kind\" <> 'simulation'\n        or (\"run_event\".\"simulation_id\" is not null\n          and \"run_event\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled'))"
+        },
+        "run_event_reason_agrees": {
+          "name": "run_event_reason_agrees",
+          "value": "\"run_event\".\"reason\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"reason\" in ('persona_concluded', 'agent_ended', 'limit_reached'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed'))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.simulation": {
+      "name": "simulation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_version_id": {
+          "name": "persona_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ending_reason": {
+          "name": "ending_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_failure": {
+          "name": "execution_failure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recording_reference": {
+          "name": "recording_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mock_tool_coverage": {
+          "name": "mock_tool_coverage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "simulation_run_id_idx": {
+          "name": "simulation_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_queued_idx": {
+          "name": "simulation_queued_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_heartbeat_idx": {
+          "name": "simulation_heartbeat_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" in ('claimed', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_version_id_idx": {
+          "name": "simulation_persona_version_id_idx",
+          "columns": [
+            {
+              "expression": "persona_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_id_idx": {
+          "name": "simulation_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_version_id_idx": {
+          "name": "simulation_test_version_id_idx",
+          "columns": [
+            {
+              "expression": "test_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_id_idx": {
+          "name": "simulation_test_id_idx",
+          "columns": [
+            {
+              "expression": "test_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulation_organization_id_organization_id_fk": {
+          "name": "simulation_organization_id_organization_id_fk",
+          "tableFrom": "simulation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_project_organization_fk": {
+          "name": "simulation_project_organization_fk",
+          "tableFrom": "simulation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_agent_project_fk": {
+          "name": "simulation_agent_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_connection_agent_fk": {
+          "name": "simulation_connection_agent_fk",
+          "tableFrom": "simulation",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_run_project_fk": {
+          "name": "simulation_run_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_version_persona_fk": {
+          "name": "simulation_persona_version_persona_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "persona_version_id",
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id",
+            "persona_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_version_test_fk": {
+          "name": "simulation_test_version_test_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id",
+            "test_id"
+          ],
+          "columnsTo": [
+            "id",
+            "test_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_project_fk": {
+          "name": "simulation_test_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulation_run_id_position_unique": {
+          "name": "simulation_run_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "position"
+          ]
+        },
+        "simulation_id_project_id_unique": {
+          "name": "simulation_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        },
+        "simulation_id_run_id_unique": {
+          "name": "simulation_id_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "simulation_id_prefix": {
+          "name": "simulation_id_prefix",
+          "value": "\"simulation\".\"id\" ~ '^sim_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "simulation_status_allowed": {
+          "name": "simulation_status_allowed",
+          "value": "\"simulation\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled')"
+        },
+        "simulation_modality_allowed": {
+          "name": "simulation_modality_allowed",
+          "value": "\"simulation\".\"modality\" in ('voice', 'chat')"
+        },
+        "simulation_position_counts_from_one": {
+          "name": "simulation_position_counts_from_one",
+          "value": "\"simulation\".\"position\" >= 1"
+        },
+        "simulation_ending_reason_allowed": {
+          "name": "simulation_ending_reason_allowed",
+          "value": "\"simulation\".\"ending_reason\" is null or \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached', 'agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')"
+        },
+        "simulation_ending_reason_agrees": {
+          "name": "simulation_ending_reason_agrees",
+          "value": "case \"simulation\".\"status\"\n        when 'completed' then \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached')\n        when 'failed' then \"simulation\".\"ending_reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')\n        else \"simulation\".\"ending_reason\" is null\n      end"
+        },
+        "simulation_execution_failure_agrees": {
+          "name": "simulation_execution_failure_agrees",
+          "value": "\"simulation\".\"execution_failure\" is null or \"simulation\".\"status\" = 'failed'"
+        },
+        "simulation_execution_failure_not_blank": {
+          "name": "simulation_execution_failure_not_blank",
+          "value": "\"simulation\".\"execution_failure\" is null or btrim(\"simulation\".\"execution_failure\") <> ''"
+        },
+        "simulation_claim_columns_agree": {
+          "name": "simulation_claim_columns_agree",
+          "value": "((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"claimed_by\" is null))\n        and ((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"heartbeat_at\" is null))"
+        },
+        "simulation_queued_shape": {
+          "name": "simulation_queued_shape",
+          "value": "\"simulation\".\"status\" <> 'queued'\n        or (\"simulation\".\"claimed_at\" is null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null and \"simulation\".\"cancel_requested_at\" is null)"
+        },
+        "simulation_claimed_shape": {
+          "name": "simulation_claimed_shape",
+          "value": "\"simulation\".\"status\" <> 'claimed'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_running_shape": {
+          "name": "simulation_running_shape",
+          "value": "\"simulation\".\"status\" <> 'running'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is not null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_completed_shape": {
+          "name": "simulation_completed_shape",
+          "value": "\"simulation\".\"status\" <> 'completed'\n        or (\"simulation\".\"started_at\" is not null and \"simulation\".\"ended_at\" is not null)"
+        },
+        "simulation_failed_shape": {
+          "name": "simulation_failed_shape",
+          "value": "\"simulation\".\"status\" <> 'failed' or \"simulation\".\"ended_at\" is not null"
+        },
+        "simulation_canceled_shape": {
+          "name": "simulation_canceled_shape",
+          "value": "\"simulation\".\"status\" <> 'canceled'\n        or (\"simulation\".\"ended_at\" is not null and \"simulation\".\"cancel_requested_at\" is not null)"
+        },
+        "simulation_report_only_when_ended": {
+          "name": "simulation_report_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or \"simulation\".\"recording_reference\" is null"
+        },
+        "simulation_summary_facts_only_when_ended": {
+          "name": "simulation_summary_facts_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"turn_count\" is null and \"simulation\".\"provider_reference\" is null)"
+        },
+        "simulation_turn_count_is_a_count": {
+          "name": "simulation_turn_count_is_a_count",
+          "value": "\"simulation\".\"turn_count\" is null or \"simulation\".\"turn_count\" >= 0"
+        },
+        "simulation_mock_tool_coverage_only_when_ended": {
+          "name": "simulation_mock_tool_coverage_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null or \"simulation\".\"mock_tool_coverage\" is null"
+        },
+        "simulation_audio_facts_are_voice_facts": {
+          "name": "simulation_audio_facts_are_voice_facts",
+          "value": "\"simulation\".\"modality\" = 'voice'\n        or \"simulation\".\"recording_reference\" is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grading_plan": {
+      "name": "grading_plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "groups": {
+          "name": "groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grading_plan_organization_id_project_id_idx": {
+          "name": "grading_plan_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grading_plan_organization_id_organization_id_fk": {
+          "name": "grading_plan_organization_id_organization_id_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_plan_project_organization_fk": {
+          "name": "grading_plan_project_organization_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_plan_run_project_fk": {
+          "name": "grading_plan_run_project_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grading_plan_run_id_unique": {
+          "name": "grading_plan_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grading_plan_id_prefix": {
+          "name": "grading_plan_id_prefix",
+          "value": "\"grading_plan\".\"id\" ~ '^gpl_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grading_plan_state_allowed": {
+          "name": "grading_plan_state_allowed",
+          "value": "\"grading_plan\".\"state\" in ('run_start')"
+        },
+        "grading_plan_groups_are_a_list": {
+          "name": "grading_plan_groups_are_a_list",
+          "value": "jsonb_typeof(\"grading_plan\".\"groups\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.idempotent_operation": {
+      "name": "idempotent_operation",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_digest": {
+          "name": "request_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "idempotent_operation_organization_id_organization_id_fk": {
+          "name": "idempotent_operation_organization_id_organization_id_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "idempotent_operation_project_organization_fk": {
+          "name": "idempotent_operation_project_organization_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "idempotent_operation_actor_fk": {
+          "name": "idempotent_operation_actor_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "idempotent_operation_pk": {
+          "name": "idempotent_operation_pk",
+          "columns": [
+            "organization_id",
+            "project_id",
+            "actor_id",
+            "operation",
+            "idempotency_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "idempotent_operation_organization_id_prefix": {
+          "name": "idempotent_operation_organization_id_prefix",
+          "value": "\"idempotent_operation\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "idempotent_operation_allowed": {
+          "name": "idempotent_operation_allowed",
+          "value": "\"idempotent_operation\".\"operation\" in ('start_run')"
+        },
+        "idempotent_operation_key_is_not_empty": {
+          "name": "idempotent_operation_key_is_not_empty",
+          "value": "length(\"idempotent_operation\".\"idempotency_key\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grading_job": {
+      "name": "grading_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_started_at": {
+          "name": "trace_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence_base": {
+          "name": "sequence_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grading_job_outstanding_idx": {
+          "name": "grading_job_outstanding_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grading_job\".\"status\" in ('pending', 'claimed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grading_job_organization_id_project_id_idx": {
+          "name": "grading_job_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grading_job_organization_id_organization_id_fk": {
+          "name": "grading_job_organization_id_organization_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_project_organization_fk": {
+          "name": "grading_job_project_organization_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_simulation_project_fk": {
+          "name": "grading_job_simulation_project_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grading_job_simulation_id_unique": {
+          "name": "grading_job_simulation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "simulation_id"
+          ]
+        },
+        "grading_job_project_id_trace_id_unique": {
+          "name": "grading_job_project_id_trace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "trace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grading_job_id_prefix": {
+          "name": "grading_job_id_prefix",
+          "value": "\"grading_job\".\"id\" ~ '^gjb_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grading_job_status_allowed": {
+          "name": "grading_job_status_allowed",
+          "value": "\"grading_job\".\"status\" in ('pending', 'claimed', 'abandoned')"
+        },
+        "grading_job_source_allowed": {
+          "name": "grading_job_source_allowed",
+          "value": "\"grading_job\".\"source\" in ('simulation', 'production')"
+        },
+        "grading_job_source_names_its_control_record": {
+          "name": "grading_job_source_names_its_control_record",
+          "value": "case \"grading_job\".\"source\"\n        when 'simulation' then \"grading_job\".\"simulation_id\" is not null and \"grading_job\".\"run_id\" is not null\n        when 'production' then \"grading_job\".\"simulation_id\" is null and \"grading_job\".\"run_id\" is null\n        else false\n      end"
+        },
+        "grading_job_entries_are_a_nonempty_list": {
+          "name": "grading_job_entries_are_a_nonempty_list",
+          "value": "jsonb_typeof(\"grading_job\".\"entries\") = 'array'\n        and jsonb_array_length(\"grading_job\".\"entries\") > 0"
+        },
+        "grading_job_claim_columns_agree": {
+          "name": "grading_job_claim_columns_agree",
+          "value": "((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"claimed_by\" is null))\n        and ((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"heartbeat_at\" is null))"
+        },
+        "grading_job_pending_shape": {
+          "name": "grading_job_pending_shape",
+          "value": "\"grading_job\".\"status\" <> 'pending'\n        or (\"grading_job\".\"claimed_at\" is null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_claimed_shape": {
+          "name": "grading_job_claimed_shape",
+          "value": "\"grading_job\".\"status\" <> 'claimed'\n        or (\"grading_job\".\"claimed_at\" is not null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_abandoned_shape": {
+          "name": "grading_job_abandoned_shape",
+          "value": "(\"grading_job\".\"status\" = 'abandoned') = (\"grading_job\".\"finished_at\" is not null)"
+        },
+        "grading_job_sequence_base_is_counted": {
+          "name": "grading_job_sequence_base_is_counted",
+          "value": "\"grading_job\".\"sequence_base\" >= 0"
+        },
+        "grading_job_attempts_are_counted": {
+          "name": "grading_job_attempts_are_counted",
+          "value": "\"grading_job\".\"attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1787993150870,
       "tag": "0005_simulation_execution_failure",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1788222232543,
+      "tag": "0006_archived_agents_release_pull",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/access/agents.ts
+++ b/packages/db/src/access/agents.ts
@@ -1582,7 +1582,16 @@ export async function archiveAgent(
   return db().transaction(async (tx): Promise<ArchivedAgent | undefined> => {
     const [archived] = await tx
       .update(agent)
-      .set({ archivedAt: now, updatedAt: now })
+      /*
+       * Archiving releases the production watch the way it releases the
+       * agent's name: the one-watcher claim belongs to the living. Without
+       * this, the archived row keeps `agent_pulled_platform_agent_unique`
+       * held and keeps being polled, and the next agent bound to the same
+       * platform agent is refused by a row no screen can show. The sealed
+       * key and the monitoring history stay, exactly as stopping leaves
+       * them.
+       */
+      .set({ archivedAt: now, updatedAt: now, pullProductionCalls: false })
       .where(
         theAgent(auth, id),
       )

--- a/packages/db/src/schema/agents.ts
+++ b/packages/db/src/schema/agents.ts
@@ -174,6 +174,14 @@ export const agent = pgTable(
       "agent_pull_needs_binding",
       sql`${table.pullProductionCalls} = false or (${table.agentPlatform} is not null and ${table.platformAgentId} is not null and ${table.monitoringApiKey} is not null)`,
     ),
+    // Only the living watch. An archived row that kept its switch on would
+    // hold the one-watcher claim and keep being polled while no screen can
+    // show it, so the state is unrepresentable rather than merely avoided by
+    // the archive path.
+    check(
+      "agent_archived_releases_pull",
+      sql`${table.pullProductionCalls} = false or ${table.archivedAt} is null`,
+    ),
     // The pairing, not each column on its own: an agent cannot name one
     // organization and another organization's project.
     foreignKey({

--- a/packages/db/test/agents.test.ts
+++ b/packages/db/test/agents.test.ts
@@ -4,9 +4,11 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   createAgent,
   archiveAgent,
+  enablePullProductionCalls,
   getAgent,
   NotPermittedError,
   ProjectOutsideOrganizationError,
+  readAgentPullState,
   type AuthContext,
   type Role,
 } from "@egma/db";
@@ -198,6 +200,28 @@ describe("an agent's name", () => {
     const filed = await getAgent(actingAsAcme(), retiring.id);
     expect(filed?.name).toBe("Retiring");
     expect(filed?.archivedAt).toBeInstanceOf(Date);
+  });
+
+  it("releases its production watch the way it releases its name", async () => {
+    const retiring = await createAgent(actingAsAcme(), {
+      agentPlatform: "retell",
+      name: "Watching until retired",
+    });
+    await enablePullProductionCalls(actingAsAcme(), {
+      agentId: retiring.id,
+      agentPlatform: "retell",
+      platformAgentId: "agent_watched_until_retired",
+      apiKey: "key_live_watch_release_secret_WXYZ",
+    });
+
+    await archiveAgent(actingAsAcme(), retiring.id);
+
+    // A row nothing lists must not keep the one-watcher claim, or the next
+    // agent bound to this platform agent is refused by a ghost. The key and
+    // the monitoring history stay stored, as stopping always leaves them.
+    const state = await readAgentPullState(actingAsAcme(), retiring.id);
+    expect(state?.pullProductionCalls).toBe(false);
+    expect(state?.monitoringApiKeyHint).not.toBeNull();
   });
 });
 


### PR DESCRIPTION
Fixes the monitoring-setup dead end found in production today: starting production monitoring on a Retell agent was refused with *"agent_… is already watched by 'PROD - Remedy phase two'"* — naming the very agent being configured — while every screen truthfully said monitoring was Not configured.

## The cause, in one chain

Archiving an agent set only `archived_at`. An agent archived with its pull switch on therefore kept the one-watcher claim — `agent_pulled_platform_agent_unique` carries no archived condition — and **kept being polled**: a watcher no screen can list, refusing every living agent bound to the same Retell agent. The roster that words the refusal reads active agents only, so the sentence named whichever active agent shared the platform id — the victim, told it was blocked by itself.

## The fix

- **Archiving turns the pull switch off** (`packages/db/src/access/agents.ts`), the way it already releases the agent's name to the living. The sealed key and monitoring history stay stored, exactly as stopping leaves them.
- **Migration `0006`** first sweeps existing archived-and-on rows — this is what un-blocks the affected production project on deploy, and stops the invisible polling — then adds the check constraint `agent_archived_releases_pull`, making the state unrepresentable rather than merely avoided. The sweep must precede the ALTER or an existing zombie row fails it. Destructive-plainly per the migrations README's **Before launch** section; the platform is pre-launch, no compatibility is owed.
- **The contested refusal only names an agent whose switch is actually on** (`apps/api/src/routes/monitoring.ts`); otherwise it says "another agent". The message can no longer blame the victim.

## Verification

- Red-first at both seams, with the production symptom reproduced byte for byte: the route test got *"agent_voice_1 is already watched by 'Front desk again'"* where Front desk again was the agent being started. Both tests now green.
- `monitoring-routes` 21/21, `agents` (db) 22/22, plus the archive-adjacent files — 203 tests across 6 files, all green.
- `pnpm build`, `pnpm lint`, `tsc -p tsconfig.tests.json` all clean.

The full suite runs here in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTgk3hcJuJTAEf1CgEUK8j)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790814471&installation_model_id=431960&pr_number=286&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F286&signature=acde49c0adc1a0dcfc75b00a810a07f223fdbe9e2c4115b36113152f255f4b9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes archiving an agent atomically release its production-monitoring watch, repairs existing archived watchers with a migration, and prevents that invalid state from recurring.
- Updates the archive transaction to disable production-call pulling while retaining monitoring credentials and history.
- Backfills archived watchers before adding a database check constraint.
- Avoids naming a switched-off agent as the holder of a contested Retell watch.
- Adds database and API regression coverage for the archived-watcher scenario.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the archive, migration, schema, and refusal-message changes aligned around the same monitoring invariant.

The archive transition disables pulling atomically, the migration repairs historical invalid rows before enforcing the constraint, and watcher selection cannot allow a switched-off duplicate to mask the active watcher.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/db/src/access/agents.ts | Archives now atomically disable production pulling without removing the sealed credential or monitoring history. |
| packages/db/migrations/0006_archived_agents_release_pull.sql | Backfills archived enabled watchers before installing the matching database invariant. |
| packages/db/src/schema/agents.ts | Adds a check preventing archived agents from retaining an enabled production-pull switch. |
| apps/api/src/routes/monitoring.ts | Contested-watch refusals name a roster holder only when that holder is actually watching. |
| apps/api/test/monitoring-routes.test.ts | Adds route-level regression coverage proving an archived former watcher no longer blocks a living agent. |
| packages/db/test/agents.test.ts | Verifies archiving releases the watch while preserving the stored monitoring-key hint. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Archive active agent] --> B[Atomically set archived_at and disable pull]
  B --> C[Release unique watcher claim]
  C --> D[Stop polling archived agent]
  D --> E[Living agent can start monitoring]
  F[Deploy migration] --> G[Disable pull on existing archived agents]
  G --> H[Add archived-agent pull check]
  H --> I[Archived watcher state cannot recur]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["An archived agent releases its productio..."](https://github.com/egma-ai/egma/commit/fb60ec21cf8a83d1f181cff1350732ef07b25249) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58858687)</sub>

**Context used:**

- Knowledge Base — [API workflows and resource management](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/api-workflows.md)
- Knowledge Base — [Database persistence](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/database-persistence.md)

<!-- /greptile_comment -->