### PR TITLE
Stop refusing a mocked tool call on its signature

### DIFF
--- a/apps/api/src/routes/mock-endpoint.ts
+++ b/apps/api/src/routes/mock-endpoint.ts
@@ -50,32 +50,46 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
  *    temporary version serves every override.
  *
  * Everything else is refused, and **each refusal is its own answer**: a dead
- * run, a foreign simulation, an uncovered tool and a bad signature are four
- * different things and are never collapsed into one.
+ * run, a foreign simulation and an uncovered tool are three different things
+ * and are never collapsed into one. All three are a 404, because all three say
+ * the same thing about the address: it names nothing this endpoint will answer.
  *
- * ## The signature, and the guess inside it
+ * **Those three gates are the whole of the authentication**, and the secret
+ * they rest on is the address itself. The request arrives from the customer's
+ * platform carrying no credential of egma's, so what stands in for one is a run
+ * identifier and a simulation identifier that nobody can guess, both of which
+ * have to name the same live run before a single word about the mocked world is
+ * said.
  *
- * Where the platform signs one of these requests, it is verified over the raw
- * bytes that arrived with **the agent's own sealed platform key** — the key the
- * customer stored for this agent.
+ * ## The signature: a guess, its falsification, and the ruling
  *
- * **That choice is a guess, and it is written down as one.** Retell's *webhook*
- * signatures are made with a dedicated webhook-signing key, which is a
- * different value from every management key on the same account — proven by
- * hand on 2026-08-27, after the management key failed to verify a real webhook.
- * Whether a **custom-function** call is signed with that same webhook key, with
- * the management key, or not signed at all is not known, and nothing here may
- * pretend otherwise.
+ * Retell signs a custom-function call with `X-Retell-Signature`, an HMAC-SHA256
+ * over the raw bytes of the body. This file used to **refuse** a signature that
+ * did not verify against the agent's own sealed platform key — the key the
+ * customer connected — and its header said in as many words that the choice of
+ * key was a guess.
  *
- * So the check is conditional in the direction that fails safe for the product:
- * a signature that is present must verify, and a request that carries none is
- * admitted on the strength of the two unguessable identifiers and the liveness
- * gate. If the guess is wrong, the symptom is a wall of `bad_signature`
- * refusals rather than a silent hole — and the refusal names which key was
- * tried and which one to try instead, so whoever sees that wall knows what they
- * are looking at. The question is on the developer's live checklist beside the
- * fork check, in `packages/retell/README.md`; when it is answered, either this
- * reads a different key or the header becomes required.
+ * **The guess was wrong, and a live run falsified it on 2026-08-31.** Every
+ * mocked tool call a real Retell agent made to this endpoint failed with
+ * `bad_signature`, and the agent apologised for a broken backend on every one
+ * of them. Retell signs these calls with the account's **webhook-badge** key —
+ * the one wearing the Webhook badge on the dashboard's API Keys page — which is
+ * a different value from the key the customer connected and from every other
+ * management key on the account. Egma is never handed that key, cannot list it
+ * over the API, and has nowhere to keep it. Probed against the live account and
+ * confirmed by the developer the same day.
+ *
+ * **The ruling (Naman, 2026-08-31): the signature is never refused on.** The
+ * three gates above carry the authentication and lose nothing by it. The header
+ * is still read, and a signature that does not match the key egma does hold is
+ * written down as one note — never a refusal — so that the day some account
+ * signs with a key egma holds is a day somebody can measure rather than guess
+ * at. Neither the key nor the signature is ever written into that note.
+ *
+ * The five-minute freshness window went out with the refusal. A replay window
+ * earns its keep by refusing a replay, and nothing here refuses; reporting a
+ * stale timestamp as a mismatch would only make the one measurement this is
+ * kept for less true.
  *
  * ## The record
  *
