### PR TITLE
Start Retell monitoring without a phone number

### DIFF
--- a/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
@@ -483,9 +483,10 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
   /**
    * The lane this goal will save, and the candidate that saves it.
    *
-   * A monitoring goal skips the question and saves the phone lane, which is
-   * what production pull needs. A simulation goal saves the one that was
-   * picked.
+   * A Both goal skips the question and saves the phone lane, and that save
+   * also starts pulling. A simulation goal saves the one that was picked.
+   * The monitoring goal saves no lane at all — its finish is the pull
+   * switch — so this value never reaches a save on that walk.
    */
   const laneToSave: RetellLane | "" =
     plan?.asksHowToTest === true ? lane : "phone";
@@ -756,10 +757,21 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
     };
   }
 
-  async function startRetellMonitoringFor(
-    targetAgentId: string,
-    targetPlatformAgentId: string,
-  ): Promise<boolean> {
+  /**
+   * Flip the pull switch through the one commit `startMonitoring` is.
+   *
+   * `agentId` is the egma agent the flow started from, when there is one.
+   * Without it the server resolves the platform agent by (project, platform,
+   * platform agent id) and registers one under `name` when nothing answers —
+   * watching an unregistered agent means registering it (ADR-0015). The
+   * stored key is spent only when an egma agent is named, because that is the
+   * only entry shape the omitted-key preflight accepts.
+   */
+  async function startRetellMonitoringWatch(target: {
+    readonly agentId: string | null;
+    readonly platformAgentId: string;
+    readonly name: string;
+  }): Promise<{ readonly agentId: string; readonly created: boolean } | null> {
     setSaving(true);
     setRefused(null);
     const answer = await platformAnswer(
@@ -767,26 +779,33 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
         {
           projectId,
           agentPlatform: "retell",
-          ...(storedRetellKey ? {} : { apiKey: apiKey.trim() }),
+          ...(storedRetellKey && target.agentId !== null
+            ? {}
+            : { apiKey: apiKey.trim() }),
           watch: [
-            {
-              agentId: targetAgentId,
-              platformAgentId: targetPlatformAgentId,
-            },
+            target.agentId === null
+              ? {
+                  platformAgentId: target.platformAgentId,
+                  name: target.name,
+                }
+              : {
+                  agentId: target.agentId,
+                  platformAgentId: target.platformAgentId,
+                },
           ],
         },
         { client: platformClient },
       ),
     );
     setSaving(false);
-    if (!finishAnswer(answer)) return false;
+    if (!finishAnswer(answer)) return null;
 
     const watching = answer.value.watching.find(
-      (one) => one.agentId === targetAgentId,
+      (one) => one.platformAgentId === target.platformAgentId,
     );
     if (watching === undefined) {
       const refusal = answer.value.refused.find(
-        (one) => one.platformAgentId === targetPlatformAgentId,
+        (one) => one.platformAgentId === target.platformAgentId,
       );
       setRefused({
         error: "monitoring_not_started",
@@ -794,10 +813,10 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
           refusal?.message ??
           "Egma did not start monitoring this agent. Try again.",
       });
-      return false;
+      return null;
     }
 
-    return true;
+    return { agentId: watching.agentId, created: watching.created === true };
   }
 
   async function resumeRetellMonitoring(): Promise<ConnectSheetResult | null> {
@@ -810,13 +829,38 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
       return null;
     }
 
-    const started = await startRetellMonitoringFor(
+    const watched = await startRetellMonitoringWatch({
       agentId,
-      known.platformAgentId,
-    );
-    if (!started) return null;
+      platformAgentId: known.platformAgentId,
+      name: known.name,
+    });
+    if (watched === null) return null;
 
     return { agentId, connectionId: null, created: false };
