### PR TITLE
The mock endpoint no longer checks the platform's signature

### DIFF
--- a/apps/api/src/routes/mock-endpoint.ts
+++ b/apps/api/src/routes/mock-endpoint.ts
@@ -1,4 +1,4 @@
-import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { randomBytes } from "node:crypto";
 
 import {
   appendSpans,
@@ -48,8 +48,8 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
  * byte, because that same version serves the tools a test does *not* mock and
  * those calls have to authenticate exactly as production does. So on a mocked
  * call the customer's backend credentials arrive here — and nothing here reads
- * them, logs them, stores them or puts them on the record. The one header this
- * endpoint reads is the platform's own signature.
+ * them, logs them, stores them or puts them on the record. No header is read at
+ * all.
  *
  * That has a cost, and it is paid deliberately: a tool the customer wrote as a
  * **GET** carries the model's arguments in the same query string as their own
@@ -58,44 +58,29 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
  * and the provenance, and no arguments. A POST tool's arguments are its body,
  * which is Egma's to read, and they land in full.
  *
- * ## Three gates, in order
+ * ## Two gates, in order
  *
  * 1. **The simulation named belongs to a live run.** A simulation nobody has
  *    heard of and one whose run has finished are the same answer: a finished
  *    run's temporary version has been deleted, so an answer served after it
  *    would come from a world that no longer exists.
- * 2. **The signature verifies**, where the platform sent one.
- * 3. **The tool is one this simulation's own test named.** The pinned test
+ * 2. **The tool is one this simulation's own test named.** The pinned test
  *    version carries the answers, so one temporary version serves every test of
  *    the run and each simulation answers for exactly what its own test wrote.
  *
  * Everything else is refused, and **each refusal is its own answer**: a dead
- * run, an unmocked tool and a bad signature are three different things and are
- * never collapsed into one.
+ * run and an unmocked tool are two different things and are never collapsed
+ * into one.
  *
- * ## The signature, and the guess inside it
+ * ## No signature check
  *
- * Where the platform signs one of these requests, it is verified over the raw
- * bytes that arrived with **the agent's own sealed platform key** — the key the
- * customer stored for this agent.
- *
- * **That choice is a guess, and it is written down as one.** Retell's *webhook*
- * signatures are made with a dedicated webhook-signing key, which is a
- * different value from every management key on the same account — proven by
- * hand on 2026-08-27, after the management key failed to verify a real webhook.
- * Whether a **custom-function** call is signed with that same webhook key, with
- * the management key, or not signed at all is not known, and nothing here may
- * pretend otherwise.
- *
- * So the check is conditional in the direction that fails safe for the product:
- * a signature that is present must verify, and a request that carries none is
- * admitted on the strength of the unguessable simulation identifier and the
- * liveness gate. If the guess is wrong, the symptom is a wall of `bad_signature`
- * refusals rather than a silent hole — and the refusal names which key was
- * tried and which one to try instead, so whoever sees that wall knows what they
- * are looking at. The question is on the developer's live checklist beside the
- * fork check, in `packages/retell/README.md`; when it is answered, either this
- * reads a different key or the header becomes required.
+ * The request is not authenticated beyond those two gates. The simulation
+ * identifier is unguessable and answers only while its run is live. Retell does
+ * sign custom-function calls, but with the account's webhook-badged key, which
+ * is not the management key a customer stores on the agent — so a check against
+ * the stored key refused every real call (2026-09-04, on the founder's own
+ * agent), and the founder chose to drop the check rather than ask customers for
+ * a second key. Nothing about the arriving headers is read, logged, or kept.
  *
  * ## The record
  *
@@ -126,95 +111,14 @@ export function mockToolBase(baseUrl: string): string {
   return `${baseUrl.replace(/\/+$/u, "")}${MOCK_TOOL_PREFIX}`;
 }
 
-/** The header the platform signs these requests with, where it signs them. */
-export const SIGNATURE_HEADER = "x-retell-signature";
-
-/**
- * How old a signed request may be, in milliseconds.
- *
- * The platform's own window. A replay of a signed request outside it is
- * refused on the signature, which is the only thing that makes a signature
- * worth checking at all.
- */
-export const SIGNATURE_WINDOW_MILLISECONDS = 5 * 60 * 1000;
-
-/** How each refusal names itself, so three different things stay three. */
-export const MOCK_TOOL_REFUSALS = [
-  "no_live_run",
-  "tool_not_mocked",
-  "bad_signature",
-] as const;
+/** How each refusal names itself, so two different things stay two. */
+export const MOCK_TOOL_REFUSALS = ["no_live_run", "tool_not_mocked"] as const;
 export type MockToolRefusal = (typeof MOCK_TOOL_REFUSALS)[number];
-
-/**
- * What a badly signed request is told.
- *
- * It names the key Egma tried and the one to try instead, because the failure
- * this sentence most likely describes is not an attack: it is Egma having
- * guessed wrong about which key Retell signs a custom-function call with. A
- * developer meeting a wall of these needs to know that in the first sentence,
- * not after reading the source.
- */
-const WRONG_SIGNING_KEY =
-  "this request's signature was not made with the Retell API key stored for " +
-  "this agent, which is the key Egma checks against. If every mocked tool " +
-  "call is failing this way, Retell is probably signing these requests with " +
-  "the account's separate webhook-signing key — the one carrying the Webhook " +
-  "badge in the Retell dashboard's API Keys page — which is a different value.";
 
 type Params = {
   readonly simulationId: string;
   readonly toolName: string;
 };
-
-/**
- * Whether a signature the platform sent is this request's.
- *
- * `v={milliseconds},d={hex}`, where the digest is an HMAC-SHA256 of the raw
- * body followed by the timestamp. The raw body, always: a body that has been
- * parsed and re-serialised is different bytes, and a check over different bytes
- * is a check of nothing.
- */
-export function signatureIsValid(
-  header: string,
-  rawBody: string,
-  key: string,
-  now: number,
-): boolean {
-  const parts = new Map<string, string>();
-  for (const piece of header.split(",")) {
-    const at = piece.indexOf("=");
-    if (at <= 0) return false;
-    parts.set(piece.slice(0, at).trim(), piece.slice(at + 1).trim());
-  }
-
-  const timestamp = parts.get("v");
-  const digest = parts.get("d");
-  if (timestamp === undefined || digest === undefined) return false;
-  if (!/^\d+$/u.test(timestamp) || !/^[0-9a-f]+$/iu.test(digest)) return false;
-  if (Math.abs(now - Number(timestamp)) > SIGNATURE_WINDOW_MILLISECONDS) {
-    return false;
-  }
-
-  const expected = createHmac("sha256", key)
-    .update(`${rawBody}${timestamp}`)
-    .digest("hex");
-  const sent = Buffer.from(digest.toLowerCase(), "utf8");
-  const mine = Buffer.from(expected, "utf8");
-  return sent.length === mine.length && timingSafeEqual(sent, mine);
-}
-
-/** The signature a caller would have to send. Exported for the tests only. */
-export function signatureFor(
-  rawBody: string,
-  key: string,
-  now: number,
-): string {
-  const digest = createHmac("sha256", key)
-    .update(`${rawBody}${now}`)
-    .digest("hex");
-  return `v=${now},d=${digest}`;
-}
 
 /**
  * One exchange, as the record keeps it.
@@ -331,11 +235,11 @@ function refuse(
 }
 
 export async function mockEndpointRoutes(app: FastifyInstance): Promise<void> {
-  // The bytes that were sent, kept as they were sent. A signature is over the
-  // raw body, and a body Fastify parsed and something else re-serialised is
-  // different bytes. Registered inside this plugin's own scope, without
-  // `fastify-plugin`, so encapsulation keeps it away from the JSON routes —
-  // the same shape the provider adapter and the OTLP door use.
+  // The bytes that were sent, kept as they were sent: the record carries the
+  // agent's arguments exactly as they arrived, not a re-serialisation of them.
+  // Registered inside this plugin's own scope, without `fastify-plugin`, so
+  // encapsulation keeps it away from the JSON routes — the same shape the
+  // provider adapter and the OTLP door use.
   app.addContentTypeParser(
     "application/json",
     { parseAs: "string" },
@@ -396,32 +300,8 @@ export async function mockEndpointRoutes(app: FastifyInstance): Promise<void> {
     }
     const simulation = target.simulation;
 
-    // Gate two, the signature: **before** the tool is looked up, and before
-    // anything is written down.
-    //
-    // Both halves of that order are load-bearing. Checking it after gate three
-    // would answer a badly signed call about an unmocked tool with
-    // `tool_not_mocked`, which is a sentence about the mocked world sent to
-    // somebody who has not authenticated. And writing the record first would
-    // let anyone holding the identifier spray `refused` spans carrying any tool
-    // name they liked, by sending a signature that was never going to verify.
-    //
-    // A request carrying no signature at all is admitted on the unguessable
-    // identifier and the liveness gate — see the note at the top of this file
-    // for why the check is conditional rather than required.
-    const signature = request.headers[SIGNATURE_HEADER];
-    if (typeof signature === "string" && signature.trim() !== "") {
-      const key = target.signingKey;
-      if (
-        key === null ||
-        !signatureIsValid(signature, rawBody, key, Date.now())
-      ) {
-        return refuse(reply, 401, "bad_signature", WRONG_SIGNING_KEY);
-      }
-    }
-
-    // Gate three. From here on the caller has got past every gate there is, so
-    // a refusal here is about the mocked world and lands on the record.
+    // Gate two, the tool. A refusal here is about the mocked world and lands on
+    // the record.
     const served = simulation.answers.find(
       (candidate) => candidate.tool === toolName,
     );

--- a/apps/api/test/mock-endpoint.test.ts
+++ b/apps/api/test/mock-endpoint.test.ts
@@ -4,12 +4,7 @@ import { traceIdOfSimulation } from "@egma/simulation-contract";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { CLAIMS_PATH } from "../src/routes/claims.ts";
-import {
-  MOCK_TOOL_PREFIX,
-  mockToolBase,
-  signatureFor,
-  SIGNATURE_HEADER,
-} from "../src/routes/mock-endpoint.ts";
+import { MOCK_TOOL_PREFIX, mockToolBase } from "../src/routes/mock-endpoint.ts";
 import { reportPathFor } from "../src/routes/reports.ts";
 import { createApi, type TestApi } from "./support/api.ts";
 import {
@@ -232,7 +227,6 @@ async function call(
   },
   options: {
     readonly body?: string;
-    readonly signature?: string;
     /** A GET tool's arguments ride the query string, so a GET sends no body. */
     readonly method?: "GET" | "POST";
     readonly query?: string;
@@ -249,9 +243,6 @@ async function call(
     headers: {
       ...(method === "GET" ? {} : { "content-type": "application/json" }),
       ...(options.headers ?? {}),
-      ...(options.signature === undefined
-        ? {}
-        : { [SIGNATURE_HEADER]: options.signature }),
     },
     ...(method === "GET" ? {} : { payload: body }),
   });
