### PR TITLE
Empty mock tools and env cells read None and offer their add line only when reached

### DIFF
--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -310,6 +310,8 @@ const ACTION =
  */
 const PAD = `${LANE_X} py-(--row-padding-y)`;
 const TEXT = "text-sm leading-(--line-caption) text-foreground";
+/** The same quiet line a summary is drawn in, which `None` is one of. */
+const CELL_QUIET = "text-sm leading-(--line-caption) text-faint";
 /*
  * A woken cell wears its 2px ink edge as an inset shadow rather than a border,
  * so waking one moves nothing: a border would take two pixels out of the cell
@@ -1053,6 +1055,17 @@ function jsonSaid(
 }
 
 /**
+ * What an empty JSON cell offers, which is a different thing in three places.
+ */
+type Offer =
+  /** A written row: `None` at rest, and the add line under a pointer or focus. */
+  | "reached"
+  /** The entry row, which is being authored right now: the add line, always. */
+  | "always"
+  /** A reader who cannot author: `None`, because there is nothing to offer. */
+  | "never";
+
+/**
  * What a JSON cell shows at rest: the summary, or the way to write the first one.
  *
  * Muted text rather than a chip (founder, 2026-09-03): a chip in a table lane
@@ -1062,30 +1075,59 @@ function jsonSaid(
  * **An empty cell says how to fill it** (founder, 2026-09-04). It used to be
  * blank, so the only thing that said a mock tool or an env could be written
  * here was the pointer changing shape over it — which a person has to already
- * suspect the cell is a control to find. The line is `ADD_LINE`, the same ember
- * affordance the Expected behaviors and Personas cells grow, so the four
- * writable things on a row are offered in one grammar.
+ * suspect the cell is a control to find.
  *
- * A reader who cannot author is offered nothing, because there is nothing they
- * could do with the offer. Their cell stays the summary or stays blank.
+ * **But it says it only to the row being reached for** (founder, 2026-09-04,
+ * on seeing it built). Two brand lines on every row of a full suite is a column
+ * of orange down a table whose job is to be scanned: `ADD_LINE` is an
+ * invitation, and an invitation repeated on forty rows stops being one. So a
+ * written row rests on `None` — the truthful empty state, in the same faint ink
+ * the summary beside it uses — and offers the line when a pointer is over the
+ * cell or the keyboard is in it. The entry row keeps the line at all times,
+ * because that row *is* the act of authoring.
+ *
+ * **The swap is CSS, not state.** Two spans and the button's own `group`, so a
+ * pointer crossing a suite re-renders nothing; a `useState` per cell would run
+ * React on every mouse move across the grid. The pointer half is gated to fine
+ * pointers, which is `DESIGN.md`'s rule and the reason `pointer-hover` exists —
+ * on a touch screen `:hover` sticks after a tap and would leave the line up on
+ * the row somebody just pressed. The focus half is not gated, because a
+ * keyboard is a keyboard on every device.
  */
 function JsonSummary({
   field,
   test,
-  add,
+  offer,
 }: {
   readonly field: JsonField;
   readonly test: Pick<Draft, "mockTools" | "env">;
-  /** Whether an empty cell offers to be filled, which only an author may do. */
-  readonly add: boolean;
+  readonly offer: Offer;
 }) {
   const said = jsonSaid(field, test);
-  if (said !== "") {
-    return <span className="text-sm leading-(--line-caption) text-faint">{said}</span>;
-  }
-  return add ? (
-    <span className={ADD_LINE}>{`+ ${JSON_FIELD[field].add}`}</span>
-  ) : null;
+  if (said !== "") return <span className={CELL_QUIET}>{said}</span>;
+  const add = `+ ${JSON_FIELD[field].add}`;
+  if (offer === "always") return <span className={ADD_LINE}>{add}</span>;
+  if (offer === "never") return <span className={CELL_QUIET}>None</span>;
+  return (
+    <>
+      <span
+        className={cn(
+          CELL_QUIET,
+          "group-pointer-hover/json:hidden group-focus-visible/json:hidden",
+        )}
+      >
+        None
+      </span>
+      <span
+        className={cn(
+          ADD_LINE,
+          "hidden group-pointer-hover/json:inline group-focus-visible/json:inline",
+        )}
+      >
+        {add}
+      </span>
+    </>
+  );
 }
 
 /**
@@ -1850,14 +1892,21 @@ export function TestsGrid(props: GridProps) {
           <button
             className={cn(
               PAD,
-              "block w-full cursor-pointer bg-transparent text-left",
+              /*
+               * Named, the way every other group in the product is: an
+               * unnamed one is claimed by whatever group wraps this cell next,
+               * and a table row is exactly the place that happens.
+               */
+              "group/json block w-full cursor-pointer bg-transparent text-left",
             )}
             type="button"
             /*
-             * The name follows what the cell shows, because the cell shows
-             * words now: a button reading "+ Add env variables" announced as
-             * "Env for Books service" is the one control on the row whose
-             * spoken name does not contain its written one.
+             * **The name says what pressing does, whichever word is showing.**
+             * At rest the cell reads `None`, which is the value rather than
+             * the control: a button announced as "None" tells a screen reader
+             * nothing about what it is for. So the name stays the verb, and
+             * the moment focus reaches the cell the written line becomes the
+             * same words.
              */
             aria-label={
               said === ""
@@ -1866,11 +1915,11 @@ export function TestsGrid(props: GridProps) {
             }
             onClick={() => openJson(test, field)}
           >
-            <JsonSummary field={field} test={test} add />
+            <JsonSummary field={field} test={test} offer="reached" />
           </button>
         ) : (
           <div className={PAD}>
-            <JsonSummary field={field} test={test} add={false} />
+            <JsonSummary field={field} test={test} offer="never" />
           </div>
         )}
       </td>