+  }
+
+  /**
+   * The Monitoring goal's whole finish, from the agent choice itself.
+   *
+   * Production pull needs the sealed key and the platform agent id — the
+   * puller selects calls by agent id alone — so no provider connection is
+   * written and no phone number is asked for.
+   */
+  async function finishRetellMonitoring(): Promise<void> {
+    if (selectedRetellAgent === undefined) return;
+    const startedFrom =
+      agentId !== undefined && agentId !== NEW_AGENT ? agentId : null;
+    const watched = await startRetellMonitoringWatch({
+      agentId: startedFrom,
+      platformAgentId: selectedRetellAgent.platformAgentId,
+      name: selectedRetellAgent.name || selectedRetellAgent.platformAgentId,
+    });
+    if (watched === null) return;
+    onConnected({
+      agentId: watched.agentId,
+      connectionId: null,
+      created: watched.created,
+    });
   }
 
   /**
@@ -1004,11 +1048,12 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
         pullsProduction &&
         !retryPullEnabled
       ) {
-        const started = await startRetellMonitoringFor(
-          landed?.agentId ?? committed.agentId,
-          selectedRetellAgent.platformAgentId,
-        );
-        if (!started) return;
+        const started = await startRetellMonitoringWatch({
+          agentId: landed?.agentId ?? committed.agentId,
+          platformAgentId: selectedRetellAgent.platformAgentId,
+          name: selectedRetellAgent.name || selectedRetellAgent.platformAgentId,
+        });
+        if (started === null) return;
         retryPullEnabled = true;
       }
       if (committed === undefined && landed !== null) {
@@ -1148,7 +1193,13 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
           return;
         }
         const next = stepAfterRetellAgent(plan);
-        // A goal that skips the question saves the phone lane, so it needs its
+        // The monitoring goal has nothing left to ask: the pull switch needs
+        // no provider route, so the agent choice is the whole of it.
+        if (next === null) {
+          await finishRetellMonitoring();
+          return;
+        }
+        // Both skips the question and saves the phone lane, so it needs its
         // first routed number chosen for it; the question's own walk waits.
         if (next === "retell-phone") {
           const first = voiceRoutes[0];
@@ -1388,16 +1439,20 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
                   const phones = one.connectionCandidates.filter(
                     (candidate) => candidate.connectionType === "phone_number",
                   ).length;
+                  // Pull selects calls by agent id, so a monitoring-only walk
+                  // has no use for a phone count and does not show one.
                   const description =
-                    modality === "voice"
-                      ? "Voice agent · " +
-                        (phones === 0
-                          ? "no phone numbers available"
-                          : phones +
-                            (phones === 1
-                              ? " phone number available"
-                              : " phone numbers available"))
-                      : "No supported connection available";
+                    modality !== "voice"
+                      ? "No supported connection available"
+                      : plan?.pullWithoutConnection === true
+                        ? "Voice agent"
+                        : "Voice agent · " +
+                          (phones === 0
+                            ? "no phone numbers available"
+                            : phones +
+                              (phones === 1
+                                ? " phone number available"
+                                : " phone numbers available"));
                   return (
                     <ChoiceCard
                       key={one.platformAgentId}
@@ -1415,7 +1470,9 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
             <InfoBox>
               {plan?.asksHowToTest === true
                 ? "Egma lists your Retell voice agents. You choose how to test the one you pick next."
-                : "Egma lists your Retell voice agents. Production monitoring needs one of the phone numbers routed to the agent you pick."}
+                : plan?.pullWithoutConnection === true
+                  ? "Egma lists your Retell voice agents, and pulls the production calls of the one you pick from your Retell account."
+                  : "Egma lists your Retell voice agents. Setting up both needs one of the phone numbers routed to the agent you pick."}
             </InfoBox>
           </div>
         );
@@ -1578,12 +1635,17 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
   }
 
   const primaryLabel =
-    step === "goal" ||
-    step === "platform" ||
-    step === "retell-agent" ||
-    step === "livekit-modality"
+    step === "goal" || step === "platform" || step === "livekit-modality"
       ? "Continue"
-      : step === "retell-lanes"
+      : step === "retell-agent"
+        ? // The monitoring goal finishes on this step: the pull switch needs
+          // no provider route, so the agent choice is the whole of it.
+          plan?.pullWithoutConnection === true
+          ? saving
+            ? "Starting…"
+            : "Start monitoring"
+          : "Continue"
+        : step === "retell-lanes"
           ? lane === "phone"
             ? "Continue"
             : saving
@@ -1598,13 +1660,13 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
                 ? "Finding agents…"
                 : "Find agents"
               : step === "retell-phone"
-                ? saving
+                ? // Monitoring never reaches the number chooser any more: it
+                  // finishes on the agent choice.
+                  saving
                   ? "Finishing…"
                   : goal === "simulation"
                     ? "Set up simulation"
-                    : goal === "monitoring"
-                      ? "Start monitoring"
-                      : "Set up both"
+                    : "Set up both"
                 : step === "livekit-simulation"
                   ? saving
                     ? "Saving…"

--- a/apps/web/lib/agent-setup-flow.ts
+++ b/apps/web/lib/agent-setup-flow.ts
@@ -23,6 +23,16 @@ export type AgentSetupPlan = {
   readonly mayWriteConnection: boolean;
   /** Whether the Retell connection save also turns on production pulling. */
   readonly pullWithConnection: boolean;