@@ -331,7 +322,7 @@ describe("the address the transform writes", () => {
   });
 });
 
-describe("the three gates", () => {
+describe("the two gates", () => {
   it("serves the answer the test named", async () => {
     const ready = await aRunningSimulation("mock_endpoint_serves");
 
@@ -448,21 +439,14 @@ describe("a tool the customer wrote as a GET", () => {
       "tool_not_mocked",
     );
 
-    // A GET carries no body, so the platform signs the timestamp alone — and a
-    // signature made with the wrong key still refuses as its own thing.
-    const badly = await call(
+    // A GET carries no body, and nothing about it is authenticated: the
+    // identifier of a live simulation and a tool its test named are the whole
+    // of what admits it.
+    const answered = await call(
       { simulationId: ready.simulationId, toolName: "get_availability" },
-      { ...asGet, signature: signatureFor("", "not-the-agents-key", Date.now()) },
+      asGet,
     );
-    expect(badly.statusCode).toBe(401);
-    expect((badly.json as { refusal: string }).refusal).toBe("bad_signature");
-
-    // And one made with the right key over that same empty body is admitted.
-    const properly = await call(
-      { simulationId: ready.simulationId, toolName: "get_availability" },
-      { ...asGet, signature: signatureFor("", PLATFORM_KEY, Date.now()) },
-    );
-    expect(properly.statusCode, properly.raw).toBe(200);
+    expect(answered.statusCode, answered.raw).toBe(200);
   });
 });
 
@@ -526,82 +510,28 @@ describe("what the customer's own tool configuration sends along", () => {
   });
 });
 
-describe("the signature", () => {
-  it("admits a request signed with the key egma holds for the agent", async () => {
-    const ready = await aRunningSimulation("mock_endpoint_signed");
+describe("the platform's signature", () => {
+  it("is not checked: a signed call and an unsigned one are answered alike", async () => {
+    // Retell signs a custom-function call with the account's webhook-badged key,
+    // which Egma does not hold, so on 2026-09-04 a check against the agent's
+    // stored key refused every real call. The founder dropped the check. What
+    // admits a call is the identifier of a live simulation and a tool its test
+    // named — a header, any header, changes nothing.
+    const ready = await aRunningSimulation("mock_endpoint_unsigned");
     const body = JSON.stringify({ service: "facial" });
 
-    const answered = await call(
+    const signed = await call(
       { simulationId: ready.simulationId, toolName: "get_availability" },
-      { body, signature: signatureFor(body, PLATFORM_KEY, Date.now()) },
+      { body, headers: { "x-retell-signature": "v=1,d=not-a-real-digest" } },
     );
-    expect(answered.statusCode).toBe(200);
-  });
+    expect(signed.statusCode, signed.raw).toBe(200);
 
-  it("refuses one signed with another key, distinctly, and writes nothing", async () => {
-    const ready = await aRunningSimulation("mock_endpoint_bad_signature");
-    const body = JSON.stringify({ service: "facial" });
-
-    const refused = await call(
+    const unsigned = await call(
       { simulationId: ready.simulationId, toolName: "get_availability" },
-      { body, signature: signatureFor(body, "not-the-agents-key", Date.now()) },
+      { body },
     );
-    expect(refused.statusCode).toBe(401);
-    expect((refused.json as { refusal: string }).refusal).toBe("bad_signature");
-    // The refusal never repeats the key it checked against — and it names which
-    // key that was, because the likeliest cause of a wall of these is Egma
-    // having guessed the wrong one rather than anybody attacking anything.
-    expect(refused.raw).not.toContain(PLATFORM_KEY);
-    expect(refused.raw).toContain("webhook-signing key");
-
-    // **Nothing is written.** A caller who cannot authenticate must not be able
-    // to put rows on somebody's record: an identifier plus a garbage signature
-    // would otherwise spray `refused` spans carrying any tool name the sender
-    // liked.
-    expect(await toolSpansOf(ready.simulationId)).toHaveLength(0);
-  });
-
-  it("is checked before the tool is looked up, so the two never blur", async () => {
-    const ready = await aRunningSimulation("mock_endpoint_signature_first");
-    const body = "{}";
-
-    // A badly signed call about a tool this simulation does not mock is a
-    // signature failure, not a sentence about the mocked world: telling an
-    // unauthenticated caller which tools are mocked would be answering a
-    // question they have not earned.
-    const refused = await call(
-      { simulationId: ready.simulationId, toolName: "charge_card" },
-      { body, signature: signatureFor(body, "not-the-agents-key", Date.now()) },
-    );
-    expect((refused.json as { refusal: string }).refusal).toBe("bad_signature");
-    expect(await toolSpansOf(ready.simulationId)).toHaveLength(0);
-  });
-
-  it("refuses a signature over different bytes than arrived", async () => {
-    const ready = await aRunningSimulation("mock_endpoint_body_swapped");
-    const signature = signatureFor(
-      JSON.stringify({ service: "facial" }),
-      PLATFORM_KEY,
-      Date.now(),
-    );
-
-    const refused = await call(
-      { simulationId: ready.simulationId, toolName: "get_availability" },
-      { body: JSON.stringify({ service: "massage" }), signature },
-    );
-    expect((refused.json as { refusal: string }).refusal).toBe("bad_signature");
-  });
-
-  it("refuses one signed outside the window a replay could not survive", async () => {
-    const ready = await aRunningSimulation("mock_endpoint_stale_signature");
-    const body = JSON.stringify({ service: "facial" });
-    const longAgo = Date.now() - 10 * 60 * 1000;
-
-    const refused = await call(
-      { simulationId: ready.simulationId, toolName: "get_availability" },
-      { body, signature: signatureFor(body, PLATFORM_KEY, longAgo) },
-    );
-    expect((refused.json as { refusal: string }).refusal).toBe("bad_signature");
+    expect(unsigned.statusCode, unsigned.raw).toBe(200);
+    expect(signed.raw).toBe(unsigned.raw);
   });
 });
 

--- a/docs/self-hosting.mdx
+++ b/docs/self-hosting.mdx
@@ -178,14 +178,13 @@ feature that needs your Egma API to be reachable from the public internet.
   names a mock tool, keeping the API on a private network costs you nothing.
 - The endpoint answers only calls that name a simulation of a run Egma is
   conducting right now, and a tool that simulation's own test named. Everything
-  else is refused. Where Retell signs the request, Egma verifies the signature
-  with the key you stored for that agent.
+  else is refused. The simulation identifier is unguessable and stops answering
+  the moment the run ends; Egma checks nothing else about the caller.
 - **Egma drops the headers and query parameters that arrive on a mocked call,
   unread.** The temporary version keeps each tool's own headers and query
   parameters exactly as you wrote them, because that same version also serves
   the tools your tests do not name. So your backend credentials arrive at this
-  endpoint, and nothing there reads, logs, or stores them. The one header it
-  reads is the platform's signature.
+  endpoint, and nothing there reads, logs, or stores them.
 
 Egma needs the agent's Retell identity and key stored already, because it builds
 the mocked world by creating one temporary version of the agent in your Retell
@@ -193,8 +192,8 @@ account at run start and deleting it when the run ends. Your serving version is
 never changed.
 
 If you put Egma behind a reverse proxy, `/mock-tools/` has to reach the API like
-the rest of it, and the request body must arrive unchanged — the signature is
-checked over the exact bytes Retell sent.
+the rest of it, and the request body must arrive unchanged — the record keeps
+the tool's arguments as the exact bytes Retell sent.
 
 ## Production Monitoring
 

--- a/packages/db/src/access/runs.ts
+++ b/packages/db/src/access/runs.ts
@@ -2203,10 +2203,8 @@ export async function resolveSimulationStanding(
  * own run, so the pair could only ever agree or be a mistake. One identifier is
  * one gate, and the run it names comes back beside it.
  *
- * `signingKey` is the agent's sealed platform key, opened. It is used to
- * **verify** a signature the platform put on the request and for nothing else:
- * nothing on this path spends it, and it never reaches an answer, a log, or a
- * refusal.
+ * No credential rides along: the endpoint verifies nothing about the caller
+ * beyond the two gates, so the agent's sealed key is never opened on this path.
  *
  * `undefined` means no such simulation, which is the first gate's answer.
  */
@@ -2224,7 +2222,6 @@ export type MockToolCallTarget = {
     readonly answers: readonly TestMockTool[];
   };
   readonly auth: AuthContext;
-  readonly signingKey: string | null;
 };
 
 export async function resolveMockToolCall(
@@ -2243,11 +2240,9 @@ export async function resolveMockToolCall(
       runStatus: run.status,
       runFinishedAt: run.finishedAt,
       mockTools: testVersion.mockTools,
-      signingKey: agent.monitoringApiKey,
     })
     .from(simulation)
     .innerJoin(run, eq(simulation.runId, run.id))
-    .innerJoin(agent, eq(run.agentId, agent.id))
     .innerJoin(testVersion, eq(simulation.testVersionId, testVersion.id))
     .where(eq(simulation.id, simulationId))
     .limit(1);
@@ -2279,7 +2274,6 @@ export async function resolveMockToolCall(
       answers,
     },
     auth,
-    signingKey: row.signingKey === null ? null : openedApiKey(row.signingKey),
   };
 }
 

--- a/packages/retell/README.md
+++ b/packages/retell/README.md
@@ -139,29 +139,15 @@ are the developer's to answer by hand. Each finding lands, dated, in
 
 **1. Does branching fork a Retell LLM?** — the command above.
 
-**2. Which key signs a custom-function call?** This one is not yet answered, and
-Egma is currently guessing. The mock endpoint verifies a request's
-`X-Retell-Signature` with **the agent's own Retell API key**, the one stored on
-the agent. But Retell's *webhook* signatures are known to use a separate
-webhook-signing key — the one wearing the **Webhook** badge in the dashboard's
-API Keys page — which is a different value from every management key on the
-same account. Whether a custom-function call uses that key, the management key,
-or is not signed at all is unknown.
-
-To answer it, run one mocked simulation and look at what arrives:
-
-- **No `X-Retell-Signature` header at all** — Retell does not sign these. Egma
-  already admits such requests; nothing to change.
-- **A header that verifies** — the guess was right. Make the header required.
-- **A header that does not verify** — every mocked tool call refuses with
-  `bad_signature`, and the refusal says so. Point the check at the
-  webhook-signing key instead: it is read in `resolveMockToolCall`
-  (`packages/db/src/access/runs.ts`), which today selects the agent's stored
-  Retell key.
-
-Until it is answered the endpoint fails safe rather than open: a signature that
-is present must verify, and a request carrying none is admitted on the
-unguessable simulation identifier and the live-run gate.
+**2. Which key signs a custom-function call?** Answered on 2026-09-04, on the
+founder's own agent: Retell does send `X-Retell-Signature` on a custom-function
+call, and it does **not** verify against the management key stored on the agent
+— every mocked call refused with `bad_signature`. Retell's docs say only the API
+key carrying the **Webhook** badge verifies its signatures, so that is the
+signing key. The founder chose not to ask customers for a second key: the mock
+endpoint no longer checks signatures at all and admits a call on the two gates
+that remain, the unguessable simulation identifier of a live run and the tool
+being one the test named. Nothing in the arriving headers is read.
 
 **3. Does an explicit `""` render the routing prefix to nothing on a live
 *voice* call?** ADR-0022's first owed check. Retell distinguishes a variable it


### PR DESCRIPTION
## What this changes

Retell signs a custom-function call with the account's **webhook-badged** API key, not with the management key a customer stores on the agent. Egma's mock endpoint verified `X-Retell-Signature` against the stored key, so on the deployed platform every mocked tool call was refused with `bad_signature` (2026-09-04, on the founder's own agent; the routing itself worked). Rather than ask customers for a second key, the check is removed.

The endpoint keeps its two gates: the call names a simulation of a run Egma is conducting right now, and the tool is one that simulation's own test named. The simulation identifier is unguessable and stops answering when the run ends. Nothing in the arriving headers is read, and the agent's sealed Retell key is no longer opened on this path.

Also: the self-hosting page and the Retell package's live checklist record the answer to the open question of which key signs these calls.

## How it was tested

`apps/api/test/mock-endpoint.test.ts` (14 tests: a signed and an unsigned call are answered alike, the two gates, GET handling, the record), `apps/api/test/mocked-run-lifecycle.test.ts` (10), `apps/api/test/mock-tools-vocabulary.test.ts` (2). Typecheck, test typecheck, and lint clean. CI runs the whole suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791085505&installation_model_id=431960&pr_number=294&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F294&signature=387853399c38dda88ab2d1c34516ff3fcf70070c8be6be059238815dcc84f640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes Retell signature verification from the mock-tool endpoint because custom-function requests are signed with a separate key Egma does not hold. It also avoids opening the stored agent key on this path and updates tests and documentation to describe the remaining live-run and mocked-tool gates.
- Removes signature parsing, verification, replay-window enforcement, and the `bad_signature` refusal.
- Simplifies mock-target resolution by dropping the agent join and decrypted signing key.
- Updates endpoint tests to require identical behavior for signed and unsigned calls.
- Documents the endpoint’s identifier-based admission model and Retell signing-key behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defect established in the changed code.

The removed signature check intentionally replaces an unusable credential check with the documented live-run identifier and mocked-tool gates, while database constraints and lifecycle behavior preserve the validity of the simplified target query.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/src/routes/mock-endpoint.ts | Removes signature authentication and its replay window while retaining live-run and per-simulation tool checks. |
| packages/db/src/access/runs.ts | Stops joining the owning agent and decrypting its stored Retell key when resolving mock calls. |
| apps/api/test/mock-endpoint.test.ts | Replaces signature-validation coverage with explicit signed-versus-unsigned equivalence coverage. |
| docs/self-hosting.mdx | Documents that mock calls are admitted solely through the live simulation identifier and named tool. |
| packages/retell/README.md | Records the observed Retell signing-key behavior and the decision not to collect a second customer key. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Retell
  participant MockEndpoint as Egma mock endpoint
  participant DB as Run database
  participant Evidence as Span record
  Retell->>MockEndpoint: "GET/POST /mock-tools/{simulationId}/{toolName}"
  MockEndpoint->>DB: Resolve simulation and run
  alt Run is not live
    MockEndpoint-->>Retell: 404 no_live_run
  else Run is live
    MockEndpoint->>DB: Find tool in pinned test answers
    alt Tool is not mocked
      MockEndpoint->>Evidence: Append refused exchange span
      MockEndpoint-->>Retell: 404 tool_not_mocked
    else Tool is mocked
      MockEndpoint->>Evidence: Append successful exchange span
      MockEndpoint-->>Retell: Return authored mock answer
    end
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["The mock endpoint no longer checks the p..."](https://github.com/egma-ai/egma/commit/346198db48916e54400b913de94884431a0e0b5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60272683)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Platform services](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/platform-services.md)
- Knowledge Base — [Data foundations](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/data-foundations.md)
- Knowledge Base — [Database persistence](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/database-persistence.md)
- Knowledge Base — [Provider and SDK integrations](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/provider-and-sdk-integrations.md)
- Knowledge Base — [Retell integration](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/retell-integration.md)
</details>


<!-- /greptile_comment -->