@@ -2007,7 +2056,7 @@ export function TestsGrid(props: GridProps) {
             }
             onClick={() => openJson(null, field)}
           >
-            <JsonSummary field={field} test={entry} add />
+            <JsonSummary field={field} test={entry} offer="always" />
           </button>
         </td>
       );

--- a/apps/web/test/test-suites-pages.test.tsx
+++ b/apps/web/test/test-suites-pages.test.tsx
@@ -1293,38 +1293,60 @@ describe("the suite-first Tests route", () => {
     expect(screen.getByText("1 mock tool")).toBeTruthy();
 
     /*
-     * And the second row's empty Env cell offers to be filled rather than
-     * sitting blank until somebody happens to press it. The offer is the
-     * button's spoken name too, so what it says and what it is called agree.
+     * And the second row's empty Env cell says `None` rather than sitting
+     * blank — the truthful empty state, in the summary's own faint ink. The
+     * brand offer is in the cell too and hidden until a pointer or the
+     * keyboard reaches it, so a full suite is not a column of orange. The
+     * button's spoken name stays the verb either way, because `None` is the
+     * value rather than a name for the control.
      */
     const second = screen.getByRole("button", {
       name: "Add env variables for Cancels service",
     });
-    expect(second.textContent).toBe("+ Add env variables");
+    const resting = within(second).getByText("None");
+    expect(resting.className).toContain("text-faint");
+    expect(resting.className).toContain("group-pointer-hover/json:hidden");
+    expect(resting.className).toContain("group-focus-visible/json:hidden");
+    const offer = within(second).getByText("+ Add env variables");
+    expect(offer.className).toContain("text-primary");
+    expect(offer.className).toContain("hidden");
+    expect(offer.className).toContain("group-pointer-hover/json:inline");
+    expect(offer.className).toContain("group-focus-visible/json:inline");
+    // The cell is the group both of them read.
+    expect(second.className).toContain("group/json");
+
     fireEvent.click(second);
     expect(await screen.findByRole("dialog", { name: "Env" })).toBeTruthy();
   });
 
   /**
-   * **An empty JSON cell says how to fill it, in every row that has one.**
+   * **An empty JSON cell says how to fill it — quietly in a written row, and
+   * out loud in the row being written.**
    *
    * The cells used to be blank until a pointer went over them, so the only
    * thing saying a mock tool or an env could be written here was the cursor
-   * changing shape. The line is the ember affordance the Expected behaviors
-   * and Personas cells already grow (founder, 2026-09-04).
+   * changing shape. Offering in brand on every row was the other extreme: two
+   * orange lines down a suite of forty tests, in a table whose job is to be
+   * scanned. A written row rests on `None` and offers when it is reached for;
+   * the entry row offers always, because that row is the authoring (founder,
+   * 2026-09-04).
    */