+  /**
+   * Whether the flow ends by flipping the pull switch, with no connection.
+   *
+   * Production pull needs the sealed key and the platform agent id — the
+   * puller selects calls by agent id alone — so the monitoring goal asks for
+   * no phone number and writes no provider route. The switch commit registers
+   * an agent this project does not hold yet (ADR-0015: watching one means
+   * registering it).
+   */
+  readonly pullWithoutConnection: boolean;
   /** Whether the UI shows LiveKit instructions without recording an on/off state. */
   readonly monitoringInstructions: boolean;
   /**
@@ -45,15 +55,17 @@ const PLANS: Readonly<
       platform: "retell",
       mayWriteConnection: true,
       pullWithConnection: false,
+      pullWithoutConnection: false,
       monitoringInstructions: false,
       asksHowToTest: true,
     },
     monitoring: {
       goal: "monitoring",
       platform: "retell",
-      /* The selected voice route is saved, and that same save starts pulling. */
-      mayWriteConnection: true,
-      pullWithConnection: true,
+      /* Nothing is saved but the pull switch: no route, no phone number. */
+      mayWriteConnection: false,
+      pullWithConnection: false,
+      pullWithoutConnection: true,
       monitoringInstructions: false,
       asksHowToTest: false,
     },
@@ -62,9 +74,10 @@ const PLANS: Readonly<
       platform: "retell",
       mayWriteConnection: true,
       pullWithConnection: true,
+      pullWithoutConnection: false,
       monitoringInstructions: false,
-      // Both needs the voice connection for production pull, so it takes the
-      // number chooser without the question, exactly as Monitoring does.
+      // Both saves the phone lane for simulation, so it takes the number
+      // chooser without the question; the same save starts pulling.
       asksHowToTest: false,
     },
   },
@@ -74,6 +87,7 @@ const PLANS: Readonly<
       platform: "livekit",
       mayWriteConnection: true,
       pullWithConnection: false,
+      pullWithoutConnection: false,
       monitoringInstructions: false,
       asksHowToTest: false,
     },
@@ -82,6 +96,7 @@ const PLANS: Readonly<
       platform: "livekit",
       mayWriteConnection: false,
       pullWithConnection: false,
+      pullWithoutConnection: false,
       monitoringInstructions: true,
       asksHowToTest: false,
     },
@@ -92,6 +107,7 @@ const PLANS: Readonly<
       // the matching production-monitoring instructions.
       mayWriteConnection: true,
       pullWithConnection: false,
+      pullWithoutConnection: false,
       monitoringInstructions: true,
       asksHowToTest: false,
     },
@@ -121,7 +137,8 @@ export function retellAgentsForPlan(
   plan: AgentSetupPlan,
   agents: readonly RetellDiscoveredAgent[] | null,
 ): readonly RetellDiscoveredAgent[] {
-  if (plan.platform !== "retell" || !plan.mayWriteConnection) return [];
+  if (plan.platform !== "retell") return [];
+  if (!plan.mayWriteConnection && !plan.pullWithoutConnection) return [];
   return agents?.filter((agent) => agent.modality === "voice") ?? [];
 }
 