@@ -106,42 +120,21 @@ export function mockToolBase(baseUrl: string): string {
   return `${baseUrl.replace(/\/+$/u, "")}${MOCK_TOOL_PREFIX}`;
 }
 
-/** The header the platform signs these requests with, where it signs them. */
+/**
+ * The header the platform signs these requests with, where it signs them.
+ *
+ * Read and noted, never refused on — the header at the top of this file says
+ * why.
+ */
 export const SIGNATURE_HEADER = "x-retell-signature";
 
-/**
- * How old a signed request may be, in milliseconds.
- *
- * The platform's own window. A replay of a signed request outside it is
- * refused on the signature, which is the only thing that makes a signature
- * worth checking at all.
- */
-export const SIGNATURE_WINDOW_MILLISECONDS = 5 * 60 * 1000;
-
-/** How each refusal names itself, so four different things stay four. */
+/** How each refusal names itself, so three different things stay three. */
 export const MOCK_TOOL_REFUSALS = [
   "no_live_run",
   "simulation_not_in_run",
   "tool_not_mocked",
-  "bad_signature",
 ] as const;
 export type MockToolRefusal = (typeof MOCK_TOOL_REFUSALS)[number];
-
-/**
- * What a badly signed request is told.
- *
- * It names the key Egma tried and the one to try instead, because the failure
- * this sentence most likely describes is not an attack: it is Egma having
- * guessed wrong about which key Retell signs a custom-function call with. A
- * developer meeting a wall of these needs to know that in the first sentence,
- * not after reading the source.
- */
-const WRONG_SIGNING_KEY =
-  "this request's signature was not made with the Retell API key stored for " +
-  "this agent, which is the key Egma checks against. If every mocked tool " +
-  "call is failing this way, Retell is probably signing these requests with " +
-  "the account's separate webhook-signing key — the one carrying the Webhook " +
-  "badge in the Retell dashboard's API Keys page — which is a different value.";
 
 export type MockEndpointOptions = {
   /**
@@ -169,18 +162,20 @@ const sleep = (milliseconds: number): Promise<void> =>
       });
 
 /**
- * Whether a signature the platform sent is this request's.
+ * Whether a signature that arrived was made with the key egma holds.
  *
  * `v={milliseconds},d={hex}`, where the digest is an HMAC-SHA256 of the raw
  * body followed by the timestamp. The raw body, always: a body that has been
- * parsed and re-serialised is different bytes, and a check over different bytes
- * is a check of nothing.
+ * parsed and re-serialised is different bytes, and a comparison over different
+ * bytes is a comparison of nothing.
+ *
+ * **Nothing turns on the answer except one log line.** It is not a gate, and
+ * there is no freshness window in it — see the ruling at the top of this file.
  */
-export function signatureIsValid(
+function signatureMatchesKey(
   header: string,
   rawBody: string,
   key: string,
-  now: number,
 ): boolean {
   const parts = new Map<string, string>();
   for (const piece of header.split(",")) {
@@ -193,9 +188,6 @@ export function signatureIsValid(
   const digest = parts.get("d");
   if (timestamp === undefined || digest === undefined) return false;
   if (!/^\d+$/u.test(timestamp) || !/^[0-9a-f]+$/iu.test(digest)) return false;
-  if (Math.abs(now - Number(timestamp)) > SIGNATURE_WINDOW_MILLISECONDS) {
-    return false;
-  }
 
   const expected = createHmac("sha256", key)
     .update(`${rawBody}${timestamp}`)
@@ -205,7 +197,13 @@ export function signatureIsValid(
   return sent.length === mine.length && timingSafeEqual(sent, mine);
 }
 
-/** The signature a caller would have to send. Exported for the tests only. */
+/**
+ * The signature a platform signing with this key would send.
+ *
+ * Exported for the tests only: nothing a caller sends changes what this
+ * endpoint answers, so this builds the two cases the note is about — one that
+ * matches the key egma holds and one that does not.
+ */
 export function signatureFor(
   rawBody: string,
   key: string,
@@ -322,13 +320,19 @@ async function record(
   }
 }
 
+/**
+ * Say no, and say which no it is.
+ *
+ * Always a 404: every refusal left here is the same kind of thing, an address
+ * naming something this endpoint will not answer for. The name in the body is
+ * what tells the three of them apart.
+ */
 function refuse(
   reply: FastifyReply,
-  status: number,
   refusal: MockToolRefusal,
   sentence: string,
 ): FastifyReply {
-  return reply.code(status).send({ refusal, error: sentence });
+  return reply.code(404).send({ refusal, error: sentence });
 }
 
 export async function mockEndpointRoutes(
@@ -380,9 +384,9 @@ export async function mockEndpointRoutes(
     // are written down as the JSON object they are — because every reader of a
     // tool call's arguments parses this column as JSON, and one row that was a
     // query string instead would be the row that breaks them. The **signature**
-    // is a separate matter and is still checked over the raw body, which on a
-    // GET is empty; conflating the two would be checking a signature over bytes
-    // that never travelled.
+    // is a separate matter and is still compared over the raw body, which on a
+    // GET is empty; conflating the two would be comparing a signature against
+    // bytes that never travelled.
     const heardArguments =
       request.method === "GET"
         ? JSON.stringify(request.query ?? {})
@@ -399,7 +403,6 @@ export async function mockEndpointRoutes(
     if (target === undefined || !target.runIsLive) {
       return refuse(
         reply,
-        404,
         "no_live_run",
         "this address does not name a run Egma is conducting right now.",
       );
@@ -410,34 +413,31 @@ export async function mockEndpointRoutes(
     if (simulation === undefined) {
       return refuse(
         reply,
-        404,
         "simulation_not_in_run",
         "this address names a simulation that is not part of that run.",
       );
     }
 
-    // The signature, **before** the tool is looked up, and before anything is
-    // written down.
+    // The signature: read here, and refused on nowhere.
     //
-    // Both halves of that order are load-bearing. Checking it after gate three
-    // would answer a badly signed call about an uncovered tool with
-    // `tool_not_mocked`, which is a sentence about the mocked world sent to
-    // somebody who has not authenticated. And writing the record first would
-    // let anyone holding the two identifiers spray `refused` spans carrying any
-    // tool name they liked, by sending a signature that was never going to
-    // verify.
+    // Retell signs these with the account's webhook-badge key, which egma is
+    // never handed — falsified live on 2026-08-31, when every mocked tool call
+    // on a real agent came back `bad_signature`. So a signature that does not
+    // match is the ordinary case and says nothing at all about the caller: the
+    // two gates above are what admitted this request.
     //
-    // A request carrying no signature at all is admitted on the two unguessable
-    // identifiers and the liveness gate — see the note at the top of this file
-    // for why the check is conditional rather than required.
+    // What is left is a measurement. One note, so that the day an account signs
+    // with a key egma holds is a day somebody can count rather than assume.
+    // Neither the key nor the signature goes into it.
     const signature = request.headers[SIGNATURE_HEADER];
     if (typeof signature === "string" && signature.trim() !== "") {
       const key = target.signingKey;
-      if (
-        key === null ||
-        !signatureIsValid(signature, rawBody, key, Date.now())
-      ) {
-        return refuse(reply, 401, "bad_signature", WRONG_SIGNING_KEY);
+      if (key === null || !signatureMatchesKey(signature, rawBody, key)) {
+        request.log.info(
+          { runId: target.runId, keyHeld: key !== null },
+          "a mocked tool call's signature did not match the platform key held " +
+            "for this agent",
+        );
       }
     }
 
@@ -464,7 +464,6 @@ export async function mockEndpointRoutes(
       );
       return refuse(
         reply,
-        404,
         "tool_not_mocked",
         "this simulation has no answer for that tool.",
       );

--- a/apps/api/test/mock-endpoint.test.ts
+++ b/apps/api/test/mock-endpoint.test.ts
@@ -76,11 +76,33 @@ const CONDUCTOR = "sim-under-test";
 /** Every delay the endpoint was asked to wait out, in the order it asked. */
 let waited: number[] = [];
 
+/** Every line this instance logged, for the claims about the one note. */
+let logged: string[] = [];
+
+/**
+ * The one note egma keeps about a signature, matched on its own words.
+ *
+ * The signature refuses nothing any more, so the note is the whole of what a
+ * test can see about it — and a substring is what the log gives a reader,
+ * rather than reaching into anything private.
+ */
+const SIGNATURE_NOTE = "signature did not match";
+
+function signatureNotes(): string[] {
+  return logged.filter((line) => line.includes(SIGNATURE_NOTE));
+}
+
 async function anInstance(label: string): Promise<void> {
   waited = [];
+  logged = [];
   api = await createApi(label, {
     traceStore: true,
     retellFetch: RETELL_CHAT_FETCH,
+    logTo: {
+      write: (line) => {
+        logged.push(line);
+      },
+    },
     mockToolWait: async (milliseconds: number) => {
       waited.push(milliseconds);
     },
@@ -506,35 +528,66 @@ describe("a tool the customer wrote as a GET", () => {
     expect((uncovered.json as { refusal: string }).refusal).toBe(
       "tool_not_mocked",
     );
-
-    // A GET carries no body, so the platform signs the timestamp alone — and a
-    // signature made with the wrong key still refuses as its own thing.
-    const badly = await call(
-      {
-        runId: ready.runId,
-        simulationId: ready.simulationId,
-        toolName: "get_availability",
-      },
-      { ...asGet, signature: signatureFor("", "not-the-agents-key", Date.now()) },
-    );
-    expect(badly.statusCode).toBe(401);
-    expect((badly.json as { refusal: string }).refusal).toBe("bad_signature");
-
-    // And one made with the right key over that same empty body is admitted.
-    const properly = await call(
-      {
-        runId: ready.runId,
-        simulationId: ready.simulationId,
-        toolName: "get_availability",
-      },
-      { ...asGet, signature: signatureFor("", PLATFORM_KEY, Date.now()) },
-    );
-    expect(properly.statusCode, properly.raw).toBe(200);
   });
 });
 
+/**
+ * The signature: read, and refused on nowhere.
+ *
+ * Retell signs a custom-function call with the account's webhook-badge key,
+ * which egma is never handed — falsified live on 2026-08-31, when every mocked
+ * tool call a real agent made here came back `bad_signature` and the agent
+ * apologised for a broken backend on every one. So what is proved here is that
+ * a signature can no longer change what the endpoint answers, and that the one
+ * note egma keeps about it is written when it does not match and not when it
+ * does.
+ */
 describe("the signature", () => {
-  it("admits a request signed with the key egma holds for the agent", async () => {
+  it("answers a call signed with a key egma does not hold, and notes it", async () => {
+    const ready = await aRunningSimulation("mock_endpoint_other_key");
+    const body = JSON.stringify({ service: "facial" });
+
+    const answered = await call(
+      {
+        runId: ready.runId,
+        simulationId: ready.simulationId,
+        toolName: "get_availability",
+      },
+      { body, signature: signatureFor(body, "not-the-agents-key", Date.now()) },
+    );
+
+    // This is what every live mocked call looks like today, and it must be the
+    // mock's answer rather than a wall of refusals.
+    expect(answered.statusCode, answered.raw).toBe(200);
+    expect(answered.json).toEqual({ slots: ["Tuesday 14:00"] });
+
+    // The record says the mock answered, the same as any other call.
+    const spans = await toolSpansOf(ready.simulationId);
+    expect(spans).toHaveLength(1);
+    expect(JSON.parse(spans[0]!.payload)["egma.tool.provenance"]).toBe("mocked");
+
+    // And one note, so the day an account signs with a key egma holds can be
+    // counted rather than assumed. Neither the key nor the signature is in it.
+    expect(signatureNotes()).toHaveLength(1);
+    expect(logged.join("\n")).not.toContain(PLATFORM_KEY);
+  });
+
+  it("answers a call carrying no signature at all, and notes nothing", async () => {
+    const ready = await aRunningSimulation("mock_endpoint_unsigned");
+
+    const answered = await call({
+      runId: ready.runId,
+      simulationId: ready.simulationId,
+      toolName: "get_availability",
+    });
+
+    expect(answered.statusCode, answered.raw).toBe(200);
+    expect(answered.json).toEqual({ slots: ["Tuesday 14:00"] });
+    // Nothing arrived to compare, so there is nothing to write down.
+    expect(signatureNotes()).toHaveLength(0);
+  });
+
+  it("notes nothing when the signature does match the key egma holds", async () => {
     const ready = await aRunningSimulation("mock_endpoint_signed");
     const body = JSON.stringify({ service: "facial" });
 
@@ -546,57 +599,13 @@ describe("the signature", () => {
       },
       { body, signature: signatureFor(body, PLATFORM_KEY, Date.now()) },
     );
-    expect(answered.statusCode).toBe(200);
+
+    expect(answered.statusCode, answered.raw).toBe(200);
+    // The measurement the note exists for: silence is a match.
+    expect(signatureNotes()).toHaveLength(0);
   });
 
-  it("refuses one signed with another key, distinctly, and writes nothing", async () => {
-    const ready = await aRunningSimulation("mock_endpoint_bad_signature");
-    const body = JSON.stringify({ service: "facial" });
-
-    const refused = await call(
-      {
-        runId: ready.runId,
-        simulationId: ready.simulationId,
-        toolName: "get_availability",
-      },
-      { body, signature: signatureFor(body, "not-the-agents-key", Date.now()) },
-    );
-    expect(refused.statusCode).toBe(401);
-    expect((refused.json as { refusal: string }).refusal).toBe("bad_signature");
-    // The refusal never repeats the key it checked against — and it names which
-    // key that was, because the likeliest cause of a wall of these is Egma
-    // having guessed the wrong one rather than anybody attacking anything.
-    expect(refused.raw).not.toContain(PLATFORM_KEY);
-    expect(refused.raw).toContain("webhook-signing key");
-
-    // **Nothing is written.** A caller who cannot authenticate must not be able
-    // to put rows on somebody's record: two identifiers plus a garbage
-    // signature would otherwise spray `refused` spans carrying any tool name
-    // the sender liked.
-    expect(await toolSpansOf(ready.simulationId)).toHaveLength(0);
-  });
-
-  it("is checked before the tool is looked up, so the two never blur", async () => {
-    const ready = await aRunningSimulation("mock_endpoint_signature_first");
-    const body = "{}";
-
-    // A badly signed call about a tool this simulation does not cover is a
-    // signature failure, not a sentence about the mocked world: telling an
-    // unauthenticated caller which tools are covered would be answering a
-    // question they have not earned.
-    const refused = await call(
-      {
-        runId: ready.runId,
-        simulationId: ready.simulationId,
-        toolName: "charge_card",
-      },
-      { body, signature: signatureFor(body, "not-the-agents-key", Date.now()) },
-    );
-    expect((refused.json as { refusal: string }).refusal).toBe("bad_signature");
-    expect(await toolSpansOf(ready.simulationId)).toHaveLength(0);
-  });
-
-  it("refuses a signature over different bytes than arrived", async () => {
+  it("is compared over the bytes that arrived, not a re-serialisation", async () => {
     const ready = await aRunningSimulation("mock_endpoint_body_swapped");
     const signature = signatureFor(
       JSON.stringify({ service: "facial" }),
@@ -604,7 +613,10 @@ describe("the signature", () => {
       Date.now(),
     );
 
-    const refused = await call(
+    // The right key over the wrong bytes is a mismatch, which is what keeps the
+    // note worth reading: a comparison over anything but the raw body would say
+    // "matched" about a signature that never covered this request.
+    const answered = await call(
       {
         runId: ready.runId,
         simulationId: ready.simulationId,
@@ -612,23 +624,91 @@ describe("the signature", () => {
       },
       { body: JSON.stringify({ service: "massage" }), signature },
     );
-    expect((refused.json as { refusal: string }).refusal).toBe("bad_signature");
+    expect(answered.statusCode, answered.raw).toBe(200);
+    expect(signatureNotes()).toHaveLength(1);
   });
 
-  it("refuses one signed outside the window a replay could not survive", async () => {
-    const ready = await aRunningSimulation("mock_endpoint_stale_signature");
-    const body = JSON.stringify({ service: "facial" });
-    const longAgo = Date.now() - 10 * 60 * 1000;
+  it("is compared over the empty body a GET sends", async () => {
+    const ready = await aRunningSimulation("mock_endpoint_get_signature", {
+      answer: { ok: true },
+      delayMs: 0,
+    });
+    const where = {
+      runId: ready.runId,
+      simulationId: ready.simulationId,
+      toolName: "get_availability",
+    };
 
-    const refused = await call(
+    // A GET carries no body, so the platform signs the timestamp alone.
+    const matching = await call(where, {
+      method: "GET",
+      signature: signatureFor("", PLATFORM_KEY, Date.now()),
+    });
+    expect(matching.statusCode, matching.raw).toBe(200);
+    expect(signatureNotes()).toHaveLength(0);
+
+    const other = await call(where, {
+      method: "GET",
+      signature: signatureFor("", "not-the-agents-key", Date.now()),
+    });
+    expect(other.statusCode, other.raw).toBe(200);
+    expect(signatureNotes()).toHaveLength(1);
+  });
+
+  it("opens none of the three gates, and closes none of them either", async () => {
+    const ready = await aRunningSimulation("mock_endpoint_signature_gates");
+    const body = "{}";
+    const wrongly = () => signatureFor(body, "not-the-agents-key", Date.now());
+
+    // A dead run and a foreign simulation are refused exactly as they are
+    // without a signature: the two unguessable identifiers are the secret, and
+    // nothing a caller signs with can stand in for either of them.
+    const dead = await call(
       {
-        runId: ready.runId,
+        runId: newId("run"),
         simulationId: ready.simulationId,
         toolName: "get_availability",
       },
-      { body, signature: signatureFor(body, PLATFORM_KEY, longAgo) },
+      { body, signature: wrongly() },
     );
-    expect((refused.json as { refusal: string }).refusal).toBe("bad_signature");
+    expect(dead.statusCode).toBe(404);
+    expect((dead.json as { refusal: string }).refusal).toBe("no_live_run");
+
+    const foreign = await call(
+      {
+        runId: ready.runId,
+        simulationId: newId("sim"),
+        toolName: "get_availability",
+      },
+      { body, signature: wrongly() },
+    );
+    expect(foreign.statusCode).toBe(404);
+    expect((foreign.json as { refusal: string }).refusal).toBe(
+      "simulation_not_in_run",
+    );
+
+    // And an uncovered tool is refused for the tool, which is now the only
+    // thing left to be wrong about it. The signature has no say either way.
+    const uncovered = await call(
+      {
+        runId: ready.runId,
+        simulationId: ready.simulationId,
+        toolName: "charge_card",
+      },
+      { body, signature: wrongly() },
+    );
+    expect(uncovered.statusCode).toBe(404);
+    expect((uncovered.json as { refusal: string }).refusal).toBe(
+      "tool_not_mocked",
+    );
+
+    // Egma was in the path and said no, so the record says so.
+    const spans = await toolSpansOf(ready.simulationId);
+    expect(spans).toHaveLength(1);
+    expect(spans[0]?.tool_name).toBe("charge_card");
+    expect(JSON.parse(spans[0]!.payload)["egma.tool.provenance"]).toBe(
+      "refused",
+    );
   });
 });
 

--- a/packages/db/src/access/runs.ts
+++ b/packages/db/src/access/runs.ts
@@ -2271,10 +2271,15 @@ export async function resolveSimulationStanding(
  * `resolveSimulationStanding` beside it takes none — there is no caller to
  * resolve, and the row is the authority.
  *
- * `signingKey` is the agent's sealed platform key, opened. It is used to
- * **verify** a signature the platform put on the request and for nothing else:
- * nothing on this path spends it, and it never reaches an answer, a log, or a
- * refusal.
+ * `signingKey` is the agent's sealed platform key, opened. The mock endpoint
+ * compares a signature the platform put on the request against it and writes
+ * down whether the two agreed, and does nothing else with it: nothing on this
+ * path spends it, and it never reaches an answer, a log, or a refusal.
+ *
+ * **It gates nothing.** Retell signs a custom-function call with the account's
+ * webhook-badge key, which egma is never handed — falsified live on 2026-08-31
+ * — so the comparison is an observation kept for the day that changes, and the
+ * mock endpoint's own header carries the ruling.
  *
  * `undefined` means no such run, which is the first gate's answer.
  */

--- a/packages/retell/README.md
+++ b/packages/retell/README.md
@@ -80,35 +80,33 @@ conversations it conducts.
 
 ## The live checklist
 
-Three questions can only be answered against a real Retell account, and all
-three are the developer's to answer by hand. Each finding lands, dated, in
+Three questions can only be answered against a real Retell account. One of them
+is answered below; the other two are still the developer's to answer by hand.
+Each finding lands, dated, in
 `.scratch/mock-tools/research/retell-mocking-surface.md`.
 
 **1. Does branching fork a Retell LLM?** — the command above.
 
-**2. Which key signs a custom-function call?** This one is not yet answered, and
-Egma is currently guessing. The mock endpoint verifies a request's
-`X-Retell-Signature` with **the agent's own Retell API key**, the one stored on
-the agent. But Retell's *webhook* signatures are known to use a separate
-webhook-signing key — the one wearing the **Webhook** badge in the dashboard's
-API Keys page — which is a different value from every management key on the
-same account. Whether a custom-function call uses that key, the management key,
-or is not signed at all is unknown.
+**2. Which key signs a custom-function call? — ANSWERED 2026-08-31: the
+account's webhook-signing key**, the one wearing the **Webhook** badge in the
+dashboard's API Keys page. It is a different value from the agent's own Retell
+API key, from every other management key on the account, and Egma is never
+handed it: it cannot be read back over the API, so Egma can neither hold it nor
+guess it.
 
-To answer it, run one mocked simulation and look at what arrives:
+Egma had guessed the agent's own key and refused any signature that did not
+verify against it. The first live mocked run answered the question the hard
+way — **every** mocked tool call failed on the signature, and the agent
+apologised to the caller for a broken backend on every one of them.
 
-- **No `X-Retell-Signature` header at all** — Retell does not sign these. Egma
-  already admits such requests; nothing to change.
-- **A header that verifies** — the guess was right. Make the header required.
-- **A header that does not verify** — every mocked tool call refuses with
-  `bad_signature`, and the refusal says so. Point the check at the
-  webhook-signing key instead: it is read in `resolveMockToolCall`
-  (`packages/db/src/access/runs.ts`), which today selects the agent's stored
-  Retell key.
-
-Until it is answered the endpoint fails safe rather than open: a signature that
-is present must verify, and a request carrying none is admitted on the two
-unguessable identifiers and the live-run gate.
+The ruling is that **the signature is never refused on**. What authenticates one
+of these requests is the address itself: an unguessable run identifier and an
+unguessable simulation identifier that have to name the same live run, plus the
+three gates in `apps/api/src/routes/mock-endpoint.ts` — live run, matching
+simulation, covered tool. The header is still read, and a signature that does
+not match the key Egma does hold is written to the log as one note, so the day
+some account signs with a key Egma holds is measurable rather than assumed. The
+endpoint's own file header carries the whole story.
 
 **3. Does `{{egma_simulation}}` render into a tool URL on a live *voice*
 call?** Per-call rendering into a custom-function URL is proven on a real agent


### PR DESCRIPTION
Every mocked tool call was answered 401 `bad_signature` in production: Retell signs its outgoing custom-function calls with the account's **webhook-badge API key** — a key egma never holds and cannot list — while the mock endpoint verified against the connection's stored key. The endpoint's own header had named this exact guess and predicted this exact wall; tonight's live run confirmed it (developer-verified, and probed against Retell's docs).

Ruling: the signature gate is dropped. The three real gates carry the auth exactly as before — a live run only, the simulation must belong to it, the tool must be covered — and the URL's unguessable run + simulation ids are the secret. The signature is now observed, never enforced: a present-but-mismatching signature writes one log note (`keyHeld` is a boolean; no key or signature value is ever logged, asserted in tests), so an account where it ever does match stays measurable.

Also retired with it: the replay-window check (a window that can refuse nothing measures nothing) and the stale README checklist item that described the old refusal. The contract did not move — `bad_signature` was never a public value (generate:check passes untouched).

Tests: the endpoint suite went 20 → 21 — wrong signature with a valid run answers the mock; unsigned answers; each of the three real gates still refuses a wrongly-signed call with its own reason; the note appears exactly once on a mismatch and never on a match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790825090&installation_model_id=431960&pr_number=290&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F290&signature=a62c1284380d017766df4f73888f554fde8670058009184270b3c9c8f2bccadc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR stops rejecting Retell mock-tool calls whose signatures cannot be verified with the credential Egma holds, while preserving live-run, simulation-membership, and mock-coverage gates.

- Treats signature matching as observational logging rather than authorization.
- Removes the obsolete signature freshness window and `bad_signature` refusal.
- Adds endpoint coverage for mismatched, absent, matching, and GET signatures.
- Updates persistence comments and Retell documentation to describe the revised trust model.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with the intended live-run, simulation-membership, and tool-coverage gates preserved.

The changed endpoint no longer blocks valid Retell calls on an unverifiable signature, while the remaining authorization checks and refusal behavior continue to be exercised by focused integration tests.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/src/routes/mock-endpoint.ts | Replaces signature-based refusal with non-secret mismatch logging while retaining the three resource and lifecycle gates. |
| apps/api/test/mock-endpoint.test.ts | Updates integration tests to prove signatures no longer affect authorization or responses and verifies mismatch logging behavior. |
| packages/db/src/access/runs.ts | Updates documentation around the stored Retell key; runtime target resolution remains unchanged. |
| packages/retell/README.md | Records the live signature-key finding and documents the resulting bearer-URL trust model. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Retell custom-function call] --> B{Run is live?}
    B -- No --> C[404 no_live_run]
    B -- Yes --> D{Simulation belongs to run?}
    D -- No --> E[404 simulation_not_in_run]
    D -- Yes --> F{Signature present and mismatched?}
    F -- Yes --> G[Log non-secret observation]
    F -- No --> H{Tool has a resolved mock?}
    G --> H
    H -- No --> I[Record refused span]
    I --> J[404 tool_not_mocked]
    H -- Yes --> K[Serve mock answer and record span]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Stop refusing a mocked tool call on its ..."](https://github.com/egma-ai/egma/commit/42bb6a29ed7fe9f99bde62a3f26444fca7791043) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58899354)</sub>

<!-- /greptile_comment -->