### PR TITLE
fix(simulator): follow up twice and end silent voice calls normally

### DIFF
--- a/apps/simulator/src/egma_simulator/conductor.py
+++ b/apps/simulator/src/egma_simulator/conductor.py
@@ -56,11 +56,9 @@ from .conversation import (
     AGENT_ENDED,
     CANCEL_DIRECTIVE,
     PERSONA_CONCLUDED,
-    SAID_NOTHING,
     Conducted,
     ConversationControls,
     Ending,
-    SilentAgent,
     duration_limit_reached,
     turn_limit_reached,
 )
@@ -103,17 +101,6 @@ PERSONA_ENDED_SILENCE: Ending = (
     "persona_concluded",
     "the agent did not respond after two persona follow-ups",
 )
-
-ASKED_BEFORE_A_SILENCE_COUNTS = 2
-"""How many persona turns an agent must go quiet through before its
-silence is read as a failure rather than an ending.
-
-Only for the case where the agent took no turn at all. Two, because one
-persona turn is what a spec whose turn limit is one produces on its own —
-the persona speaks, the budget is spent, and the agent never had a
-chance. A limit is deliberate and is never the agent failing, so that run
-keeps its own ending. By the second turn nothing else explains the quiet.
-"""
 
 OnUtterance = Callable[[str, str, int, int], Awaitable[None]]
 OnMeasured = Callable[[str, int, int], Awaitable[None]]
@@ -925,56 +912,15 @@ class VoiceConductor:
             await self.close()
 
         if controls.cause == CANCEL_DIRECTIVE:
-            # A directive is somebody's own act, so it is answered before
-            # the silence below is even looked at: a run stopped on
-            # purpose is not a run that failed, whatever it had heard.
             return Conducted(
                 status="canceled",
                 ending="canceled",
                 reason=None,
                 provider_reference=self.provider_reference,
             )
-        self._refuse_a_silence()
         if controls.cause is not None:
             return self._ended(duration_limit_reached(max_duration_seconds))
         return self._ended(self._ending or turn_limit_reached(max_turns))
-
-    def _refuse_a_silence(self) -> None:
-        """A conversation the agent said no word in is a failure, not an ending.
-
-        Ahead of every deliberate ending on purpose. The endings below all
-        describe a conversation — the persona concluded one, the agent
-        ended one, a limit cut one short — and a call the agent was silent
-        through is none of those. It reported itself as one, and the
-        grader judged the silence as a finished conversation.
-
-        The bar is that the agent **had a real chance and said nothing**,
-        which is two shapes:
-
-        - it took turns, and every one of them was wordless. Whatever it
-          was doing, none of it reached the transcript, so there is
-          nothing for a grader to read.
-        - it took no turn at all, and the persona got through
-          :data:`ASKED_BEFORE_A_SILENCE_COUNTS` of its own waiting for
-          one. Two rather than one, because one is what a spec whose turn
-          limit *is* one produces by itself: the persona speaks, the
-          budget is spent, and the run ends before the agent could ever
-          have answered. A limit is deliberate and is never the agent
-          failing, so a run a limit ended that early keeps its own ending.
-
-        A record with no turns at all is left where its ending put it for
-        the same reason — nobody spoke, the exchange never got under way,
-        and a limit that tripped while the line was still ringing is that
-        record.
-        """
-        answers = [turn for turn in self._record.history if turn.speaker == "agent"]
-        if any(turn.text.strip() for turn in answers):
-            return
-        if not answers:
-            asked = sum(1 for turn in self._record.history if turn.speaker == "human")
-            if asked < ASKED_BEFORE_A_SILENCE_COUNTS:
-                return
-        raise SilentAgent(SAID_NOTHING)
 
     def _ended(self, named: Ending) -> Conducted:
         ending, reason = named