@@ -232,7 +249,11 @@ export function retellAgentCanEnterPlan(
   plan: AgentSetupPlan,
   agent: RetellDiscoveredAgent,
 ): boolean {
-  if (plan.platform !== "retell" || !plan.mayWriteConnection) return false;
+  if (plan.platform !== "retell") return false;
+  // Pull selects calls by platform agent id, so a monitoring-only plan takes
+  // every voice agent — one with no routed number as much as any other.
+  if (plan.pullWithoutConnection) return true;
+  if (!plan.mayWriteConnection) return false;
   if (!plan.asksHowToTest) {
     return agent.connectionCandidates.some(
       (candidate) => candidate.connectionType === "phone_number",
@@ -302,15 +323,19 @@ export function stepAfterLiveKitTesting(
 }
 
 /**
- * Where a chosen Retell agent leads.
+ * Where a chosen Retell agent leads, or `null` when the flow can finish now.
  *
  * Straight to the one question — how should Egma test this agent — because the
- * choice a person understands comes before any plumbing. Monitoring and Both
- * need the voice connection for production pull, so they skip the question and
- * go to the number chooser exactly as they do today.
+ * choice a person understands comes before any plumbing. Both needs the voice
+ * connection for the simulation phone lane, so it skips the question and goes
+ * to the number chooser. Monitoring needs no connection at all — the pull
+ * switch is the whole finish — so the agent choice is its last step.
  */
-export function stepAfterRetellAgent(plan: AgentSetupPlan): AgentSetupStep {
-  return plan.asksHowToTest ? "retell-lanes" : "retell-phone";
+export function stepAfterRetellAgent(
+  plan: AgentSetupPlan,
+): AgentSetupStep | null {
+  if (plan.asksHowToTest) return "retell-lanes";
+  return plan.pullWithoutConnection ? null : "retell-phone";
 }
 
 /**
@@ -356,7 +381,8 @@ export function previousAgentSetupStep({
       return null;
     case "retell-phone":
       // The phone chooser is reached through the one question when the goal is
-      // a simulation, and straight from the agent for the goals that skip it.
+      // a simulation, and straight from the agent for Both, which skips it.
+      // Monitoring never arrives here: it finishes on the agent choice.
       return goal === "simulation" ? "retell-lanes" : "retell-agent";
     case "livekit-simulation":
       return "livekit-modality";

--- a/apps/web/test/agent-setup-flow.test.ts
+++ b/apps/web/test/agent-setup-flow.test.ts
@@ -108,18 +108,23 @@ describe("the goal-first agent setup plan", () => {
     expect(agentSetupPlan("simulation", "retell")).toMatchObject({
       mayWriteConnection: true,
       pullWithConnection: false,
+      pullWithoutConnection: false,
       asksHowToTest: true,
     });
-    // Monitoring and Both need the voice connection for production pull, so
-    // they skip the one question exactly as they do today.
+    // Monitoring saves nothing but the pull switch — no route and no phone
+    // number — so it skips the one question and every connection write.
     expect(agentSetupPlan("monitoring", "retell")).toMatchObject({
-      mayWriteConnection: true,
-      pullWithConnection: true,
+      mayWriteConnection: false,
+      pullWithConnection: false,
+      pullWithoutConnection: true,
       asksHowToTest: false,
     });
+    // Both saves the phone lane for simulation and starts pulling on that
+    // same save, so it skips the question and keeps the number chooser.
     expect(agentSetupPlan("both", "retell")).toMatchObject({
       mayWriteConnection: true,
       pullWithConnection: true,
+      pullWithoutConnection: false,
       asksHowToTest: false,
     });
     expect(agentSetupPlan("simulation", "livekit")).toMatchObject({
@@ -137,15 +142,23 @@ describe("the goal-first agent setup plan", () => {
   });
 
   it("keeps every voice agent visible, including one with no routed number", () => {
-    const plan = agentSetupPlan("simulation", "retell");
-
-    expect(retellAgentsForPlan(plan, [VOICE, UNROUTED_VOICE])).toEqual([
-      VOICE,
-      UNROUTED_VOICE,
-    ]);
+    expect(
+      retellAgentsForPlan(agentSetupPlan("simulation", "retell"), [
+        VOICE,
+        UNROUTED_VOICE,
+      ]),
+    ).toEqual([VOICE, UNROUTED_VOICE]);
+    // Monitoring writes no connection, and its picker still lists every
+    // voice agent: the pull switch is what it is there to flip.
+    expect(
+      retellAgentsForPlan(agentSetupPlan("monitoring", "retell"), [
+        VOICE,
+        UNROUTED_VOICE,
+      ]),
+    ).toEqual([VOICE, UNROUTED_VOICE]);
   });
 
-  it("lets simulations use non-phone routes but requires a phone for production pull", () => {
+  it("requires a phone only for Both, which saves the lane — never for Monitoring", () => {
     const withoutPhone = {
       ...VOICE_WITH_ROUTES,
       connectionCandidates: VOICE_WITH_ROUTES.connectionCandidates.filter(
@@ -159,12 +172,14 @@ describe("the goal-first agent setup plan", () => {
         withoutPhone,
       ),
     ).toBe(true);
+    // Pull selects calls by platform agent id, so a monitoring-only plan
+    // takes a voice agent with no routed number as it takes any other.
     expect(
       retellAgentCanEnterPlan(
         agentSetupPlan("monitoring", "retell"),
         withoutPhone,
       ),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       retellAgentCanEnterPlan(agentSetupPlan("both", "retell"), withoutPhone),
     ).toBe(false);
@@ -287,15 +302,16 @@ describe("the goal-first agent setup plan", () => {
     expect(stepAfterPlatform("monitoring", "livekit")).toBe(
       "livekit-monitoring",
     );
-    // The one question leads for a simulation. Monitoring and Both go straight
-    // to the number chooser, which is the connection production pull needs —
-    // so a monitoring-goal web user never sees the test question.
+    // The one question leads for a simulation. Both goes straight to the
+    // number chooser its phone lane needs. Monitoring finishes on the agent
+    // choice itself: the pull switch needs no provider route, so there is
+    // nothing after the pick but the switch.
     expect(stepAfterRetellAgent(agentSetupPlan("simulation", "retell"))).toBe(
       "retell-lanes",
     );
-    expect(stepAfterRetellAgent(agentSetupPlan("monitoring", "retell"))).toBe(
-      "retell-phone",
-    );
+    expect(
+      stepAfterRetellAgent(agentSetupPlan("monitoring", "retell")),
+    ).toBeNull();
     expect(stepAfterRetellAgent(agentSetupPlan("both", "retell"))).toBe(
       "retell-phone",
     );

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -1153,6 +1153,35 @@ describe("goal-first agent setup", () => {
     ],
   };
 
+  /** One voice agent whose discovery answers with no routed number at all. */
+  const unroutedVoiceDiscovery = {
+    agents: [
+      {
+        platformAgentId: "agent_voice_unrouted",
+        name: "Voice without a number",
+        modality: "voice",
+        connectionCandidates: [
+          {
+            agentPlatform: "retell",
+            connectionType: "retell_text_mode",
+            accessVariant: "retell_text_mode.api_key",
+            modality: "chat",
+            productLabel: "Retell text mode",
+            config: { retellAgentId: "agent_voice_unrouted" },
+          },
+          {
+            agentPlatform: "retell",
+            connectionType: "retell_web_call",
+            accessVariant: "retell_web_call.api_key",
+            modality: "voice",
+            productLabel: "Retell web call",
+            config: { retellAgentId: "agent_voice_unrouted" },
+          },
+        ],
+      },
+    ],
+  };
+
   const liveKitAgent = {
     ...AGENT,
     id: "agt_livekit",
@@ -1215,6 +1244,16 @@ describe("goal-first agent setup", () => {
       await screen.findByRole("radio", { name: new RegExp(`^${name}`) }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+  }
+
+  /**
+   * Select the agent radio without advancing. The monitoring goal finishes on
+   * this step, so its primary button is Start monitoring, not Continue.
+   */
+  async function selectRetellAgent(name: string): Promise<void> {
+    fireEvent.click(
+      await screen.findByRole("radio", { name: new RegExp(`^${name}`) }),
+    );
   }
 
   /** Choose the simulation modality before any connection detail. */
@@ -1636,9 +1675,16 @@ describe("goal-first agent setup", () => {
     expect(
       await screen.findByRole("heading", { name: "Choose a Retell agent" }),
     ).toBeDefined();
-    await pickRetellAgent("Appointment line");
 
-    expect(await screen.findByLabelText("Phone number*")).toBeDefined();
+    // Monitoring finishes on the agent choice and never sees a phone number.
+    // Both saves the phone lane, so its walk keeps the chooser.
+    if (goal === "monitoring") {
+      await selectRetellAgent("Appointment line");
+      expect(screen.queryByLabelText("Phone number*")).toBeNull();
+    } else {
+      await pickRetellAgent("Appointment line");
+      expect(await screen.findByLabelText("Phone number*")).toBeDefined();
+    }
     const start = screen.getByRole("button", { name: action });
     for (let turn = 1; turn <= 2; turn += 1) {
       fireEvent.click(start);
@@ -1766,42 +1812,32 @@ describe("goal-first agent setup", () => {
     expect(unrouted.disabled).toBe(false);
   });
 
-  it("disables a no-phone Retell agent when production monitoring needs a phone", async () => {
+  it("keeps a no-phone Retell agent usable and counts no phones when Monitoring is the goal", async () => {
+    // Pull selects calls by platform agent id, so a voice agent with no
+    // routed number can be monitored — and a phone count would be a fact
+    // about a chooser this walk never reaches.
     sheetAnswers({
-      "/v1/agents:discover": {
-        status: 200,
-        body: {
-          agents: [
-            {
-              platformAgentId: "agent_voice_unrouted",
-              name: "Voice without a number",
-              modality: "voice",
-              connectionCandidates: [
-                {
-                  agentPlatform: "retell",
-                  connectionType: "retell_text_mode",
-                  accessVariant: "retell_text_mode.api_key",
-                  modality: "chat",
-                  productLabel: "Retell text mode",
-                  config: { retellAgentId: "agent_voice_unrouted" },
-                },
-                {
-                  agentPlatform: "retell",
-                  connectionType: "retell_web_call",
-                  accessVariant: "retell_web_call.api_key",
-                  modality: "voice",
-                  productLabel: "Retell web call",
-                  config: { retellAgentId: "agent_voice_unrouted" },
-                },
-              ],
-            },
-          ],
-        },
-      },
+      "/v1/agents:discover": { status: 200, body: unroutedVoiceDiscovery },
     });
     render(<RegisterAgentPage />);
 
     await choose("Monitor production", "Retell");
+    await findRetellAgents();
+
+    const unrouted = screen.getByRole("radio", {
+      name: /Voice without a number/,
+    }) as HTMLButtonElement;
+    expect(unrouted.disabled).toBe(false);
+    expect(screen.queryByText(/phone numbers? available/)).toBeNull();
+  });
+
+  it("disables a no-phone Retell agent when Both needs a phone for its lane", async () => {
+    sheetAnswers({
+      "/v1/agents:discover": { status: 200, body: unroutedVoiceDiscovery },
+    });
+    render(<RegisterAgentPage />);
+
+    await choose("Set up both", "Retell");
     await findRetellAgents();
 
     const unrouted = screen.getByRole("radio", {
@@ -2715,54 +2751,52 @@ describe("goal-first agent setup", () => {
     ).toBe(false);
   });
 
-  it("never sees the test question when Monitoring is the goal", async () => {
-    // A monitoring-goal user skips the question, as before: production pull
-    // needs the voice connection and nothing else, so asking "text, web call
-    // or phone?" would be a question whose answer it cannot use.
+  it("never sees the test question or a phone number when Monitoring is the goal", async () => {
+    // A monitoring-goal user skips the question: pull selects calls by
+    // platform agent id, so "text, web call or phone?" would be a question
+    // whose answer it cannot use — and so would a phone-number chooser.
     sheetAnswers({
       "/v1/agents:discover": { status: 200, body: retellDiscovery },
     });
     render(<RegisterAgentPage />);
     await choose("Monitor production", "Retell");
     await findRetellAgents();
-    await pickRetellAgent("Appointment line");
+    await selectRetellAgent("Appointment line");
 
-    expect(await screen.findByLabelText("Phone number*")).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: "Start monitoring" }),
+    ).toBeDefined();
     expect(
       screen.queryByRole("heading", {
         name: "How should Egma test this agent?",
       }),
     ).toBeNull();
+    expect(screen.queryByLabelText("Phone number*")).toBeNull();
   });
 
-  it("stores the selected Retell route and starts pulling when Monitoring is the goal", async () => {
+  it("starts pulling with no connection and no phone number when Monitoring is the goal", async () => {
     sheetAnswers({
       "/v1/agents:discover": { status: 200, body: retellDiscovery },
-      "/v1/agents": [
-        { status: 200, body: { agents: [], nextPageToken: null } },
-        {
-          status: 201,
-          body: {
-            result: "created",
-            agent: {
-              ...AGENT,
-              name: "Appointment line",
+      "/v1/monitoring/start": {
+        status: 200,
+        body: {
+          watching: [
+            {
+              agentId: "agt_watched",
+              agentName: "Appointment line",
               platformAgentId: "agent_voice_1",
-              monitoringKeyPresent: true,
-              monitoringApiKeyHint: "WXYZ",
+              created: true,
               pullProductionCalls: true,
             },
-            connection: MEASURED_CONNECTION,
-          },
+          ],
+          refused: [],
         },
-        { status: 200, body: { agents: [LISTED_AGENT], nextPageToken: null } },
-      ],
+      },
     });
     render(<RegisterAgentPage />);
     await choose("Monitor production", "Retell");
     await findRetellAgents();
-    await pickRetellAgent("Appointment line");
-    expect(await screen.findByLabelText("Phone number*")).toBeDefined();
+    await selectRetellAgent("Appointment line");
 
     const start = screen.getByRole("button", { name: "Start monitoring" });
     await waitFor(() => {
@@ -2772,30 +2806,32 @@ describe("goal-first agent setup", () => {
 
     await waitFor(() => {
       expect(
-        sent.some((call) => call.url === "/v1/agents?projectId=prj_1"),
+        sent.some((call) => call.url.startsWith("/v1/monitoring/start")),
       ).toBe(true);
     });
-    const registration = sent.find(
-      (call) => call.url === "/v1/agents?projectId=prj_1",
+    // The switch commit carries the key and registers the platform agent
+    // itself, so the walk names the agent by the platform's own identity.
+    const started = sent.find((call) =>
+      call.url.startsWith("/v1/monitoring/start"),
     );
-    expect(registration?.body).toEqual({
-      name: "Appointment line",
+    expect(started?.body).toEqual({
       agentPlatform: "retell",
-      connection: {
-        agentPlatform: "retell",
-        connectionType: "phone_number",
-        accessVariant: "phone_number.public_e164",
-        modality: "voice",
-        config: { phoneNumber: "+14155550100" },
-        platformAgentId: "agent_voice_1",
-        credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
-        pullProductionCalls: true,
-        mockToolsEnabled: false,
-      },
+      apiKey: "retell-secret-A1B2C3D4WXYZ",
+      watch: [
+        { platformAgentId: "agent_voice_1", name: "Appointment line" },
+      ],
     });
+    await waitFor(() => {
+      expect(routed.replace).toHaveBeenCalledWith("/projects/prj_1/agents");
+    });
+    // No agent registration write and no connection write anywhere.
     expect(
-      sent.some((call) => call.url.startsWith("/v1/monitoring/start")),
+      sent.some(
+        (call) =>
+          call.method === "POST" && call.url.startsWith("/v1/agents?"),
+      ),
     ).toBe(false);
+    expect(sent.some((call) => call.url.includes("/connections"))).toBe(false);
   });
 
   it("creates the LiveKit room connection, then shows the testing hook", async () => {


### PR DESCRIPTION
## Why

A person who only wants production monitoring for a Retell agent was walked to a **Choose a phone number** step. The number was never needed for monitoring:

- The pull switch needs the sealed key and the platform agent id — the DB constraint on `agent.pull_production_calls` names exactly those.
- The puller selects calls by platform agent id alone (`retell-production-ingestion.ts`, `retellCallBelongsToTarget`). The phone number plays no part in what arrives.
- A switch-only commit already exists and was already used by the Resume path: `POST /v1/monitoring/start` seals the key, flips the switch, and registers an unregistered platform agent by itself (ADR-0015: watching one means registering it).

The phone step existed because the monitoring goal rode the connection-save machinery (`pullWithConnection`). That also meant two side effects nobody asked for: a voice agent with **no routed number could not be monitored at all** ("no phone numbers available", disabled), and every monitoring-only setup silently created a phone simulation lane.

## What changed

- `agent-setup-flow.ts`: the Retell monitoring plan now carries `pullWithoutConnection` — it writes no connection, and `stepAfterRetellAgent` returns `null` so the agent choice is the last step. The picker admits every voice agent for that plan, routed number or not.
- `connect-sheet.tsx`: the agent step's primary action becomes **Start monitoring**, wired to a shared `startRetellMonitoringWatch` helper around the one `startMonitoring` commit. With an egma agent in context it spends the stored key (`watch: [{agentId, platformAgentId}]` — the Resume path, unchanged on the wire); without one it sends `{platformAgentId, name}` and the server registers or recognizes the agent. Picker copy drops the phone counts and the "needs one of the phone numbers" sentence for this goal.
- **Unchanged:** Simulation and Both walks (Both still takes the number chooser — its simulation phone lane needs the connection, and that save still starts pulling), the LiveKit flows, and every server route.

## Behavior notes

- A Retell voice agent with zero routed phone numbers can now be monitored.
- A monitoring-only setup no longer creates a phone connection, so it no longer makes the Simulation column read "Configured" as a side effect — the agent shows monitoring on, simulation not configured, which is now the truth.

## Proof

- `vitest run --project fast apps/web/test` — 32 files, 689 tests green (includes the rewritten monitoring-goal walks: finish on the agent step, `/v1/monitoring/start` body with `{platformAgentId, name}`, no `/v1/agents` registration POST, no `/connections` write; the no-phone agent selectable for Monitoring and still disabled for Both).
- `pnpm typecheck` and `pnpm lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790823237&installation_model_id=431960&pr_number=289&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F289&signature=428a61af4ebbf877a17d6f593dba2f43a63151f24dae27eb0078565e9b02c896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR lets Retell monitoring finish immediately after agent selection without requiring or creating a phone connection.
- Adds a connection-free monitoring setup plan for Retell.
- Starts monitoring through the existing monitoring endpoint and supports server-side agent registration.
- Keeps phone selection for combined monitoring and simulation setup.
- Updates flow and page tests for routed and unrouted voice agents.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/agents/connect-sheet.tsx | Finishes Retell monitoring at agent selection and delegates registration or activation to the monitoring endpoint. |
| apps/web/lib/agent-setup-flow.ts | Adds a connection-free Retell monitoring plan while retaining connection requirements for simulation and combined setup. |
| apps/web/test/agent-setup-flow.test.ts | Updates setup-plan and transition coverage for connection-free monitoring. |
| apps/web/test/agents-pages.test.tsx | Covers direct monitoring startup, absence of connection writes, and monitoring of voice agents without routed numbers. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Choose monitoring goal] --> B[Select Retell voice agent]
  B --> C[Start monitoring request]
  C --> D{Egma agent exists?}
  D -->|Yes| E[Enable production pulling]
  D -->|No| F[Register agent and enable pulling]
  E --> G[Return to Agents page]
  F --> G
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Start Retell monitoring without a phone ..."](https://github.com/egma-ai/egma/commit/9007834f1413383c6b5ac8238a589c88043456af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58893153)</sub>

**Context used:**

- Knowledge Base — [Web application](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/web-application.md)

<!-- /greptile_comment -->