-  it("offers the add line in an existing row and in the entry row, and each opens its dialog", async () => {
+  it("keeps the add line quiet in a written row and plain in the entry row, and each opens its dialog", async () => {
     gridAnswers({ tests: [testBody({ personas: [PERSONA] })] });
 
     render(<TestSuitePage />);
 
     expect(await screen.findByText("Books service")).toBeTruthy();
 
-    // The written row holds neither, so both cells offer.
+    // The written row holds neither, so both cells rest on `None`.
     const rowMockTools = screen.getByRole("button", {
       name: "Add mock tools for Books service",
     });
-    expect(rowMockTools.textContent).toBe("+ Add mock tools");
+    expect(within(rowMockTools).getByText("None")).toBeTruthy();
+    expect(
+      within(rowMockTools).getByText("+ Add mock tools").className,
+    ).toContain("hidden");
+    // Pressing it opens the same dialog whichever word was showing.
     fireEvent.click(rowMockTools);
     const opened = await screen.findByRole("dialog", { name: "Mock tools" });
     fireEvent.click(within(opened).getByRole("button", { name: "Cancel" }));
@@ -1332,15 +1354,20 @@ describe("the suite-first Tests route", () => {
       expect(screen.queryByRole("dialog", { name: "Mock tools" })).toBeNull();
     });
 
-    // And the row being written offers the same two lines, in the same words.
+    // And the row being written offers the same two lines with nothing hiding
+    // them, and says no `None`: nothing about that row is settled yet.
     fireEvent.click(screen.getByRole("button", { name: "+ Write a test" }));
     const entry = await waitFor(() => {
       const held = document.querySelector("tr[data-entry-row]");
       if (held === null) throw new Error("no entry row yet");
       return held as HTMLTableRowElement;
     });
-    expect(within(entry).getByText("+ Add mock tools")).toBeTruthy();
-    expect(within(entry).getByText("+ Add env variables")).toBeTruthy();
+    for (const line of ["+ Add mock tools", "+ Add env variables"]) {
+      const said = within(entry).getByText(line);
+      expect(said.className).toContain("text-primary");
+      expect(said.className).not.toContain("hidden");
+    }
+    expect(within(entry).queryByText("None")).toBeNull();
 
     fireEvent.click(
       within(entry).getByRole("button", { name: "Add env variables for the new test" }),
@@ -1348,6 +1375,26 @@ describe("the suite-first Tests route", () => {
     expect(await screen.findByRole("dialog", { name: "Env" })).toBeTruthy();
     // Nothing is written by opening a dialog from a row that does not exist.
     expect(sent.some((request) => request.method === "POST")).toBe(false);
+  });
+
+  it("shows a reader who cannot author the empty state and no offer at all", async () => {
+    gridAnswers({ role: "viewer", tests: [testBody({ personas: [PERSONA] })] });
+
+    render(<TestSuitePage />);
+
+    expect(await screen.findByText("Books service")).toBeTruthy();
+    // Both JSON cells say the same true thing about the row they are in.
+    expect(screen.getAllByText("None")).toHaveLength(2);
+    /*
+     * And there is no offer in the cell, hidden or otherwise: a line inviting
+     * somebody to write what their role cannot write is an invitation to a
+     * refusal. The cell is not even a button.
+     */
+    expect(screen.queryByText("+ Add mock tools")).toBeNull();
+    expect(screen.queryByText("+ Add env variables")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /^(Add|Mock tools|Env)/ }),
+    ).toBeNull();
   });
 
   /**


### PR DESCRIPTION
## What this changes

On the tests sheet, an empty Mock tools or Env cell in a written row reads **None** in the muted summary colour. Hovering it with a fine pointer, or focusing it with the keyboard, swaps it to **+ Add mock tools** / **+ Add env variables** in brand. The swap is pure CSS (the repo's `pointer-hover` variant plus `focus-visible`), so a touch tap leaves nothing stuck and nothing re-renders on hover. The entry row keeps its brand add lines. A reader who cannot author sees "None" where they saw a blank.

Founder's pick, option 1, after seeing brand add lines on every row.

## Tests

`apps/web/test/test-suites-pages.test.tsx`: 51 pass (one new case for the reader who cannot author). Web typecheck and lint clean. The hover reveal is verified as compiled CSS and class names; jsdom cannot exercise `:hover`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791139076&installation_model_id=431960&pr_number=296&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F296&signature=56e03ea91d883d5708edaba66e37a78ae0d4bfc4fd175d918e8ae7ab28d1bfb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes empty Mock tools and Env cells so completed editable rows show a muted `None` until hovered or keyboard-focused, while entry rows retain persistent add actions and viewer rows remain non-interactive.

- Adds explicit reached, always, and never presentation modes for empty JSON cells.
- Uses named-group pointer and focus variants to reveal authoring actions without React state.
- Expands tests for editable-row presentation, entry-row behavior, and viewer permissions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete correctness, accessibility, permission, or security failure identified.

The presentation modes preserve existing author actions, keep viewer cells non-interactive, and retain explicit accessible labels while changing only how empty values are displayed.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/tests/tests-grid.tsx | Introduces role- and row-sensitive empty-cell presentation while preserving existing dialog actions and accessible button labels. |
| apps/web/test/test-suites-pages.test.tsx | Updates assertions for the CSS reveal classes and adds coverage ensuring viewers see only non-interactive empty states. |

<sub>Reviews (1): Last reviewed commit: ["An empty mock tools or env cell reads &quot;N..."](https://github.com/egma-ai/egma/commit/d0b070057ae750c5382f5841e426586b7ee7acc2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60523845)</sub>

<!-- /greptile_comment -->