--- a/apps/simulator/src/egma_simulator/conductor.py
+++ b/apps/simulator/src/egma_simulator/conductor.py
@@ -23,6 +23,7 @@ from pipecat.frames.frames import (
     FunctionCallFromLLM,
     FunctionCallResultProperties,
     InputAudioRawFrame,
+    InterruptionFrame,
     LLMContextFrame,
     LLMFullResponseEndFrame,
     LLMFullResponseStartFrame,
@@ -65,7 +66,7 @@ from .conversation import (
 )
 from .media import RemoteParticipantLeftFrame, VoiceMedia
 from .model import END_CALL_TOOL_NAME, ModelFailure, PersonaReply
-from .persona import Persona, Turn
+from .persona import SILENCE_FOLLOW_UP_LIMIT, SILENCE_WAIT_SECONDS, Persona, Turn
 from .platform_logging import log_event
 from .plugs import PlugError, VoiceConnection
 from .recording import AudioFacts, dual_channel_wav
@@ -91,12 +92,17 @@ class ConductParameters:
 
     agent_opening_seconds: float = 10.0
     persona_pause_seconds: float = 0.4
-    agent_quiet_seconds: float = 12.0
+    agent_quiet_seconds: float = SILENCE_WAIT_SECONDS
     agent_turn_backstop_seconds: float = 5.0
     yields_to_the_agent: bool = True
 
 
 DEFAULT_CONDUCT = ConductParameters()
+
+PERSONA_ENDED_SILENCE: Ending = (
+    "persona_concluded",
+    "the agent did not respond after two persona follow-ups",
+)
 
 ASKED_BEFORE_A_SILENCE_COUNTS = 2
 """How many persona turns an agent must go quiet through before its
@@ -117,6 +123,7 @@ OnAnswered = Callable[[], Awaitable[None]]
 @dataclass
 class _AgentFinished(ControlFrame):
     heard_a_turn: bool = True
+    silence_follow_up: int = 0
 
 
 @dataclass(frozen=True)
@@ -183,9 +190,7 @@ class _AgentEar(VADProcessor):
                 * self._analyzer.num_frames_required()
                 / self._analyzer.sample_rate
             )
-            await self.broadcast_frame(
-                VADUserStoppedSpeakingFrame, stop_secs=stop_secs
-            )
+            await self.broadcast_frame(VADUserStoppedSpeakingFrame, stop_secs=stop_secs)
 
     async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
         if isinstance(frame, RemoteParticipantLeftFrame):
@@ -194,9 +199,7 @@ class _AgentEar(VADProcessor):
             await self.finalize_active_utterance()
         if isinstance(frame, InputAudioRawFrame):
             source_start = self.position
-            source_end = source_start + Fraction(
-                frame.num_frames, frame.sample_rate
-            )
+            source_end = source_start + Fraction(frame.num_frames, frame.sample_rate)
             frame.metadata[_INPUT_SOURCE_RANGE] = (source_start, source_end)
             self.position = source_end
         await super().process_frame(frame, direction)
@@ -210,9 +213,8 @@ class _TurnBoundary(FrameProcessor):
     async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
         await super().process_frame(frame, direction)
         await self.push_frame(frame, direction)
-        if (
-            direction == FrameDirection.DOWNSTREAM
-            and isinstance(frame, UserStoppedSpeakingFrame)
+        if direction == FrameDirection.DOWNSTREAM and isinstance(
+            frame, UserStoppedSpeakingFrame
         ):
             await self.push_frame(_AgentFinished())
 
@@ -321,9 +323,7 @@ class _EvidenceRecorder(AudioBufferProcessor):
                     "the pinned pipecat release skipped its recording resampler"
                 ) from changed
             if written:
-                represented_end_samples = (
-                    float(source_end * self.sample_rate) - pending
-                )
+                represented_end_samples = float(source_end * self.sample_rate) - pending
                 rounded_end = round(represented_end_samples)
                 if abs(represented_end_samples - rounded_end) > 1e-6:
                     raise SpeechFault(
@@ -437,9 +437,7 @@ class _EvidenceRecorder(AudioBufferProcessor):
         if not self.sample_rate:
             return None
         segments = (
-            reversed(self._input_segments)
-            if at_turn_start
-            else self._input_segments
+            reversed(self._input_segments) if at_turn_start else self._input_segments
         )
         for segment in segments:
             inside = (
@@ -448,9 +446,9 @@ class _EvidenceRecorder(AudioBufferProcessor):
                 else segment.source_start < source_position <= segment.source_end
             )
             if inside:
-                return Fraction(
-                    segment.recording_start_sample, self.sample_rate
-                ) + (source_position - segment.source_start)
+                return Fraction(segment.recording_start_sample, self.sample_rate) + (
+                    source_position - segment.source_start
+                )
         return None
 
     def _mapped_past(
@@ -620,18 +618,22 @@ class _PersonaReplyGate(FrameProcessor):
         self._due: MediaPosition | None = None
         self._collecting = False
         self._text: list[str] = []
+        self._silence_follow_up = 0
 
     async def request(
         self,
         context: LLMContext,
         due: MediaPosition,
         push: Callable[[Frame], Awaitable[None]],
+        *,
+        silence_follow_up: int = 0,
     ) -> None:
         if self._waiting is not None:
             raise RuntimeError("the persona model already has a reply in flight")
         waiting = asyncio.get_running_loop().create_future()
         self._waiting = waiting
         self._due = due
+        self._silence_follow_up = silence_follow_up
         try:
             await push(LLMContextFrame(context=context))
             await waiting
@@ -673,7 +675,9 @@ class _PersonaReplyGate(FrameProcessor):
                 await self._conductor.wait_until(due)
                 if not self._conductor.is_ending:
                     self._conductor.persona_will_speak(
-                        reply.text, concludes=reply.concluded
+                        reply.text,
+                        concludes=reply.concluded,
+                        silence_follow_up=self._silence_follow_up,
                     )
                     await self.push_frame(LLMFullResponseStartFrame())
                     await self.push_frame(TextFrame(reply.text))
@@ -693,6 +697,7 @@ class _PersonaReplyGate(FrameProcessor):
         self._due = None
         self._collecting = False
         self._text = []
+        self._silence_follow_up = 0
 
 
 class _PersonaBrain(FrameProcessor):
@@ -717,9 +722,9 @@ class _PersonaBrain(FrameProcessor):
             self._heard.append(frame.text)
         await self.push_frame(frame, direction)
         if isinstance(frame, _AgentFinished):
-            await self._answer(frame.heard_a_turn)
+            await self._answer(frame.heard_a_turn, frame.silence_follow_up)
 
-    async def _answer(self, heard_a_turn: bool) -> None:
+    async def _answer(self, heard_a_turn: bool, silence_follow_up: int = 0) -> None:
         try:
             said = " ".join(piece for piece in self._heard if piece)
             self._heard.clear()
@@ -727,9 +732,12 @@ class _PersonaBrain(FrameProcessor):
             if due is None:
                 return
             await self._replies.request(
-                self._persona.context(self._conductor.history),
+                self._persona.context(
+                    self._conductor.history, silence_follow_up=silence_follow_up
+                ),
                 due,
                 self.push_frame,
+                silence_follow_up=silence_follow_up,
             )
         except Exception as fault:
             self._conductor.the_brain_failed(fault)
@@ -762,6 +770,8 @@ class _Timeline(FrameProcessor):
             )
         elif isinstance(frame, TTSStoppedFrame):
             await self._conductor.persona_stopped()
+        elif isinstance(frame, InterruptionFrame):
+            self._conductor.persona_interrupted()
         elif isinstance(frame, RemoteParticipantLeftFrame):
             frame.completed.set()
             self._conductor.media_advanced()
@@ -775,6 +785,8 @@ class _Record:
     persona_last_stopped_at: MediaPosition | None = None
     quiet_since: MediaPosition = Fraction(0)
     first_answer_measured: bool = False
+    silence_follow_ups: int = 0
+    persona_response_pending: bool = False
 
 
 class PipelineGone(RuntimeError):
@@ -824,6 +836,7 @@ class VoiceConductor:
 
         self._pending_persona_text: str | None = None
         self._pending_persona_concludes = False
+        self._pending_silence_follow_up = 0
         self._persona_began: MediaPosition | None = None
         self._persona_ended: MediaPosition | None = None
 
@@ -1149,7 +1162,9 @@ class VoiceConductor:
         if self._heard_so_far < len(ear.utterances):
             return
 
-        if self._record.persona_last_stopped_at is None and not ear.utterances:
+        if self._record.persona_last_stopped_at is None and not any(
+            turn.speaker == "human" for turn in self._record.history
+        ):
             if self._position >= _seconds(self._parameters.agent_opening_seconds):
                 await self._ask_the_persona(heard_a_turn=False)
             return
@@ -1158,13 +1173,23 @@ class VoiceConductor:
         if self._position - self._record.quiet_since >= _seconds(
             self._parameters.agent_quiet_seconds
         ):
-            await self._ask_the_persona(heard_a_turn=False)
+            if self._record.silence_follow_ups >= SILENCE_FOLLOW_UP_LIMIT:
+                self._ending = PERSONA_ENDED_SILENCE
+            else:
+                await self._ask_the_persona(heard_a_turn=False)
 
     async def _ask_the_persona(self, *, heard_a_turn: bool) -> None:
         if self._worker is None:
             raise PipelineGone("the persona was asked before the pipeline started")
         self._owes_a_turn = True
-        await self._worker.queue_frame(_AgentFinished(heard_a_turn=heard_a_turn))
+        follow_up = (
+            self._record.silence_follow_ups + 1
+            if not heard_a_turn and self._record.persona_last_stopped_at is not None
+            else 0
+        )
+        await self._worker.queue_frame(
+            _AgentFinished(heard_a_turn=heard_a_turn, silence_follow_up=follow_up)
+        )
 
     async def the_agent_finished(
         self, said: str, heard_a_turn: bool
@@ -1173,6 +1198,7 @@ class VoiceConductor:
         if ear is None:
             return None
         stopped_at: MediaPosition | None = None
+        received_words = False
         if heard_a_turn and self._heard_so_far < len(ear.utterances):
             source_began = ear.utterances[self._heard_so_far].began
             source_ended = ear.utterances[-1].ended
@@ -1197,14 +1223,16 @@ class VoiceConductor:
                 if answering:
                     if not self._record.first_answer_measured:
                         self._record.first_answer_measured = True
-                        await self._measure(
-                            "first_response_latency", quiet_from, began
-                        )
+                        await self._measure("first_response_latency", quiet_from, began)
                     await self._measure("turn_response_latency", quiet_from, began)
             await self._took_a_turn("agent", said, began, ended)
             await self._measure("agent_speech_duration", began, ended)
-            self._record.persona_last_stopped_at = None
-            self._record.quiet_since = max(self._record.quiet_since, ended)
+            received_words = bool(said.strip())
+            if received_words:
+                self._record.silence_follow_ups = 0
+                self._record.persona_response_pending = True
+                self._record.persona_last_stopped_at = None
+                self._record.quiet_since = max(self._record.quiet_since, ended)
         if self._on_answered is not None:
             await self._on_answered()
         if self._ending is not None:
@@ -1216,6 +1244,17 @@ class VoiceConductor:
         if self._media is not None and self._media.ended.is_set():
             self._agent_departed = True
             self._ending = AGENT_ENDED
+            self._owes_a_turn = False
+            self.media_advanced()
+            return None
+        if (
+            heard_a_turn
+            and not received_words
+            and (stopped_at is None or not self._record.persona_response_pending)
+        ):
+            # A wordless or already-consumed boundary is not a new response.
+            # Keep waiting from the last persona turn without asking the model
+            # to answer an empty message or resetting its follow-up allowance.
             self._owes_a_turn = False
             self.media_advanced()
             return None
@@ -1231,9 +1270,16 @@ class VoiceConductor:
                 return
             await self._activity.wait()
 
-    def persona_will_speak(self, text: str, *, concludes: bool = False) -> None:
+    def persona_will_speak(
+        self,
+        text: str,
+        *,
+        concludes: bool = False,
+        silence_follow_up: int = 0,
+    ) -> None:
         self._pending_persona_text = text
         self._pending_persona_concludes = concludes
+        self._pending_silence_follow_up = silence_follow_up
         self._persona_began = None
         self._persona_ended = None
 
@@ -1248,11 +1294,32 @@ class VoiceConductor:
         if self._persona_began is None:
             duration = Fraction(frame.num_frames, frame.sample_rate)
             self._persona_began = max(Fraction(0), recorded_until - duration)
+            # Count an audible follow-up even if the agent interrupts it.
+            # A model request canceled before audio uses no allowance.
+            if self._pending_silence_follow_up:
+                self._record.silence_follow_ups += 1
+                self._pending_silence_follow_up = 0
         self._persona_ended = recorded_until
+        self.media_advanced()
+
+    def persona_interrupted(self) -> None:
+        """Start waiting from the last audio heard before an interruption."""
+        ended = self._persona_ended
+        if ended is None:
+            return
+        self._record.persona_last_stopped_at = ended
+        self._record.quiet_since = max(self._record.quiet_since, ended)
+        self._pending_persona_text = None
+        self._pending_persona_concludes = False
+        self._pending_silence_follow_up = 0
+        self._persona_began = None
+        self._persona_ended = None
+        self._owes_a_turn = False
         self.media_advanced()
 
     async def persona_stopped(self) -> None:
         text, self._pending_persona_text = self._pending_persona_text, None
+        self._pending_silence_follow_up = 0
         concludes, self._pending_persona_concludes = (
             self._pending_persona_concludes,
             False,
@@ -1272,6 +1339,7 @@ class VoiceConductor:
             "human", text, began, ended, apply_turn_limit=not concludes
         )
         self._record.persona_last_stopped_at = ended
+        self._record.persona_response_pending = False
         self._record.quiet_since = max(self._record.quiet_since, ended)
         if concludes and not self.is_ending:
             self._ending = PERSONA_CONCLUDED
@@ -1303,9 +1371,7 @@ class VoiceConductor:
         )
         self._record.turns += 1
         if self._on_utterance is not None:
-            await self._on_utterance(
-                speaker, text, self._at(began), self._at(ended)
-            )
+            await self._on_utterance(speaker, text, self._at(began), self._at(ended))
         if (
             apply_turn_limit
             and self._record.turns >= self._max_turns
@@ -1318,9 +1384,7 @@ class VoiceConductor:
         self, measure: str, began: MediaPosition, ended: MediaPosition
     ) -> None:
         if ended < began:
-            raise ValueError(
-                f"{measure} was measured over a backwards media interval"
-            )
+            raise ValueError(f"{measure} was measured over a backwards media interval")
         if self._on_measured is not None:
             await self._on_measured(measure, self._at(began), self._at(ended))
 
@@ -1360,13 +1424,9 @@ class VoiceConductor:
 
     def _transport_lost(self) -> PlugError:
         transport = (
-            self._media.transport_name
-            if self._media is not None
-            else "voice transport"
+            self._media.transport_name if self._media is not None else "voice transport"
         )
-        return PlugError(
-            f"the {transport} disconnected before the simulation ended"
-        )
+        return PlugError(f"the {transport} disconnected before the simulation ended")
 
     async def _agent_left(self) -> None:
         """Finish any active input turn before recording a normal departure."""

--- a/apps/simulator/src/egma_simulator/conductor.py
+++ b/apps/simulator/src/egma_simulator/conductor.py
@@ -124,6 +124,7 @@ OnAnswered = Callable[[], Awaitable[None]]
 class _AgentFinished(ControlFrame):
     heard_a_turn: bool = True
     silence_follow_up: int = 0
+    silence_wait_seconds: float = SILENCE_WAIT_SECONDS
 
 
 @dataclass(frozen=True)
@@ -722,9 +723,16 @@ class _PersonaBrain(FrameProcessor):
             self._heard.append(frame.text)
         await self.push_frame(frame, direction)
         if isinstance(frame, _AgentFinished):
-            await self._answer(frame.heard_a_turn, frame.silence_follow_up)
+            await self._answer(
+                frame.heard_a_turn, frame.silence_follow_up, frame.silence_wait_seconds
+            )
 
-    async def _answer(self, heard_a_turn: bool, silence_follow_up: int = 0) -> None:
+    async def _answer(
+        self,
+        heard_a_turn: bool,
+        silence_follow_up: int = 0,
+        silence_wait_seconds: float = SILENCE_WAIT_SECONDS,
+    ) -> None:
         try:
             said = " ".join(piece for piece in self._heard if piece)
             self._heard.clear()
@@ -733,7 +741,9 @@ class _PersonaBrain(FrameProcessor):
                 return
             await self._replies.request(
                 self._persona.context(
-                    self._conductor.history, silence_follow_up=silence_follow_up
+                    self._conductor.history,
+                    silence_follow_up=silence_follow_up,
+                    silence_wait_seconds=silence_wait_seconds,
                 ),
                 due,
                 self.push_frame,
@@ -1188,7 +1198,11 @@ class VoiceConductor:
             else 0
         )
         await self._worker.queue_frame(
-            _AgentFinished(heard_a_turn=heard_a_turn, silence_follow_up=follow_up)
+            _AgentFinished(
+                heard_a_turn=heard_a_turn,
+                silence_follow_up=follow_up,
+                silence_wait_seconds=self._parameters.agent_quiet_seconds,
+            )
         )
 
     async def the_agent_finished(

--- a/apps/simulator/src/egma_simulator/conversation.py
+++ b/apps/simulator/src/egma_simulator/conversation.py
@@ -13,12 +13,9 @@ through :class:`ConversationControls`, and the first cause to land is the one th
 record shows — a cause arriving after the conversation already ended changes
 nothing, because what happened is the record.
 
-One outcome here is deliberately *not* an ending: :class:`SilentAgent`,
-raised where a voice simulation ran and the agent never said a word. It is
-an execution failure, so the run is reported failed rather than completed
-and is never graded. It lives beside the endings because it is the same
-question answered — how did this simulation turn out — and it is the one
-answer that is not a conversation.
+An agent that stays silent is an observed outcome of the conversation.
+The voice persona follows up at most twice, then concludes normally. The
+record is available to graders; silence alone is not an execution fault.
 """
 
 from __future__ import annotations
@@ -148,10 +145,6 @@ class Conducted:
 # comparing the same scenario over both modalities is comparing exactly
 # that. The sentences are asserted verbatim by the acceptance suite, so a
 # second copy of one is a way for the two to drift apart silently.
-#
-# The silent-agent failure below is the exception to both halves of that
-# sentence, and says so where it is defined: it is not an ending, and it
-# is the voice conductor's alone.
 
 Ending = tuple[str, str]
 """One ending: the contract's word for it, and the prose a report carries."""
@@ -161,46 +154,6 @@ PERSONA_CONCLUDED: Ending = (
     "the persona concluded the scenario",
 )
 AGENT_ENDED: Ending = ("agent_ended", "the agent ended the exchange")
-
-
-# -- The one outcome that is not an ending -----------------------------------
-#
-# Raised, never returned, and by the voice conductor only. A chat agent
-# that types nothing in any turn is the same shape of problem and is
-# deliberately left alone here: the decision that produced this rule was
-# written about voice, and a rule extended past what was decided is a
-# rule nobody agreed to.
-
-SAID_NOTHING = (
-    "the agent said nothing in this simulation: every one of its turns was "
-    "empty, so there is no conversation to grade — check that the agent's "
-    "worker speaks, and that the audio it publishes is its voice"
-)
-"""Why a simulation the agent was silent through is a failure, in the
-words the developer who has to fix it reads.
-
-Actionable on purpose: the two things it names are the two that were
-really wrong the day this rule was written — an agent whose worker was
-speaking fluently, and a second audio track that reached egma's ear
-instead of that voice. A reader of this sentence goes and looks at one of
-those rather than at the transcript, which says nothing by definition.
-"""
-
-
-class SilentAgent(Exception):
-    """The agent produced no words in any turn, so nothing was tested.
-
-    An execution failure and never an ending: the contract's failed
-    endings all mean "the test never ran" or "the test broke", and none of
-    them is ever graded. A silence reported as ``persona_concluded`` or
-    ``limit_reached`` is graded like any other conversation, which is the
-    one outcome worse than a failed run — the product would be judging an
-    agent on ten minutes of nothing.
-
-    It carries no ``ending`` of its own, so :func:`plugs.failed_ending`
-    reads it as ``error``: the simulator could not conduct through what it
-    was given.
-    """
 
 
 def turn_limit_reached(max_turns: int) -> Ending:

--- a/apps/simulator/src/egma_simulator/persona.py
+++ b/apps/simulator/src/egma_simulator/persona.py
@@ -125,7 +125,11 @@ class Persona:
         return messages_for(self._system_prompt, history)
 
     def context(
-        self, history: Sequence[Turn], *, silence_follow_up: int = 0
+        self,
+        history: Sequence[Turn],
+        *,
+        silence_follow_up: int = 0,
+        silence_wait_seconds: float = SILENCE_WAIT_SECONDS,
     ) -> LLMContext:
         """The provider-neutral messages and tools for one persona turn."""
         messages = self.messages(history)
@@ -134,7 +138,7 @@ class Persona:
                 {
                     "role": "user",
                     "content": (
-                        f"(The agent has not replied for {SILENCE_WAIT_SECONDS:g} "
+                        f"(The agent has not replied for {silence_wait_seconds:g} "
                         f"seconds. This is follow-up {silence_follow_up} of "
                         f"{SILENCE_FOLLOW_UP_LIMIT}. Stay in character and say a "
                         "brief follow-up to check whether the agent is still "

--- a/apps/simulator/src/egma_simulator/persona.py
+++ b/apps/simulator/src/egma_simulator/persona.py
@@ -31,6 +31,9 @@ from pipecat.processors.aggregators.llm_context import LLMContext
 from .model import PERSONA_TOOLS, ModelClient, PersonaReply
 from .spec import AuthoredPersona
 
+SILENCE_WAIT_SECONDS = 10.0
+SILENCE_FOLLOW_UP_LIMIT = 2
+
 OPENING_NUDGE = (
     "(The conversation is open and the agent is listening. Speak your first turn.)"
 )
@@ -90,9 +93,11 @@ def messages_for(system_prompt: str, history: Sequence[Turn]) -> list[dict[str, 
     """The conversation so far, in chat shape, from the persona's seat."""
     messages = [{"role": "system", "content": system_prompt}]
     for turn in history:
+        if not turn.text.strip():
+            continue
         role = "assistant" if turn.speaker == "human" else "user"
         messages.append({"role": role, "content": turn.text})
-    if not history:
+    if not any(turn.text.strip() for turn in history):
         messages.append({"role": "user", "content": OPENING_NUDGE})
     return messages
 
@@ -119,10 +124,27 @@ class Persona:
         """The exact provider input for this point in the conversation."""
         return messages_for(self._system_prompt, history)
 
-    def context(self, history: Sequence[Turn]) -> LLMContext:
+    def context(
+        self, history: Sequence[Turn], *, silence_follow_up: int = 0
+    ) -> LLMContext:
         """The provider-neutral messages and tools for one persona turn."""
+        messages = self.messages(history)
+        if silence_follow_up:
+            messages.append(
+                {
+                    "role": "user",
+                    "content": (
+                        f"(The agent has not replied for {SILENCE_WAIT_SECONDS:g} "
+                        f"seconds. This is follow-up {silence_follow_up} of "
+                        f"{SILENCE_FOLLOW_UP_LIMIT}. Stay in character and say a "
+                        "brief follow-up to check whether the agent is still "
+                        "there. Do not repeat your full request or invent an "
+                        "agent response. Then wait for the agent to reply.)"
+                    ),
+                }
+            )
         return LLMContext(
-            messages=self.messages(history),
+            messages=messages,
             tools=PERSONA_TOOLS,
             tool_choice="auto",
         )

--- a/apps/simulator/src/egma_simulator/plugs/loopback.py
+++ b/apps/simulator/src/egma_simulator/plugs/loopback.py
@@ -107,9 +107,8 @@ class LoopbackCounterpart:
             # The counterpart's default is to keep the conversation going
             # once its script runs out, because most tests want a far end
             # that stays available. ``goes_quiet_after_replies`` is the
-            # other real agent: one that is in the room, publishing, and
-            # saying nothing — which is what a broken worker looks like,
-            # and the case the silent-agent rule exists for.
+            # case where the agent stays in the room and sends no reply,
+            # so the persona must handle unanswered turns.
             fallback_reply=(
                 None if ends_after_replies or goes_quiet else FALLBACK_REPLY
             ),

--- a/apps/simulator/src/egma_simulator/service.py
+++ b/apps/simulator/src/egma_simulator/service.py
@@ -327,14 +327,8 @@ class RunningSimulation:
                         name=f"sim:{self.simulation_id}",
                     )
             finally:
-                # The platform's own name for the exchange, taken here
-                # rather than off the ending. A simulation that failed has
-                # an ending only if it reached one, and the failures worth
-                # reading are exactly the ones that did not: "the agent
-                # said nothing — go and listen to the call" is worth
-                # little without the call's own identifier beside it. So
-                # it is read wherever conducting stopped, and every
-                # terminal document carries it.
+                # Keep the platform call reference on every terminal report,
+                # including faults that stopped conducting before an ending.
                 conducting = assembled.conductor or assembled.plug
                 if conducting is not None:
                     reporter.provider_reference = conducting.provider_reference

--- a/apps/simulator/tests/test_acceptance.py
+++ b/apps/simulator/tests/test_acceptance.py
@@ -991,25 +991,17 @@ async def test_a_text_mode_billing_wall_fails_loudly_and_says_nothing(
     assert_kept_secret(sentinel, records=records, simulator=simulator)
 
 
-async def test_a_voice_run_the_agent_was_silent_through_fails_and_names_the_call(
+async def test_a_silent_voice_agent_completes_with_its_call_evidence(
     workbench, start_simulator
 ):
-    """The whole silence story, read back off the record the platform gets.
+    """Silence is observed agent behavior, which graders can judge.
 
-    An agent that joins, is heard, and says no word in any turn: the run
-    is reported ``failed`` with an ending the contract never grades,
-    rather than ``completed`` with an ending that would send ten minutes
-    of nothing to a grader.
-
-    And it keeps the platform's own name for the call. That reference is
-    written when conducting stops rather than when an ending is decided,
-    because a run that failed may have reached no ending at all — and
-    "the agent said nothing, go and listen to the call" is worth very
-    little without the call's own identifier beside it.
+    The persona opens, follows up twice, and hangs up. The service reports
+    completion and preserves the transcript, recording, and call reference.
     """
     spec = loopback_spec(
         "sim-voice-silent",
-        scenario="One point. Two point.",
+        scenario="One point. Two point. Three point. Four point.",
         greeting=None,
         replies=[],
         goes_quiet_after_replies=True,
@@ -1020,23 +1012,28 @@ async def test_a_voice_run_the_agent_was_silent_through_fails_and_names_the_call
 
     records = await workbench.wait_for(has_terminal("sim-voice-silent"))
 
+    assert status_events_for(records, "sim-voice-silent") == [
+        "running",
+        "completed",
+    ]
     terminal = terminal_event_for(records, "sim-voice-silent")
-    assert terminal["status"] == "failed"
-    # The contract's failed endings are the ones that mean the test never
-    # ran or the test broke, and none of them is ever graded.
-    assert terminal["facts"]["ending"] == "error"
-    reason = terminal["reason"]
-    assert "said nothing" in reason, reason
-    assert "grade" in reason, reason
-    # Never one of the deliberate endings this used to claim.
-    assert "persona_concluded" not in reason
-    assert "limit_reached" not in reason
-    # The call is still named, so the sentence is actionable.
-    assert terminal["facts"]["provider_reference"] == "loopback-voice-silent-1"
-    # The persona really did talk to it — a conversation that ran and got
-    # nothing back, not a run that never opened.
-    speakers = [speaker for speaker, _text in turns_for(records, "sim-voice-silent")]
-    assert speakers and set(speakers) == {"human"}
+    facts = terminal["facts"]
+    assert facts["ending"] == "persona_concluded"
+    assert terminal["reason"] == (
+        "the agent did not respond after two persona follow-ups"
+    )
+    assert facts["provider_reference"] == "loopback-voice-silent-1"
+    turns = turns_for(records, "sim-voice-silent")
+    assert turns == [
+        ("human", "One point."),
+        ("human", "Two point."),
+        ("human", "Three point."),
+    ]
+    assert facts["turn_count"] == len(turns)
+    recording = simulator.blob(facts["audio"]["recording"])
+    assert channels_of(recording)[2] > 0
+    assert_one_speaker_to_a_channel(recording, turns)
+    assert [record for record in records if record["kind"] == "refusal"] == []
 
     simulator.stop()
 

--- a/apps/simulator/tests/test_persona.py
+++ b/apps/simulator/tests/test_persona.py
@@ -13,6 +13,7 @@ scripted client or a recording fake.
 
 from __future__ import annotations
 
+import pytest
 from conftest import load_fixture_spec
 from pipecat.processors.aggregators.llm_context import LLMContext
 
@@ -168,6 +169,27 @@ def test_an_empty_history_gets_the_opening_nudge():
         {"role": "system", "content": "the prompt"},
         {"role": "user", "content": OPENING_NUDGE},
     ]
+
+
+@pytest.mark.parametrize("follow_up", [1, 2])
+def test_silence_follow_up_explains_the_pause_without_changing_history(follow_up):
+    persona = Persona(
+        authored=AUTHORED,
+        scenario_instructions=SCENARIO,
+        model=ScriptedModel(SCENARIO),
+    )
+    history = [Turn("agent", "Hello."), Turn("human", "Can I book a tour?")]
+    ordinary = persona.messages(history)
+
+    context = persona.context(history, silence_follow_up=follow_up)
+    messages = context.get_messages()
+
+    assert messages[:-1] == ordinary
+    assert messages[-1]["role"] == "user"
+    assert "10 seconds" in messages[-1]["content"]
+    assert f"{follow_up} of 2" in messages[-1]["content"]
+    assert persona.messages(history) == ordinary
+    assert history[-1] == Turn("human", "Can I book a tour?")
 
 
 def test_every_persona_context_advertises_the_native_end_call_tool():

--- a/apps/simulator/tests/test_persona_pipeline.py
+++ b/apps/simulator/tests/test_persona_pipeline.py
@@ -189,7 +189,9 @@ class ConductorProbe:
     async def wait_until(self, _due: Fraction) -> None:
         return None
 
-    def persona_will_speak(self, text: str, *, concludes: bool = False) -> None:
+    def persona_will_speak(
+        self, text: str, *, concludes: bool = False, silence_follow_up: int = 0
+    ) -> None:
         self.spoken.append(text)
         self.history.append(Turn("human", text))
         if concludes:

--- a/apps/simulator/tests/test_persona_silence.py
+++ b/apps/simulator/tests/test_persona_silence.py
@@ -1,0 +1,442 @@
+"""Persona follow-ups through the actual voice, audio, and turn pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import io
+import wave
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from fractions import Fraction
+from itertools import pairwise
+from pathlib import Path
+
+import pytest
+from conftest import loopback_spec
+from pipecat.frames.frames import TranscriptionFrame
+from pipecat.processors.aggregators.llm_context import LLMContext
+
+from egma_simulator.blob import FilesystemBlobStore
+from egma_simulator.conductor import ConductParameters, VoiceConductor
+from egma_simulator.conversation import Conducted, ConversationControls, SilentAgent
+from egma_simulator.media import VoiceMedia
+from egma_simulator.media.scripted_transport import ScriptedTransport
+from egma_simulator.model import PersonaReply
+from egma_simulator.persona import Persona
+from egma_simulator.spec import SimulationSpec
+from egma_simulator.speech import (
+    SCRIPTED_PAIR,
+    ScriptedSTT,
+    silence,
+    voice_from_models,
+)
+
+NANOSECONDS = 1_000_000_000
+GREETING = "Front desk, how can I help?"
+WORDLESS_AUDIO = "Speech with no recognized words."
+
+
+class AgentScript(ScriptedTransport):
+    """A fixture agent can speak, wait, or stay quiet after each persona turn."""
+
+    def __init__(self, greeting: str | None, answers: list[tuple[float, str | None]]):
+        super().__init__(
+            greeting=greeting,
+            replies=[],
+            answer_delay_seconds=0,
+            ends_after_replies=False,
+        )
+        self.answers = list(answers)
+        self.resume_after_wordless_boundary = greeting == WORDLESS_AUDIO
+
+    async def persona_stopped(self) -> None:
+        self._hearing.clear()
+        if not self.answers:
+            self._queue_audio(silence(13, self._input_rate))
+            return
+        delay, words = self.answers.pop(0)
+        self._queue_audio(silence(delay, self._input_rate))
+        if words is None:
+            self._queue_audio(silence(13, self._input_rate))
+        else:
+            self.resume_after_wordless_boundary = words == WORDLESS_AUDIO
+            self._queue_words(words)
+
+
+class AgentConnection:
+    provider_reference = None
+
+    def __init__(self, transport: AgentScript):
+        self.transport = transport
+
+    async def prepare(self) -> VoiceMedia:
+        return self.transport.media
+
+    async def open(self) -> None:
+        await self.transport.activate()
+
+    async def close(self) -> None:
+        self.transport.stop()
+
+
+@dataclass
+class Asked:
+    messages: list[dict]
+    transcript: list[tuple[str, str, int, int]]
+    silence_on_media_clock: Fraction | None
+
+
+@dataclass
+class Walk:
+    turns: list[tuple[str, str, int, int]] = field(default_factory=list)
+    requests: list[Asked] = field(default_factory=list)
+    result: Conducted | None = None
+    silent_error: SilentAgent | None = None
+    canceled_requests: list[int] = field(default_factory=list)
+    recording_started: int = 0
+    recording_ended: int = 0
+
+    @property
+    def persona_turns(self) -> list[tuple[str, str, int, int]]:
+        return [turn for turn in self.turns if turn[0] == "human"]
+
+
+class PersonaModel:
+    model_name = "silence-test-persona"
+
+    def __init__(
+        self,
+        walk: Walk,
+        conclude_at: int | None,
+        silence_on_media_clock: Callable[[], Fraction | None],
+        before_reply: Callable[[int], Awaitable[None]],
+    ):
+        self.walk = walk
+        self.conclude_at = conclude_at
+        self.silence_on_media_clock = silence_on_media_clock
+        self.before_reply = before_reply
+
+    async def reply(self, context: LLMContext) -> PersonaReply:
+        self.walk.requests.append(
+            Asked(
+                copy.deepcopy(context.get_messages()),
+                list(self.walk.turns),
+                self.silence_on_media_clock(),
+            )
+        )
+        number = len(self.walk.requests)
+        try:
+            await self.before_reply(number)
+        except asyncio.CancelledError:
+            self.walk.canceled_requests.append(number)
+            raise
+        return PersonaReply(
+            f"Persona reply {number}.", concluded=number == self.conclude_at
+        )
+
+    async def close(self) -> None:
+        return None
+
+
+async def walk_silence(
+    tmp_path: Path,
+    *,
+    greeting: str | None = GREETING,
+    answers: list[tuple[float, str | None]] | None = None,
+    conclude_at: int | None = None,
+    max_turns: int = 12,
+    stop_after_first_persona: str | None = None,
+    parameters: ConductParameters | None = None,
+    interrupt_second_request: bool = False,
+) -> Walk:
+    spec = SimulationSpec.from_document(loopback_spec("sim-persona-silence"))
+    transport = AgentScript(greeting, answers or [])
+    conductor = VoiceConductor(
+        connection=AgentConnection(transport),
+        voice=voice_from_models(spec.models),
+        blobs=FilesystemBlobStore(tmp_path),
+        recording_key="silence.wav",
+        speech=SCRIPTED_PAIR,
+        parameters=parameters or ConductParameters(),
+    )
+    walk = Walk()
+    controls = ConversationControls()
+
+    async def utterance(speaker: str, text: str, began: int, ended: int):
+        walk.turns.append((speaker, text, began, ended))
+        if (
+            speaker == "agent"
+            and not text.strip()
+            and transport.resume_after_wordless_boundary
+        ):
+            # Blank transcription ends through Pipecat's wall-clock backstop.
+            # Resume the accelerated fixture only after that boundary is
+            # recorded, so queued media cannot outrun the pending turn.
+            transport.resume_after_wordless_boundary = False
+            transport._queue_audio(silence(13, transport._input_rate))
+        if speaker == "human" and len(walk.persona_turns) == 1:
+            if stop_after_first_persona == "cancel":
+                controls.request_cancel()
+            elif stop_after_first_persona == "duration":
+                controls.trip_duration_limit()
+
+    async def measured(*_args):
+        return None
+
+    def silence_on_media_clock() -> Fraction | None:
+        # Observe the actual timer clock, without replacing the timer or its
+        # frame processing. Transcript timestamps use a separate output cursor.
+        stopped = conductor._record.persona_last_stopped_at
+        return None if stopped is None else conductor._position - stopped
+
+    async def before_reply(number: int) -> None:
+        if interrupt_second_request and number == 2:
+            transport.resume_after_wordless_boundary = True
+            transport._queue_words(WORDLESS_AUDIO)
+            await asyncio.Event().wait()  # Real VAD interrupts this model request.
+
+    try:
+        walk.result = await conductor.conduct(
+            persona=Persona(
+                authored=spec.persona,
+                scenario_instructions="Ask the agent one question.",
+                model=PersonaModel(
+                    walk, conclude_at, silence_on_media_clock, before_reply
+                ),
+            ),
+            max_turns=max_turns,
+            max_duration_seconds=20,
+            controls=controls,
+            name="sim:persona-silence-test",
+            on_utterance=utterance,
+            on_measured=measured,
+        )
+    except SilentAgent as error:
+        walk.silent_error = error
+    assert conductor.audio is not None
+    with wave.open(io.BytesIO((tmp_path / "silence.wav").read_bytes())) as recording:
+        duration = recording.getnframes() / recording.getframerate()
+    walk.recording_started = conductor.audio.started_unix_nano
+    walk.recording_ended = walk.recording_started + round(duration * NANOSECONDS)
+    return walk
+
+
+def assert_ten_seconds(gap: int) -> None:
+    # The recorder's input and output resampling cursors can differ by <100ms.
+    # Keep that transcript alignment margin separate from the strict timer
+    # assertion below, which observes the actual media clock at model request.
+    assert 9.9 <= gap / NANOSECONDS < 10.25
+
+
+async def test_persona_follows_up_twice_after_ten_seconds_then_hangs_up(tmp_path):
+    walk = await walk_silence(tmp_path)
+
+    assert walk.result is not None
+    assert walk.result.status == "completed"
+    assert walk.result.ending == "persona_concluded"
+    assert (
+        walk.result.reason == "the agent did not respond after two persona follow-ups"
+    )
+    assert len(walk.requests) == 3  # Normal reply, first follow-up, second follow-up.
+    assert len(walk.persona_turns) == 3
+    for request in walk.requests[1:]:
+        assert request.silence_on_media_clock is not None
+        assert Fraction(10) <= request.silence_on_media_clock < Fraction(41, 4)
+    for earlier, later in pairwise(walk.persona_turns):
+        assert_ten_seconds(later[2] - earlier[3])
+    assert_ten_seconds(walk.recording_ended - walk.persona_turns[-1][3])
+
+
+async def test_silence_instruction_reaches_model_but_never_spoken_history(tmp_path):
+    walk = await walk_silence(tmp_path)
+
+    assert len(walk.requests) == 3
+    for number, request in enumerate(walk.requests[1:], start=1):
+        instruction = request.messages[-1]
+        assert instruction["role"] == "user"
+        assert "10" in instruction["content"]
+        assert str(number) in instruction["content"]
+        history = [
+            {"role": "assistant" if speaker == "human" else "user", "content": text}
+            for speaker, text, _began, _ended in request.transcript
+        ]
+        assert request.messages[1:-1] == history
+        assert all(text != instruction["content"] for _speaker, text, *_ in walk.turns)
+    assert [turn[1] for turn in walk.persona_turns] == [
+        "Persona reply 1.",
+        "Persona reply 2.",
+        "Persona reply 3.",
+    ]
+
+
+async def test_real_agent_answer_resets_two_followup_allowance(tmp_path):
+    walk = await walk_silence(
+        tmp_path,
+        answers=[(0, None), (0, "Yes, I am here. What did you need?")],
+    )
+
+    assert walk.result is not None and walk.result.ending == "persona_concluded"
+    # Initial reply, first follow-up, normal answer to resumed agent,
+    # then a fresh pair of follow-ups before hanging up.
+    assert len(walk.requests) == 5
+    assert [turn[0] for turn in walk.turns] == [
+        "agent",
+        "human",
+        "human",
+        "agent",
+        "human",
+        "human",
+        "human",
+    ]
+    resumed = walk.requests[2]
+    assert resumed.messages[-1] == {
+        "role": "user",
+        "content": "Yes, I am here. What did you need?",
+    }
+    assert_ten_seconds(walk.persona_turns[3][2] - walk.persona_turns[2][3])
+    assert_ten_seconds(walk.persona_turns[4][2] - walk.persona_turns[3][3])
+    assert_ten_seconds(walk.recording_ended - walk.persona_turns[-1][3])
+
+
+async def test_initial_opening_is_not_one_of_the_two_followups(tmp_path):
+    walk = await walk_silence(tmp_path, greeting=None)
+
+    assert walk.silent_error is not None  # Preserve the entirely silent agent failure.
+    assert len(walk.requests) == 3
+    assert len(walk.persona_turns) == 3
+    for earlier, later in pairwise(walk.persona_turns):
+        assert_ten_seconds(later[2] - earlier[3])
+    assert_ten_seconds(walk.recording_ended - walk.persona_turns[-1][3])
+
+
+async def test_persona_does_not_follow_up_while_agent_is_still_speaking(tmp_path):
+    long_answer = "I am checking that information for you. " * 80
+    walk = await walk_silence(tmp_path, answers=[(9, long_answer)], conclude_at=2)
+
+    assert walk.result is not None and walk.result.ending == "persona_concluded"
+    assert len(walk.requests) == 2
+    assert walk.requests[1].messages[-1] == {"role": "user", "content": long_answer}
+    agent_turn = [turn for turn in walk.turns if turn[0] == "agent"][-1]
+    assert (agent_turn[3] - agent_turn[2]) / NANOSECONDS > 10
+
+
+@pytest.mark.parametrize(
+    ("stop", "max_turns", "status", "ending", "requests"),
+    [
+        ("cancel", 12, "canceled", "canceled", 1),
+        ("duration", 12, "completed", "limit_reached", 1),
+        (None, 3, "completed", "limit_reached", 2),
+    ],
+)
+async def test_existing_stop_conditions_take_priority_over_followups(
+    tmp_path, stop, max_turns, status, ending, requests
+):
+    walk = await walk_silence(
+        tmp_path, stop_after_first_persona=stop, max_turns=max_turns
+    )
+
+    assert walk.result is not None
+    assert (walk.result.status, walk.result.ending) == (status, ending)
+    assert len(walk.requests) == requests
+
+
+@pytest.fixture
+def unrecognized_speech(monkeypatch):
+    """Real speech/VAD boundaries, but the STT leg finds no words in one clip."""
+    transcribe = ScriptedSTT.run_stt
+
+    async def omit_selected_words(self, audio):
+        async for frame in transcribe(self, audio):
+            if isinstance(frame, TranscriptionFrame) and frame.text == WORDLESS_AUDIO:
+                frame.text = ""
+            yield frame
+
+    monkeypatch.setattr(ScriptedSTT, "run_stt", omit_selected_words)
+
+
+async def test_wordless_agent_speech_keeps_followup_count_and_timer(
+    tmp_path, unrecognized_speech
+):
+    walk = await walk_silence(
+        tmp_path,
+        answers=[(0, None), (0, WORDLESS_AUDIO)],
+        parameters=ConductParameters(agent_turn_backstop_seconds=0.5),
+    )
+
+    assert walk.result is not None and walk.result.ending == "persona_concluded"
+    assert len(walk.requests) == 3
+    assert [turn[0] for turn in walk.turns] == [
+        "agent",
+        "human",
+        "human",
+        "agent",
+        "human",
+    ]
+    assert walk.turns[3][1] == ""  # The wordless speech remains evidence.
+    assert_ten_seconds(walk.persona_turns[2][2] - walk.persona_turns[1][3])
+    assert_ten_seconds(walk.recording_ended - walk.persona_turns[-1][3])
+
+
+async def test_wordless_opening_does_not_prevent_persona_opening(
+    tmp_path, unrecognized_speech
+):
+    walk = await walk_silence(
+        tmp_path,
+        greeting=WORDLESS_AUDIO,
+        parameters=ConductParameters(agent_turn_backstop_seconds=0.5),
+    )
+
+    assert walk.silent_error is not None
+    assert walk.turns[0][0:2] == ("agent", "")
+    assert len(walk.requests) == 3
+    assert_ten_seconds(walk.persona_turns[0][2] - walk.recording_started)
+    for earlier, later in pairwise(walk.persona_turns):
+        assert_ten_seconds(later[2] - earlier[3])
+
+
+async def test_wordless_interruption_resumes_pending_normal_persona_reply(
+    tmp_path, unrecognized_speech
+):
+    walk = await walk_silence(
+        tmp_path,
+        answers=[(0, "Yes, what documents do you need?")],
+        interrupt_second_request=True,
+        conclude_at=3,
+        parameters=ConductParameters(agent_turn_backstop_seconds=0.5),
+    )
+
+    assert walk.canceled_requests == [2]
+    assert walk.result is not None and walk.result.ending == "persona_concluded"
+    assert len(walk.requests) == 3
+    assert [turn[1] for turn in walk.persona_turns] == [
+        "Persona reply 1.",
+        "Persona reply 3.",
+    ]
+    assert walk.turns[-2][0:2] == ("agent", "")
+    # Resume the interrupted normal request, without turning the wordless
+    # audio into a new question or adding a silence follow-up instruction.
+    assert walk.requests[2].messages == walk.requests[1].messages
+
+
+async def test_silence_request_canceled_before_audio_does_not_spend_followup(
+    tmp_path, unrecognized_speech
+):
+    walk = await walk_silence(
+        tmp_path,
+        interrupt_second_request=True,
+        parameters=ConductParameters(agent_turn_backstop_seconds=0.5),
+    )
+
+    assert walk.canceled_requests == [2]
+    assert walk.result is not None and walk.result.ending == "persona_concluded"
+    assert len(walk.requests) == 4
+    assert [turn[1] for turn in walk.persona_turns] == [
+        "Persona reply 1.",
+        "Persona reply 3.",
+        "Persona reply 4.",
+    ]
+    first_attempt = walk.requests[1].messages[-1]
+    retry = walk.requests[2].messages[-1]
+    assert retry == first_attempt  # The same first follow-up is still available.
+    assert walk.requests[3].messages[-1] != retry

--- a/apps/simulator/tests/test_persona_silence.py
+++ b/apps/simulator/tests/test_persona_silence.py
@@ -50,6 +50,15 @@ class AgentScript(ScriptedTransport):
         self.answers = list(answers)
         self.resume_after_wordless_boundary = greeting == WORDLESS_AUDIO
 
+    async def next_input(self):
+        chunk = await super().next_input()
+        # Recording acknowledges an input frame before queued turn processing
+        # finishes. Pace each 20ms frame so the real conductor and persona tasks
+        # can run before the fixture advances the media clock again. A positive
+        # delay also yields to event-loop timers on Linux; sleep(0) does not.
+        await asyncio.sleep(0.001)
+        return chunk
+
     async def persona_stopped(self) -> None:
         self._hearing.clear()
         if not self.answers:
@@ -246,6 +255,19 @@ async def test_persona_follows_up_twice_after_ten_seconds_then_hangs_up(tmp_path
     for earlier, later in pairwise(walk.persona_turns):
         assert_ten_seconds(later[2] - earlier[3])
     assert_ten_seconds(walk.recording_ended - walk.persona_turns[-1][3])
+
+
+async def test_silence_instruction_uses_the_same_wait_as_the_timer(tmp_path):
+    walk = await walk_silence(
+        tmp_path, parameters=ConductParameters(agent_quiet_seconds=2.0)
+    )
+
+    assert walk.result is not None and walk.result.ending == "persona_concluded"
+    assert len(walk.requests) == 3
+    for request in walk.requests[1:]:
+        assert request.silence_on_media_clock is not None
+        assert Fraction(2) <= request.silence_on_media_clock < Fraction(9, 4)
+        assert "has not replied for 2 seconds" in request.messages[-1]["content"]
 
 
 async def test_silence_instruction_reaches_model_but_never_spoken_history(tmp_path):

--- a/apps/simulator/tests/test_persona_silence.py
+++ b/apps/simulator/tests/test_persona_silence.py
@@ -19,7 +19,7 @@ from pipecat.processors.aggregators.llm_context import LLMContext
 
 from egma_simulator.blob import FilesystemBlobStore
 from egma_simulator.conductor import ConductParameters, VoiceConductor
-from egma_simulator.conversation import Conducted, ConversationControls, SilentAgent
+from egma_simulator.conversation import Conducted, ConversationControls
 from egma_simulator.media import VoiceMedia
 from egma_simulator.media.scripted_transport import ScriptedTransport
 from egma_simulator.model import PersonaReply
@@ -101,7 +101,6 @@ class Walk:
     turns: list[tuple[str, str, int, int]] = field(default_factory=list)
     requests: list[Asked] = field(default_factory=list)
     result: Conducted | None = None
-    silent_error: SilentAgent | None = None
     canceled_requests: list[int] = field(default_factory=list)
     recording_started: int = 0
     recording_ended: int = 0
@@ -155,7 +154,8 @@ async def walk_silence(
     answers: list[tuple[float, str | None]] | None = None,
     conclude_at: int | None = None,
     max_turns: int = 12,
-    stop_after_first_persona: str | None = None,
+    stop: str | None = None,
+    stop_at_persona_turn: int = 1,
     parameters: ConductParameters | None = None,
     interrupt_second_request: bool = False,
 ) -> Walk:
@@ -184,10 +184,10 @@ async def walk_silence(
             # recorded, so queued media cannot outrun the pending turn.
             transport.resume_after_wordless_boundary = False
             transport._queue_audio(silence(13, transport._input_rate))
-        if speaker == "human" and len(walk.persona_turns) == 1:
-            if stop_after_first_persona == "cancel":
+        if speaker == "human" and len(walk.persona_turns) == stop_at_persona_turn:
+            if stop == "cancel":
                 controls.request_cancel()
-            elif stop_after_first_persona == "duration":
+            elif stop == "duration":
                 controls.trip_duration_limit()
 
     async def measured(*_args):
@@ -205,24 +205,19 @@ async def walk_silence(
             transport._queue_words(WORDLESS_AUDIO)
             await asyncio.Event().wait()  # Real VAD interrupts this model request.
 
-    try:
-        walk.result = await conductor.conduct(
-            persona=Persona(
-                authored=spec.persona,
-                scenario_instructions="Ask the agent one question.",
-                model=PersonaModel(
-                    walk, conclude_at, silence_on_media_clock, before_reply
-                ),
-            ),
-            max_turns=max_turns,
-            max_duration_seconds=20,
-            controls=controls,
-            name="sim:persona-silence-test",
-            on_utterance=utterance,
-            on_measured=measured,
-        )
-    except SilentAgent as error:
-        walk.silent_error = error
+    walk.result = await conductor.conduct(
+        persona=Persona(
+            authored=spec.persona,
+            scenario_instructions="Ask the agent one question.",
+            model=PersonaModel(walk, conclude_at, silence_on_media_clock, before_reply),
+        ),
+        max_turns=max_turns,
+        max_duration_seconds=20,
+        controls=controls,
+        name="sim:persona-silence-test",
+        on_utterance=utterance,
+        on_measured=measured,
+    )
     assert conductor.audio is not None
     with wave.open(io.BytesIO((tmp_path / "silence.wav").read_bytes())) as recording:
         duration = recording.getnframes() / recording.getframerate()
@@ -324,7 +319,12 @@ async def test_real_agent_answer_resets_two_followup_allowance(tmp_path):
 async def test_initial_opening_is_not_one_of_the_two_followups(tmp_path):
     walk = await walk_silence(tmp_path, greeting=None)
 
-    assert walk.silent_error is not None  # Preserve the entirely silent agent failure.
+    assert walk.result is not None
+    assert walk.result.status == "completed"
+    assert walk.result.ending == "persona_concluded"
+    assert (
+        walk.result.reason == "the agent did not respond after two persona follow-ups"
+    )
     assert len(walk.requests) == 3
     assert len(walk.persona_turns) == 3
     for earlier, later in pairwise(walk.persona_turns):
@@ -354,13 +354,37 @@ async def test_persona_does_not_follow_up_while_agent_is_still_speaking(tmp_path
 async def test_existing_stop_conditions_take_priority_over_followups(
     tmp_path, stop, max_turns, status, ending, requests
 ):
-    walk = await walk_silence(
-        tmp_path, stop_after_first_persona=stop, max_turns=max_turns
-    )
+    walk = await walk_silence(tmp_path, stop=stop, max_turns=max_turns)
 
     assert walk.result is not None
     assert (walk.result.status, walk.result.ending) == (status, ending)
     assert len(walk.requests) == requests
+
+
+@pytest.mark.parametrize(
+    ("stop", "max_turns", "status", "ending"),
+    [
+        ("cancel", 12, "canceled", "canceled"),
+        ("duration", 12, "completed", "limit_reached"),
+        (None, 2, "completed", "limit_reached"),
+    ],
+)
+async def test_silent_agent_keeps_explicit_stop_ending(
+    tmp_path, stop, max_turns, status, ending
+):
+    walk = await walk_silence(
+        tmp_path,
+        greeting=None,
+        stop=stop,
+        stop_at_persona_turn=2,
+        max_turns=max_turns,
+    )
+
+    assert walk.result is not None
+    assert (walk.result.status, walk.result.ending) == (status, ending)
+    assert len(walk.requests) == 2
+    assert len(walk.persona_turns) == 2
+    assert walk.recording_ended > walk.recording_started
 
 
 @pytest.fixture
@@ -409,7 +433,12 @@ async def test_wordless_opening_does_not_prevent_persona_opening(
         parameters=ConductParameters(agent_turn_backstop_seconds=0.5),
     )
 
-    assert walk.silent_error is not None
+    assert walk.result is not None
+    assert walk.result.status == "completed"
+    assert walk.result.ending == "persona_concluded"
+    assert (
+        walk.result.reason == "the agent did not respond after two persona follow-ups"
+    )
     assert walk.turns[0][0:2] == ("agent", "")
     assert len(walk.requests) == 3
     assert_ten_seconds(walk.persona_turns[0][2] - walk.recording_started)

--- a/apps/simulator/tests/test_persona_silence_interruptions.py
+++ b/apps/simulator/tests/test_persona_silence_interruptions.py
@@ -1,0 +1,117 @@
+"""Interrupted follow-ups still have a two-attempt limit and a full reply wait."""
+
+from __future__ import annotations
+
+import asyncio
+
+import test_persona_silence as silence_tests
+from pipecat.frames.frames import (
+    TranscriptionFrame,
+    TTSAudioRawFrame,
+    TTSStartedFrame,
+)
+
+from egma_simulator.conductor import ConductParameters, VoiceConductor
+from egma_simulator.speech import ScriptedSTT, ScriptedTTS, encode_speech, silence
+
+
+async def test_partial_followups_keep_two_attempt_cap_and_ten_second_reply_wait(
+    tmp_path, monkeypatch
+):
+    transport = None
+    active = None
+    recorded = {1: asyncio.Event(), 2: asyncio.Event()}
+    intervals = []
+
+    create_transport = silence_tests.AgentScript.__init__
+
+    def remember_transport(self, *args, **kwargs):
+        nonlocal transport
+        create_transport(self, *args, **kwargs)
+        transport = self
+
+    will_speak = VoiceConductor.persona_will_speak
+
+    def remember_persona(self, *args, **kwargs):
+        nonlocal active
+        active = self
+        will_speak(self, *args, **kwargs)
+
+    accept_audio = VoiceConductor.persona_audio
+
+    def remember_audio(self, frame, *, recorded_until):
+        follow_up = self._pending_silence_follow_up
+        accept_audio(self, frame, recorded_until=recorded_until)
+        if follow_up:
+            intervals.append((self._at(self._persona_began), self._at(recorded_until)))
+            recorded[follow_up].set()
+
+    speak = ScriptedTTS._speak
+
+    async def interrupted_speech(self, text):
+        assert active is not None
+        follow_up = active._pending_silence_follow_up
+        if not follow_up:
+            await speak(self, text)
+            return
+        await self.push_frame(TTSStartedFrame())
+        await self.push_frame(
+            TTSAudioRawFrame(
+                audio=encode_speech("Hello", self.sample_rate_hz),
+                sample_rate=self.sample_rate_hz,
+                num_channels=1,
+            )
+        )
+        await recorded[follow_up].wait()
+        assert transport is not None
+        transport._queue_words(silence_tests.WORDLESS_AUDIO)
+        # A real VAD interruption cancels this partial TTS response. Stock TTS
+        # also drops the remaining audio without delivering TTSStoppedFrame.
+        await asyncio.Event().wait()
+
+    transcribe = ScriptedSTT.run_stt
+
+    async def omit_noise_words(self, audio):
+        async for frame in transcribe(self, audio):
+            if (
+                isinstance(frame, TranscriptionFrame)
+                and frame.text == silence_tests.WORDLESS_AUDIO
+            ):
+                frame.text = ""
+            yield frame
+
+    agent_finished = VoiceConductor.the_agent_finished
+
+    async def finish_noise_before_more_silence(self, said, heard_a_turn):
+        due = await agent_finished(self, said, heard_a_turn)
+        if heard_a_turn and not said.strip():
+            assert transport is not None
+            # Continue the media clock after the blank boundary is processed.
+            # This prevents fixture audio from racing ahead of its backstop.
+            transport._queue_audio(silence(13, transport._input_rate))
+        return due
+
+    monkeypatch.setattr(silence_tests.AgentScript, "__init__", remember_transport)
+    monkeypatch.setattr(VoiceConductor, "persona_will_speak", remember_persona)
+    monkeypatch.setattr(VoiceConductor, "persona_audio", remember_audio)
+    monkeypatch.setattr(
+        VoiceConductor, "the_agent_finished", finish_noise_before_more_silence
+    )
+    monkeypatch.setattr(ScriptedTTS, "_speak", interrupted_speech)
+    monkeypatch.setattr(ScriptedSTT, "run_stt", omit_noise_words)
+
+    walk = await silence_tests.walk_silence(
+        tmp_path, parameters=ConductParameters(agent_turn_backstop_seconds=0.5)
+    )
+
+    assert walk.result is not None
+    assert (
+        walk.result.reason == "the agent did not respond after two persona follow-ups"
+    )
+    assert len(walk.requests) == 3
+    assert len(intervals) == 2
+    assert (
+        len(walk.persona_turns) == 1
+    )  # Partial speech is not invented as a full turn.
+    silence_tests.assert_ten_seconds(intervals[1][0] - intervals[0][1])
+    silence_tests.assert_ten_seconds(walk.recording_ended - intervals[1][1])

--- a/apps/simulator/tests/test_plug_livekit.py
+++ b/apps/simulator/tests/test_plug_livekit.py
@@ -49,10 +49,8 @@ from token_endpoint_stub import serving
 from egma_simulator.blob import FilesystemBlobStore
 from egma_simulator.contract import AGENT_NEVER_JOINED, ERROR, contract_dir
 from egma_simulator.conversation import (
-    SAID_NOTHING,
     Conducted,
     ConversationControls,
-    SilentAgent,
 )
 from egma_simulator.media import MediaBackend, MediaBackendError, VoiceMedia
 from egma_simulator.media import livekit_room as livekit_room_module
@@ -871,8 +869,7 @@ async def test_a_muted_lead_hands_the_room_on_instead_of_deafening_it(
     not the end of a track: nothing is unsubscribed and the stream never
     ends, so a mix that only handed the clock on at those two events would
     hold it forever. The persona would then hear nothing while the other
-    track published — this lane's own defect by a second door, and one
-    that ends the run as a silent agent.
+    track published, losing the agent's speech from the simulation.
 
     LiveKit publishes the mute; Pipecat 1.7.0 registers no handler for it,
     so the room does.
@@ -2137,34 +2134,31 @@ async def test_a_dispatch_the_platform_refuses_is_a_fault_in_its_words(
     assert stub.deleted == [stub.rooms[0].name]
 
 
-async def test_an_agent_that_said_nothing_at_all_never_held_a_conversation(
+async def test_a_silent_agent_completes_after_two_persona_follow_ups(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """A worker that joins, publishes, and says no word in any turn.
-
-    The persona talks to it, gets nothing back, runs out of scenario and
-    concludes — so the simulation used to end ``persona_concluded`` and go
-    to grading, and a grader read ten minutes of silence as a finished
-    conversation. It is an execution failure now: nothing was tested, so
-    nothing is graded, and the sentence says what to go and look at.
-    """
+    """An agent's silence is recorded behavior, and the room still closes."""
     stub = RoomStub(greeting=None, replies=[])
 
-    with pytest.raises(SilentAgent) as silent:
-        await room_walk(tmp_path, stub, monkeypatch, scenario="One point.")
+    conducted, turns, _measures, assembled = await room_walk(
+        tmp_path,
+        stub,
+        monkeypatch,
+        scenario="One point. Two point. Three point. Four point.",
+    )
 
-    # What the record carries, asked the way the service asks it: a failed
-    # simulation, and an ending the contract never grades.
-    assert failed_ending(silent.value) == ERROR
-    assert ERROR in FAILED_ENDINGS
-    told = str(silent.value)
-    assert told == SAID_NOTHING
-    assert "said nothing" in told
-    assert "grade" in told
-    # And never one of the deliberate endings, which is the whole defect.
-    assert "persona_concluded" not in told
-    assert "limit_reached" not in told
-    # The room still went away, the way it does however a simulation ends.
+    assert conducted.status == "completed"
+    assert conducted.ending == "persona_concluded"
+    assert conducted.reason == (
+        "the agent did not respond after two persona follow-ups"
+    )
+    assert turns == [
+        ("human", "One point."),
+        ("human", "Two point."),
+        ("human", "Three point."),
+    ]
+    recording = (tmp_path / assembled.audio["recording"]).read_bytes()
+    assert_one_speaker_to_a_channel(recording, turns)
     assert stub.deleted == [stub.rooms[0].name]
 
 

--- a/apps/simulator/tests/test_voice.py
+++ b/apps/simulator/tests/test_voice.py
@@ -43,7 +43,7 @@ from egma_simulator.conversation import (
     ConversationControls,
     SilentAgent,
 )
-from egma_simulator.media import VoiceMedia
+from egma_simulator.media import VoiceMedia, scripted_transport
 from egma_simulator.media.scripted_transport import ScriptedTransport
 from egma_simulator.model import GOODBYE, ScriptedModel
 from egma_simulator.persona import Persona
@@ -809,8 +809,13 @@ async def test_transport_loss_is_a_platform_fault(tmp_path: Path):
     assert "voice transport disconnected" in str(lost.value)
 
 
-async def test_the_persona_opens_when_the_far_end_does_not(tmp_path: Path):
+async def test_the_persona_opens_when_the_far_end_does_not(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
     """No greeting is not a broken call: a persona may speak first."""
+    # Match this test's shortened opening wait so the fixture does not leave
+    # ten more seconds of queued silence in front of the agent's answer.
+    monkeypatch.setattr(scripted_transport, "OPENING_SILENCE_SECONDS", 2.0)
     observed = await voice_simulation(
         tmp_path,
         scenario="One point.",
@@ -1347,6 +1352,9 @@ async def test_a_turn_no_transcriber_finds_words_in_is_a_turn_without_words(
     """
 
     monkeypatch.setattr(conductor_module, "build_legs", deaf_legs)
+    # Keep the media clock running while the persona waits ten seconds after
+    # wordless agent speech. The usual fixture sends only 0.6 seconds of quiet.
+    monkeypatch.setattr(scripted_transport, "TRAILING_SILENCE_SECONDS", 13.0)
 
     spans: list[tuple[str, str, int, int]] = []
     with pytest.raises(SilentAgent) as silent:
@@ -1436,6 +1444,7 @@ async def test_a_cancel_outranks_a_silence(
     would be a defect nobody could act on.
     """
     monkeypatch.setattr(conductor_module, "build_legs", deaf_legs)
+    monkeypatch.setattr(scripted_transport, "TRAILING_SILENCE_SECONDS", 13.0)
 
     spans: list[tuple[str, str, int, int]] = []
     observed = await voice_simulation(

--- a/apps/simulator/tests/test_voice.py
+++ b/apps/simulator/tests/test_voice.py
@@ -38,10 +38,8 @@ from egma_simulator.blob import FilesystemBlobStore
 from egma_simulator.conductor import ConductParameters, VoiceConductor
 from egma_simulator.contract import ERROR
 from egma_simulator.conversation import (
-    SAID_NOTHING,
     Conducted,
     ConversationControls,
-    SilentAgent,
 )
 from egma_simulator.media import VoiceMedia, scripted_transport
 from egma_simulator.media.scripted_transport import ScriptedTransport
@@ -1296,10 +1294,8 @@ async def test_a_leg_that_refuses_a_turn_fails_the_simulation_in_its_own_words(
 class DeafEars(FrameProcessor):
     """A listening leg that carries audio but emits no transcription.
 
-    What a transcriber handed a stretch of audio it finds no words in
-    really does: it pushes no frame at all. Every agent turn is then
-    recorded with no words, which is the shape of the dead call the
-    silence rule exists for, and the cheapest way to script one.
+    A transcriber that finds no words can push no frame at all. The
+    pipeline must still close the agent turn and record it without words.
     """
 
     async def process_frame(self, frame, direction) -> None:
@@ -1308,7 +1304,7 @@ class DeafEars(FrameProcessor):
 
 
 def deaf_legs(providers, *, voice):
-    """The scripted legs, with nobody listening on the agent's side."""
+    """Scripted speech with no transcription of the agent's audio."""
     return SpeechLegs(stt=DeafEars(), tts=ScriptedTTS(voice=voice), voice=voice)
 
 
@@ -1332,23 +1328,11 @@ async def test_a_brain_that_refuses_a_turn_fails_in_its_own_words(
 async def test_a_turn_no_transcriber_finds_words_in_is_a_turn_without_words(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """The other way a turn goes wrong, and the one a phone call makes
-    ordinary: audio arrives and nobody can read it.
+    """Audio without recognized words remains conversation evidence.
 
-    A transcriber handed a stretch of audio it finds no words in pushes no
-    frame at all — there is no empty transcript, only silence — and the
-    turn model will not call a turn over until it has one. So the turn
-    would stay open forever, and without a backstop the simulation runs to
-    its duration limit and the record says "limit reached" about hold
-    music. What the record should say is that the turn carried no words,
-    which is what it did.
-
-    That backstop is the subject here, and it holds: the turn closes, it
-    is recorded with no words, and the persona carries on rather than
-    waiting out the clock. What the whole simulation is then *worth* is
-    the second half of the story — every one of the agent's turns empty is
-    the dead call this product must never grade, so the run fails instead
-    of ending.
+    The backstop closes the turn even when the transcriber emits no frame.
+    The persona can then continue and end the conversation normally. The
+    agent's lack of words does not turn that ending into an execution error.
     """
 
     monkeypatch.setattr(conductor_module, "build_legs", deaf_legs)
@@ -1357,16 +1341,13 @@ async def test_a_turn_no_transcriber_finds_words_in_is_a_turn_without_words(
     monkeypatch.setattr(scripted_transport, "TRAILING_SILENCE_SECONDS", 13.0)
 
     spans: list[tuple[str, str, int, int]] = []
-    with pytest.raises(SilentAgent) as silent:
-        await voice_simulation(
-            tmp_path,
-            scenario="One point.",
-            replies=["Noted."],
-            # Only the waiting is shortened; what is given up on is exactly
-            # what a deployment gives up on.
-            parameters=ConductParameters(agent_turn_backstop_seconds=0.3),
-            spans=spans,
-        )
+    observed = await voice_simulation(
+        tmp_path,
+        scenario="One point.",
+        replies=["Noted."],
+        parameters=ConductParameters(agent_turn_backstop_seconds=0.3),
+        spans=spans,
+    )
 
     # The backstop did its work: the turn was closed and recorded, and the
     # persona spoke on both sides of it rather than the clock running out.
@@ -1377,22 +1358,16 @@ async def test_a_turn_no_transcriber_finds_words_in_is_a_turn_without_words(
     # what says the turn really was given up on rather than waited out —
     # the run got all the way to its natural end inside the limits.
     assert turns[-1] == ("human", GOODBYE), turns
-    # And the simulation is a failure the contract never grades, never one
-    # of the deliberate endings it used to claim.
-    assert failed_ending(silent.value) == ERROR
-    assert str(silent.value) == SAID_NOTHING
+    assert observed.conducted.status == "completed"
+    assert observed.conducted.ending == "persona_concluded"
+    assert observed.conducted.reason == "the persona concluded the scenario"
+    audio = observed.assembled.audio
+    assert audio is not None
+    assert (tmp_path / audio["recording"]).is_file()
 
 
 async def test_a_turn_limit_of_one_keeps_its_own_ending(tmp_path: Path):
-    """A spec that allows one turn ends before the agent could answer.
-
-    The persona speaks, the budget is spent, and the run stops — with no
-    agent turn on the record, which looks exactly like an agent that said
-    nothing. It is not: the limit is deliberate and is never the agent
-    failing, so the run keeps ``limit_reached`` rather than being called
-    a silence. One persona turn is the whole of the difference, which is
-    why the silence rule waits for a second one.
-    """
+    """The turn limit keeps its normal ending even before the agent answers."""
     observed = await voice_simulation(
         tmp_path,
         scenario="One point. Two point.",
@@ -1409,12 +1384,8 @@ async def test_a_turn_limit_of_one_keeps_its_own_ending(tmp_path: Path):
 class CancelsOnce(ConversationControls):
     """A cancel directive that lands the moment the record says to.
 
-    A directive really arrives on a heartbeat answer, mid-exchange, and
-    *when* it lands is the whole subject of the test below. A cancel that
-    landed before the agent had taken a turn would be answered the same
-    way whichever order the two answers were decided in, so it would
-    prove nothing: the record has to already hold what the silence rule
-    fires on at the moment the directive arrives.
+    The test can cancel after a wordless agent turn is recorded, so it
+    exercises cancellation during that conversation state.
     """
 
     def __init__(self, when: Callable[[], bool]) -> None:
@@ -1430,19 +1401,7 @@ class CancelsOnce(ConversationControls):
 async def test_a_cancel_outranks_a_silence(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """A run stopped on purpose is not a run that failed.
-
-    Both answers are true of this run at once. Nobody is listening on the
-    agent's side, so every turn it takes is recorded with no words — the
-    dead call the silence rule fails runs for — and the directive lands
-    only once one of those turns is on the record, so the rule really
-    would fire if it were asked first.
-
-    The cancel is the answer. It is somebody's own act, and a run stopped
-    before it could finish is not a run that failed: reporting a defect
-    there would put one on the record where a decision belongs, and it
-    would be a defect nobody could act on.
-    """
+    """Cancellation keeps its own ending after a wordless agent turn."""
     monkeypatch.setattr(conductor_module, "build_legs", deaf_legs)
     monkeypatch.setattr(scripted_transport, "TRAILING_SILENCE_SECONDS", 13.0)
 
@@ -1458,9 +1417,7 @@ async def test_a_cancel_outranks_a_silence(
         spans=spans,
     )
 
-    # The record really did hold a wordless agent turn when the directive
-    # landed — without this the test would pass on an empty record, which
-    # the silence rule leaves alone anyway.
+    # The directive lands after a wordless turn is part of the record.
     turns = [(speaker, text) for speaker, text, _began, _ended in spans]
     assert ("agent", "") in turns, turns
     # And the cancel is still what the run is reported as.


### PR DESCRIPTION
When an agent stopped replying, the simulator could ask the persona model to speak without any new agent input or a silence instruction. An empty model answer then failed the simulation. The silence request now contains an explicit, numbered follow-up instruction using the same wait setting as the timer.

For voice conversations, the persona waits 10 seconds after its speech ends, follows up at most twice, then waits another 10 seconds before hanging up. A real agent reply resets the allowance. Audible interrupted follow-ups count, and the next wait starts at the last audio sent. Wordless audio does not spend or reset the allowance.

Unanswered calls now complete normally even if the agent never said any words. The report carries `persona_concluded` and “the agent did not respond after two persona follow-ups,” preserving the transcript, recording, and platform call reference. Removing the old `SilentAgent` exception also preserves explicit cancellation and limit endings. These calls remain available to the configured graders; silence does not force a failed score. Genuine model, speech-provider, and connection faults retain their existing failure reporting.

Validation:
- Ruff and `git diff --check` pass.
- 61 voice, silence-timing, and interruption tests pass.
- Five focused subprocess-reporting and LiveKit connection tests pass, including the fully silent call and genuine connection failures.
- Three captured failing conversations completed in local replay with the real model during the initial fix, each producing two spoken follow-ups and the expected hang-up.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes unanswered voice calls from execution failures into evidence-preserving completed conversations. It removes the former silent-agent exception, allows the persona to make two timed follow-ups before concluding, and preserves explicit cancellations, limits, and genuine infrastructure faults.
- Entirely silent and wordless voice calls now complete as `persona_concluded` after two audible follow-ups.
- Silence instructions use the same configurable delay as the conductor timer.
- Real agent speech resets the follow-up allowance, while wordless audio does not.
- Interrupted audible follow-ups count, and subsequent waiting begins at the last emitted audio.
- Acceptance and LiveKit tests verify terminal reporting, recordings, transcripts, provider references, and fault behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no actionable regression remains in the latest revision.

The configurable wait-duration drift reported previously is fixed by carrying `agent_quiet_seconds` into the persona context, and the other prior finding was withdrawn and manually resolved after the intended grading policy was clarified. The latest change consistently applies that policy to entirely silent calls while preserving explicit stop conditions, genuine fault reporting, and terminal evidence.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/simulator/src/egma_simulator/conductor.py | Implements bounded silence follow-ups, timer/reset behavior, interruption accounting, and normal silent-call completion while retaining existing fault and control paths. |
| apps/simulator/src/egma_simulator/conversation.py | Removes the obsolete `SilentAgent` execution-failure type and documents silence as observable grading evidence. |
| apps/simulator/src/egma_simulator/persona.py | Adds numbered silence instructions using the conductor-provided wait duration and excludes empty turns from model history. |
| apps/simulator/src/egma_simulator/service.py | Retains provider references for every terminal report, including genuine faults. |
| apps/simulator/tests/test_persona_silence.py | Exercises follow-up timing, allowance resets, wordless audio, interruption behavior, cancellation, limits, and fully silent completion through the voice pipeline. |
| apps/simulator/tests/test_acceptance.py | Verifies that an entirely silent voice call completes with transcript, recording, provider reference, and no refusal report. |
| apps/simulator/tests/test_plug_livekit.py | Verifies the silent-call policy through the LiveKit connection path while preserving cleanup and evidence. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant A as Voice agent
    participant C as Voice conductor
    participant P as Persona
    participant R as Reporter
    P->>A: Initial persona turn
    C->>C: Wait configured quiet interval
    C->>P: Request follow-up 1 of 2
    P->>A: First follow-up
    C->>C: Wait from last persona audio
    C->>P: Request follow-up 2 of 2
    P->>A: Second follow-up
    C->>C: Wait from last persona audio
    C->>R: Complete as persona_concluded
    Note over R: Preserve transcript, recording, and provider reference
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(simulator): complete unanswered voic..."](https://github.com/egma-ai/egma/commit/eaa3990b6b78571c5831ef20a8e17c20b4f8d227) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60704387)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Simulation platform](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/simulation-platform.md)
- Knowledge Base — [Simulator execution pipeline](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/simulator-execution.md)
- Knowledge Base — [Simulator personas and scenarios](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/simulator-personas-and-scenarios.md)
- Knowledge Base — [Simulator media transports](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/simulator-media-transports.md)
- Knowledge Base — [Restore safe Retell simulation lifecycle](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/reverts/rollback_287-20260831-retell-simulation-safety-6a1524e.md)
</details>


<!-- /greptile_comment -->