### PR TITLE
The recorder places each channel of a recording by time, not by count

### DIFF
--- a/apps/simulator/src/egma_simulator/conductor.py
+++ b/apps/simulator/src/egma_simulator/conductor.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-import math
 import time
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass, field, replace
@@ -62,7 +61,13 @@ from .conversation import (
     duration_limit_reached,
     turn_limit_reached,
 )
-from .media import RemoteParticipantLeftFrame, VoiceMedia
+from .media import (
+    TRANSPORT_ARRIVAL,
+    TRANSPORT_PLAYOUT,
+    RemoteParticipantLeftFrame,
+    VoiceMedia,
+    transport_time,
+)
 from .model import END_CALL_TOOL_NAME, ModelFailure, PersonaReply
 from .persona import SILENCE_FOLLOW_UP_LIMIT, SILENCE_WAIT_SECONDS, Persona, Turn
 from .platform_logging import log_event
@@ -215,68 +220,89 @@ class _RecordedInputSegment:
     recording_end_sample: int
 
 
+@dataclass
+class _RecordedTrack:
+    """How far one channel of the recording has been written.
+
+    ``written_through`` is the sample the next audio follows, which is not
+    the same as the length of the buffer: a channel the conversation has
+    left quiet keeps its cursor where its own last audio ended while the
+    other channel runs on.
+    """
+
+    written_through: int | None = None
+
+
+RESYNC_TOLERANCE_SECONDS = 0.1
+"""How far a channel may run from its own transport clock before the
+recorder puts it back where the clock says.
+
+Under the tolerance the audio is written end to end. That is what keeps a
+jittery delivery — one frame late, the next one early — from chopping a
+single utterance into pieces, and it is why the recorder does not simply
+seek on every frame. Over it, the count and the clock disagree about the
+passing of time itself, and time wins: the audio goes where the transport
+says it belongs and the recording holds quiet across the difference.
+LiveKit's own in-process recorder re-anchors at the same tenth of a
+second.
+
+A channel that runs *ahead* of its clock is never pulled back. Audio
+arriving faster than real time is a delivery that stalled and caught up,
+and a second of speech is a second of speech whenever it reaches here;
+overwriting it to obey the clock would destroy evidence to correct a
+timestamp.
+"""
+
+
 class _EvidenceRecorder(AudioBufferProcessor):
-    """Expose Pipecat's canonical recording cursor to the transcript."""
+    """One recording, on one timeline, written by the clock and not by the
+    count.
+
+    Pipecat's recorder keeps time by buffer length: whichever side writes
+    first pads the other side up to its own position. That makes a file
+    whose two channels are the same length and whose content is in the
+    wrong place — the agent's reply lands wherever the persona's buffer
+    had already reached, and the lead accumulates, so the whole recording
+    slides later than the call it came from.
+
+    This recorder places every frame where its transport says it happened.
+    The agent's audio goes at the instant it arrived at the transport; the
+    persona's goes at the instant the transport plays it out, which is
+    after the transport's own pacing and not when the speech leg made it.
+    Silence is whatever nothing was written over. Both channels read one
+    clock, so a distance measured across them on the file is the distance
+    the caller lived through — which is what every latency egma reads off
+    a recording claims to be.
+    """
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         # Pipecat's recorder clears its resampler after 0.2s of *wall-clock*
         # quiet, to keep stale history out of audio that really did pause.
-        # This recorder must not: the map from a turn's source time to its
-        # place in the recording is read out of that same resampler's
-        # `delay()`, and a clear discards samples the delay had accounted
-        # for. The map then carries a hole, and a turn boundary landing in
-        # it cannot be placed at all — which is a SpeechFault and a failed
-        # simulation, over audio the recording actually holds.
-        #
-        # The trigger is wall-clock, not conversation: a loaded machine
-        # deschedules this process past 0.2s between two frames of one
-        # continuous utterance. Nothing paused; only the CPU did.
+        # This recorder must not: a clear discards the samples the resampler
+        # still holds, which is audio the recording then never carries at
+        # all, and the trigger is wall-clock rather than conversation — a
+        # loaded machine deschedules this process past 0.2s between two
+        # frames of one continuous utterance. Nothing paused; only the CPU
+        # did.
         #
         # `None` is Pipecat's own documented answer — its docstring
         # recommends it "for telephony providers that have irregular gaps
         # between chunks", which is this case exactly, and the artefact it
         # protects against needs a real silence to appear across.
         self._input_resampler = SOXRStreamAudioResampler(clear_after_secs=None)
-        # The persona's channel, for the same reason and with a different
-        # symptom. Nothing reads a delay on this side — `bot_position` counts
-        # the buffer — so a clear here raises nothing at all. It simply drops
-        # the tail of an utterance out of the recording a customer plays
-        # back, on any machine, at any load, and says nothing about it. The
-        # agent's side at least failed loudly.
         self._output_resampler = SOXRStreamAudioResampler(clear_after_secs=None)
         self._recording_ready = asyncio.Condition()
-        self._resampled_input: dict[int, tuple[int, float]] = {}
         self._processed_source_end = Fraction(0)
+        self._represented_source_end = Fraction(0)
         self._last_input_frame_duration = Fraction(0)
         self._input_segments: list[_RecordedInputSegment] = []
         self._closing_source_end: MediaPosition | None = None
         self._input_closed = False
-
-    async def _resample_input_audio(self, frame: InputAudioRawFrame) -> bytes:
-        audio = await super()._resample_input_audio(frame)
-        self._resampled_input[frame.id] = (
-            len(audio) // 2,
-            self._input_resampler_delay(),
-        )
-        return audio
-
-    def _input_resampler_delay(self) -> float:
-        """Read the exact pending output from Pipecat's pinned recorder."""
-        resampler = getattr(self, "_input_resampler", None)
-        if not isinstance(resampler, SOXRStreamAudioResampler):
-            raise SpeechFault(
-                "the pinned pipecat release changed its recording resampler"
-            )
-        stream = getattr(resampler, "_soxr_stream", None)
-        if stream is None:
-            return 0.0
-        delay = float(stream.delay())
-        if delay < 0 or not math.isfinite(delay):
-            raise SpeechFault(
-                "the pinned pipecat release returned an invalid resampler delay"
-            )
-        return delay
+        self._agent = _RecordedTrack()
+        self._persona = _RecordedTrack()
+        self._origin_seconds: float | None = None
+        self._origin_unix_nano = 0
 
     @staticmethod
     def _source_range(
@@ -291,61 +317,175 @@ class _EvidenceRecorder(AudioBufferProcessor):
             raise SpeechFault("agent audio reached the recorder without its position")
         return cast(tuple[MediaPosition, MediaPosition], source_range)
 
+    @staticmethod
+    def _transport_time(frame: Frame, named: str, whose: str) -> float:
+        stamped = transport_time(frame, named)
+        if stamped is None:
+            raise SpeechFault(
+                f"{whose} reached the recorder without its transport time"
+            )
+        return stamped
+
+    def _reset_recording(self) -> None:
+        """Start the timeline over with the buffers Pipecat just emptied."""
+        super()._reset_recording()
+        self._agent = _RecordedTrack()
+        self._persona = _RecordedTrack()
+        self._origin_seconds = None
+        self._origin_unix_nano = 0
+
     async def _process_recording(self, frame: Frame) -> None:
-        # Input audio is a Pipecat SystemFrame while output audio is a normal
-        # frame, so Pipecat can present both to this processor at once. Keep
-        # each recorder update and its position map indivisible.
+        """Put one frame on the recording, at the time it happened.
+
+        Pipecat's own placement is replaced outright rather than extended:
+        its padding rule is the defect, and running both would pad the
+        very gaps this fills. Input audio is a Pipecat SystemFrame while
+        output audio is an ordinary frame, so Pipecat can present both to
+        this processor at once. Keep each write and its position map
+        indivisible.
+        """
         async with self._recording_ready:
-            if isinstance(frame, InputAudioRawFrame) and self._input_closed:
-                raise SpeechFault("agent audio arrived after its recorded input ended")
-            await super()._process_recording(frame)
-            if not isinstance(frame, InputAudioRawFrame):
+            if isinstance(frame, InputAudioRawFrame):
+                await self._record_agent(frame)
+            elif isinstance(frame, OutputAudioRawFrame):
+                await self._record_persona(frame)
+            elif isinstance(frame, InterruptionFrame):
+                self._drop_what_was_never_played(frame)
+            else:
                 return
-            source_start, source_end = self._source_range(frame)
-            if source_start != self._processed_source_end or source_end < source_start:
-                raise SpeechFault("agent audio reached the recorder out of order")
-            try:
-                written, pending = self._resampled_input.pop(frame.id)
-            except KeyError as changed:
-                raise SpeechFault(
-                    "the pinned pipecat release skipped its recording resampler"
-                ) from changed
-            if written:
-                represented_end_samples = float(source_end * self.sample_rate) - pending
-                rounded_end = round(represented_end_samples)
-                if abs(represented_end_samples - rounded_end) > 1e-6:
-                    raise SpeechFault(
-                        "pipecat's recording resampler returned an invalid position"
-                    )
-                represented_end = Fraction(rounded_end, self.sample_rate)
-                represented_start = represented_end - Fraction(
-                    written, self.sample_rate
-                )
-                recording_end = len(self._user_audio_buffer) // 2
-                recording_start = recording_end - written
-                if represented_start < 0 or represented_end > source_end:
-                    raise SpeechFault(
-                        "pipecat's recording resampler returned an invalid position"
-                    )
-                if (
-                    self._input_segments
-                    and represented_start < self._input_segments[-1].source_end
-                ):
-                    raise SpeechFault(
-                        "pipecat's recording resampler moved agent audio backwards"
-                    )
-                self._input_segments.append(
-                    _RecordedInputSegment(
-                        source_start=represented_start,
-                        source_end=represented_end,
-                        recording_start_sample=recording_start,
-                        recording_end_sample=recording_end,
-                    )
-                )
-            self._processed_source_end = source_end
-            self._last_input_frame_duration = source_end - source_start
-            self._maybe_close_input()
             self._recording_ready.notify_all()
+
+    async def _record_agent(self, frame: InputAudioRawFrame) -> None:
+        """The agent's audio, where it arrived at the transport."""
+        if self._input_closed:
+            raise SpeechFault("agent audio arrived after its recorded input ended")
+        source_start, source_end = self._source_range(frame)
+        if source_start != self._processed_source_end or source_end < source_start:
+            raise SpeechFault("agent audio reached the recorder out of order")
+        arrived = self._transport_time(frame, TRANSPORT_ARRIVAL, "agent audio")
+        audio = await self._resample_input_audio(frame)
+        written = len(audio) // 2
+        if written:
+            # A resampler emits its samples in order and holds part of a
+            # frame back to give out with the next one. So what it just
+            # returned is the audio that *ends* with this frame rather
+            # than the audio that starts with it, and one chunk after
+            # another covers the source with no gap and no overlap,
+            # trailing it by whatever is held. Placing each chunk by its
+            # end keeps every sample inside the frame it came from, and
+            # carrying the boundary forward keeps the map from a turn's
+            # source time to its place in the recording whole from one end
+            # of a call to the other.
+            through = arrived + float(source_end - source_start)
+            began, ended = self._place(
+                self._user_audio_buffer,
+                self._agent,
+                through - written / self.sample_rate,
+                audio,
+            )
+            represented_start = self._represented_source_end
+            represented_end = represented_start + Fraction(written, self.sample_rate)
+            if represented_end > source_end:
+                raise SpeechFault(
+                    "pipecat's recording resampler returned more audio than it was fed"
+                )
+            self._represented_source_end = represented_end
+            self._input_segments.append(
+                _RecordedInputSegment(
+                    source_start=represented_start,
+                    source_end=represented_end,
+                    recording_start_sample=began,
+                    recording_end_sample=ended,
+                )
+            )
+        self._processed_source_end = source_end
+        self._last_input_frame_duration = source_end - source_start
+        self._maybe_close_input()
+
+    async def _record_persona(self, frame: OutputAudioRawFrame) -> None:
+        """The persona's audio, where the transport plays it out."""
+        played = self._transport_time(frame, TRANSPORT_PLAYOUT, "persona audio")
+        audio = await self._resample_output_audio(frame)
+        written = len(audio) // 2
+        if not written:
+            return
+        through = played + frame.num_frames / frame.sample_rate
+        self._place(
+            self._bot_audio_buffer,
+            self._persona,
+            through - written / self.sample_rate,
+            audio,
+        )
+
+    def _drop_what_was_never_played(self, frame: Frame) -> None:
+        """Forget persona audio the transport threw away unheard.
+
+        An interruption clears whatever the transport had queued and had
+        not yet played. A recording that kept it would say the persona
+        spoke for as long as the queue was deep, and would start the next
+        wait that much late.
+        """
+        cleared = transport_time(frame, TRANSPORT_PLAYOUT)
+        if cleared is None or self._origin_seconds is None:
+            return
+        heard_through = self._sample_at(cleared)
+        written_through = self._persona.written_through
+        if written_through is None or written_through <= heard_through:
+            return
+        del self._bot_audio_buffer[heard_through * 2 :]
+        self._persona.written_through = heard_through
+
+    def _place(
+        self,
+        buffer: bytearray,
+        track: _RecordedTrack,
+        starts_at: float,
+        audio: bytes,
+    ) -> tuple[int, int]:
+        """Write one channel's audio where its transport clock puts it.
+
+        The first frame anybody writes fixes the recording's own zero, so
+        a file always starts with the audio that opened the call.
+        """
+        if self._origin_seconds is None:
+            self._origin_seconds = starts_at
+            self._origin_unix_nano = _now()
+        began = self._sample_at(starts_at)
+        written_through = track.written_through
+        if written_through is not None and began - written_through <= self._tolerance:
+            began = written_through
+        ended = began + len(audio) // 2
+        self._write(buffer, began, audio)
+        track.written_through = ended
+        return began, ended
+
+    def _sample_at(self, seconds: float) -> int:
+        """One instant on the transport's clock, as a recording position.
+
+        Audio stamped before the recording's own zero is held at its
+        start. Only a frame that crossed the pipeline beside the very
+        first one can be, and holding it there costs the interleave of
+        those two rather than anything a listener would find.
+        """
+        origin = self._origin_seconds
+        if origin is None or not self.sample_rate:
+            return 0
+        return max(0, round((seconds - origin) * self.sample_rate))
+
+    @property
+    def _tolerance(self) -> int:
+        return round(RESYNC_TOLERANCE_SECONDS * self.sample_rate)
+
+    @staticmethod
+    def _write(buffer: bytearray, at_sample: int, audio: bytes) -> None:
+        """Audio at one position, with quiet wherever nothing was written."""
+        at = at_sample * 2
+        if len(buffer) < at:
+            buffer.extend(bytes(at - len(buffer)))
+        through = at + len(audio)
+        if len(buffer) < through:
+            buffer.extend(bytes(through - len(buffer)))
+        buffer[at:through] = audio
 
     async def close_input_at(self, source_end: MediaPosition) -> None:
         """Close input after the recorder has written every earlier frame."""
@@ -367,19 +507,32 @@ class _EvidenceRecorder(AudioBufferProcessor):
             self._input_closed = True
 
     @property
+    def started_unix_nano(self) -> int:
+        """When the recording's own zero was, on the wall clock.
+
+        Every transcript position is an offset from here, so this is what
+        makes a seek into the file land on the words the turn names.
+        """
+        return self._origin_unix_nano
+
+    @property
     def bot_position(self) -> MediaPosition:
-        if not self.sample_rate:
+        """Where the persona's audio has been played out through."""
+        if not self.sample_rate or self._persona.written_through is None:
             return Fraction(0)
-        # Pipecat 1.7.0 has no public current-output cursor. This one access is
-        # pinned in uv.lock and covered by the frame-level alignment test.
-        return Fraction(len(self._bot_audio_buffer) // 2, self.sample_rate)
+        return Fraction(self._persona.written_through, self.sample_rate)
 
     @property
     def position(self) -> MediaPosition:
+        """The last instant either side put audio on the recording."""
         if not self.sample_rate:
             return Fraction(0)
-        samples = max(len(self._user_audio_buffer), len(self._bot_audio_buffer)) // 2
-        return Fraction(samples, self.sample_rate)
+        written = [
+            track.written_through
+            for track in (self._agent, self._persona)
+            if track.written_through is not None
+        ]
+        return Fraction(max(written, default=0), self.sample_rate)
 
     async def agent_interval(
         self,
@@ -388,7 +541,7 @@ class _EvidenceRecorder(AudioBufferProcessor):
         *,
         observed_through: MediaPosition,
     ) -> tuple[MediaPosition, MediaPosition]:
-        """Place one agent turn on Pipecat's canonical recorded track."""
+        """Place one agent turn on the recording's own timeline."""
         async with self._recording_ready:
             while True:
                 if self._processed_source_end < observed_through:
@@ -768,7 +921,9 @@ class _Timeline(FrameProcessor):
         elif isinstance(frame, TTSStoppedFrame):
             await self._conductor.persona_stopped()
         elif isinstance(frame, InterruptionFrame):
-            self._conductor.persona_interrupted()
+            self._conductor.persona_interrupted(
+                heard_through=self._recorder.bot_position
+            )
         elif isinstance(frame, RemoteParticipantLeftFrame):
             frame.completed.set()
             self._conductor.media_advanced()
@@ -1083,7 +1238,7 @@ class VoiceConductor:
             return
         self.audio = AudioFacts(
             recording=reference,
-            started_unix_nano=self._opened_unix_nano,
+            started_unix_nano=self._recording_began_unix_nano,
         )
 
     async def _run(self) -> None:
@@ -1262,11 +1417,20 @@ class VoiceConductor:
         self._persona_ended = recorded_until
         self.media_advanced()
 
-    def persona_interrupted(self) -> None:
-        """Start waiting from the last audio heard before an interruption."""
+    def persona_interrupted(self, *, heard_through: MediaPosition) -> None:
+        """Start waiting from the last audio heard before an interruption.
+
+        The transport throws away what it had queued and not yet played,
+        so the persona stopped where the recording stops holding it — not
+        where the speech leg had already run to.
+        """
         ended = self._persona_ended
         if ended is None:
             return
+        began = self._persona_began
+        ended = min(ended, heard_through)
+        if began is not None and ended < began:
+            ended = began
         self._record.persona_last_stopped_at = ended
         self._record.quiet_since = max(self._record.quiet_since, ended)
         self._pending_persona_text = None
@@ -1350,7 +1514,22 @@ class VoiceConductor:
 
     def _at(self, position: MediaPosition) -> int:
         nanos = position.numerator * 1_000_000_000 // position.denominator
-        return self._opened_unix_nano + nanos
+        return self._recording_began_unix_nano + nanos
+
+    @property
+    def _recording_began_unix_nano(self) -> int:
+        """The instant the recording's own zero stands for.
+
+        Positions are offsets into the recording, so a transcript span
+        only seeks to the right words while this is the wall-clock time
+        of the recording's first sample. Until the first audio is placed
+        there is no recording yet, and the moment the line was opened is
+        the closest honest answer.
+        """
+        recorder = self._recorder
+        if recorder is not None and recorder.started_unix_nano:
+            return recorder.started_unix_nano
+        return self._opened_unix_nano
 
     def media_advanced(self) -> None:
         self._activity.set()

--- a/apps/simulator/src/egma_simulator/conductor.py
+++ b/apps/simulator/src/egma_simulator/conductor.py
@@ -229,13 +229,26 @@ class _RecordedTrack:
     left quiet keeps its cursor where its own last audio ended while the
     other channel runs on.
 
-    ``quiet_owed`` is how much of the quiet at ``quiet_ends_at`` the
-    recorder put there itself, at a re-anchor, and can still take back.
+    ``owed`` is every stretch of quiet the recorder put there itself, at
+    a re-anchor, and can still take back — each as the sample it ends at
+    and how much of it is left, oldest first. A channel can fall behind
+    twice before it catches up at all, and a burst that could only reach
+    the newer of the two would leave the older one in the recording for
+    good.
     """
 
     written_through: int | None = None
-    quiet_owed: int = 0
-    quiet_ends_at: int = 0
+    owed: list[tuple[int, int]] = field(default_factory=list)
+
+
+LONGEST_QUIET_LEDGER = 64
+"""How many outstanding stretches of re-anchor quiet one channel keeps.
+
+Every real silence in a call opens one that will never be claimed, so
+the ledger is bounded and the oldest entries go first. Sixty-four is far
+more than the stalls of one call, and forgetting the oldest costs only
+the chance to close a gap opened minutes ago.
+"""
 
 
 RESYNC_TOLERANCE_SECONDS = 0.1
@@ -443,6 +456,11 @@ class _EvidenceRecorder(AudioBufferProcessor):
         not yet played. A recording that kept it would say the persona
         spoke for as long as the queue was deep, and would start the next
         wait that much late.
+
+        Cutting the tail off also settles the quiet this channel was
+        owed: some of that quiet may have gone with the tail, and quiet
+        given back out of a ledger describing a recording that no longer
+        exists would pull the channel back over audio that was heard.
         """
         cleared = transport_time(frame, TRANSPORT_PLAYOUT)
         if cleared is None or self._origin_seconds is None:
@@ -453,6 +471,7 @@ class _EvidenceRecorder(AudioBufferProcessor):
             return
         del self._bot_audio_buffer[heard_through * 2 :]
         self._persona.written_through = heard_through
+        self._persona.owed.clear()
 
     def _place(
         self,
@@ -478,8 +497,8 @@ class _EvidenceRecorder(AudioBufferProcessor):
             # so. Remember the quiet, in case what follows shows it was a
             # delivery holding audio back rather than a far end holding
             # its tongue.
-            track.quiet_owed = wanted - cursor
-            track.quiet_ends_at = wanted
+            track.owed.append((wanted, wanted - cursor))
+            del track.owed[:-LONGEST_QUIET_LEDGER]
             began = wanted
         elif cursor - wanted > self._tolerance:
             self._give_the_quiet_back(buffer, track, cursor - wanted)
@@ -497,33 +516,39 @@ class _EvidenceRecorder(AudioBufferProcessor):
         """Close up quiet the recorder wrote that the audio has caught up on.
 
         A channel writing faster than its clock has been fed a burst, and
-        a burst is a delivery catching up on a stall. The stall is the
-        quiet at ``quiet_ends_at``, so the burst is given as much of it
-        back as it needs, and the recording holds the call end to end
-        again. Only quiet this recorder put there is taken, and only from
-        the one stretch it last put there, so nothing a listener could
-        hear is written over.
+        a burst is a delivery catching up on a stall. The stalls are the
+        quiet on the ledger, so the burst is given as much of it back as
+        it needs — the newest stretch first, because that is the stall it
+        is catching up on, and back through older ones while it is still
+        ahead. Only quiet this recorder put there is taken, so nothing a
+        listener could hear is written over. Closing a newer stretch does
+        not move an older one, which is why the ledger is walked from the
+        end.
         """
-        given = min(ahead, track.quiet_owed)
-        if given <= 0:
-            return
-        closed_from = (track.quiet_ends_at - given) * 2
-        del buffer[closed_from : track.quiet_ends_at * 2]
-        if track is self._agent:
-            # The agent's channel is the one a turn is looked up on, so
-            # closing quiet on it moves every place already mapped past
-            # the quiet. The persona's channel carries no such map.
-            for position, segment in enumerate(self._input_segments):
-                if segment.recording_start_sample >= track.quiet_ends_at:
-                    self._input_segments[position] = replace(
-                        segment,
-                        recording_start_sample=segment.recording_start_sample - given,
-                        recording_end_sample=segment.recording_end_sample - given,
-                    )
-        track.quiet_owed -= given
-        track.quiet_ends_at -= given
-        if track.written_through is not None:
-            track.written_through -= given
+        while ahead > 0 and track.owed:
+            ends_at, owed = track.owed[-1]
+            given = min(ahead, owed)
+            del buffer[(ends_at - given) * 2 : ends_at * 2]
+            if track is self._agent:
+                # The agent's channel is the one a turn is looked up on,
+                # so closing quiet on it moves every place already mapped
+                # past the quiet. The persona's channel carries no map.
+                for position, segment in enumerate(self._input_segments):
+                    if segment.recording_start_sample >= ends_at:
+                        self._input_segments[position] = replace(
+                            segment,
+                            recording_start_sample=(
+                                segment.recording_start_sample - given
+                            ),
+                            recording_end_sample=segment.recording_end_sample - given,
+                        )
+            if track.written_through is not None:
+                track.written_through -= given
+            ahead -= given
+            if given < owed:
+                track.owed[-1] = (ends_at - given, owed - given)
+            else:
+                track.owed.pop()
 
     def _wall_clock_zero(self, starts_at: float) -> int:
         """The wall-clock instant the recording's first sample stands for.

--- a/apps/simulator/src/egma_simulator/conductor.py
+++ b/apps/simulator/src/egma_simulator/conductor.py
@@ -228,9 +228,14 @@ class _RecordedTrack:
     the same as the length of the buffer: a channel the conversation has
     left quiet keeps its cursor where its own last audio ended while the
     other channel runs on.
+
+    ``quiet_owed`` is how much of the quiet at ``quiet_ends_at`` the
+    recorder put there itself, at a re-anchor, and can still take back.
     """
 
     written_through: int | None = None
+    quiet_owed: int = 0
+    quiet_ends_at: int = 0
 
 
 RESYNC_TOLERANCE_SECONDS = 0.1
@@ -246,11 +251,14 @@ says it belongs and the recording holds quiet across the difference.
 LiveKit's own in-process recorder re-anchors at the same tenth of a
 second.
 
-A channel that runs *ahead* of its clock is never pulled back. Audio
-arriving faster than real time is a delivery that stalled and caught up,
-and a second of speech is a second of speech whenever it reaches here;
-overwriting it to obey the clock would destroy evidence to correct a
-timestamp.
+A channel that has run *ahead* of its clock is pulled back only into
+quiet the recorder itself wrote. Audio arriving faster than real time is
+a delivery that stalled and caught up, and the stall is why that quiet is
+there: the audio the burst carries was spoken while the line was silent,
+so taking the quiet back and closing the two together is what puts it
+where it was said. Real audio is never written over to obey a clock, so a
+channel with no quiet left to give back stays where it is — a sender
+genuinely producing more audio than time keeps all of it.
 """
 
 
@@ -275,7 +283,7 @@ class _EvidenceRecorder(AudioBufferProcessor):
     a recording claims to be.
     """
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, *, real_time: bool = True, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         # Pipecat's recorder clears its resampler after 0.2s of *wall-clock*
         # quiet, to keep stale history out of audio that really did pause.
@@ -303,6 +311,7 @@ class _EvidenceRecorder(AudioBufferProcessor):
         self._persona = _RecordedTrack()
         self._origin_seconds: float | None = None
         self._origin_unix_nano = 0
+        self._real_time = real_time
 
     @staticmethod
     def _source_range(
@@ -326,13 +335,23 @@ class _EvidenceRecorder(AudioBufferProcessor):
             )
         return stamped
 
-    def _reset_recording(self) -> None:
-        """Start the timeline over with the buffers Pipecat just emptied."""
-        super()._reset_recording()
-        self._agent = _RecordedTrack()
-        self._persona = _RecordedTrack()
-        self._origin_seconds = None
-        self._origin_unix_nano = 0
+    async def start_recording(self) -> None:
+        """Begin a recording, and a timeline for it to be written on.
+
+        Pipecat empties its buffers from both ends of a recording, so the
+        timeline is started here rather than there: the recording's zero
+        is read after the pipeline has stopped, by whoever files the
+        audio, and a zero cleared on the way out is a whole transcript
+        stamped from the moment the line opened instead of from the first
+        sample of the call.
+        """
+        starting = not self._recording
+        await super().start_recording()
+        if starting:
+            self._agent = _RecordedTrack()
+            self._persona = _RecordedTrack()
+            self._origin_seconds = None
+            self._origin_unix_nano = 0
 
     async def _process_recording(self, frame: Frame) -> None:
         """Put one frame on the recording, at the time it happened.
@@ -449,15 +468,79 @@ class _EvidenceRecorder(AudioBufferProcessor):
         """
         if self._origin_seconds is None:
             self._origin_seconds = starts_at
-            self._origin_unix_nano = _now()
-        began = self._sample_at(starts_at)
-        written_through = track.written_through
-        if written_through is not None and began - written_through <= self._tolerance:
-            began = written_through
+            self._origin_unix_nano = self._wall_clock_zero(starts_at)
+        wanted = self._sample_at(starts_at)
+        cursor = track.written_through
+        if cursor is None:
+            began = wanted
+        elif wanted - cursor > self._tolerance:
+            # Behind its clock: the line was quiet, and the recording says
+            # so. Remember the quiet, in case what follows shows it was a
+            # delivery holding audio back rather than a far end holding
+            # its tongue.
+            track.quiet_owed = wanted - cursor
+            track.quiet_ends_at = wanted
+            began = wanted
+        elif cursor - wanted > self._tolerance:
+            self._give_the_quiet_back(buffer, track, cursor - wanted)
+            began = cast(int, track.written_through)
+        else:
+            began = cursor
         ended = began + len(audio) // 2
         self._write(buffer, began, audio)
         track.written_through = ended
         return began, ended
+
+    def _give_the_quiet_back(
+        self, buffer: bytearray, track: _RecordedTrack, ahead: int
+    ) -> None:
+        """Close up quiet the recorder wrote that the audio has caught up on.
+
+        A channel writing faster than its clock has been fed a burst, and
+        a burst is a delivery catching up on a stall. The stall is the
+        quiet at ``quiet_ends_at``, so the burst is given as much of it
+        back as it needs, and the recording holds the call end to end
+        again. Only quiet this recorder put there is taken, and only from
+        the one stretch it last put there, so nothing a listener could
+        hear is written over.
+        """
+        given = min(ahead, track.quiet_owed)
+        if given <= 0:
+            return
+        closed_from = (track.quiet_ends_at - given) * 2
+        del buffer[closed_from : track.quiet_ends_at * 2]
+        if track is self._agent:
+            # The agent's channel is the one a turn is looked up on, so
+            # closing quiet on it moves every place already mapped past
+            # the quiet. The persona's channel carries no such map.
+            for position, segment in enumerate(self._input_segments):
+                if segment.recording_start_sample >= track.quiet_ends_at:
+                    self._input_segments[position] = replace(
+                        segment,
+                        recording_start_sample=segment.recording_start_sample - given,
+                        recording_end_sample=segment.recording_end_sample - given,
+                    )
+        track.quiet_owed -= given
+        track.quiet_ends_at -= given
+        if track.written_through is not None:
+            track.written_through -= given
+
+    def _wall_clock_zero(self, starts_at: float) -> int:
+        """The wall-clock instant the recording's first sample stands for.
+
+        A real-time transport stamps the clock this machine reads, so the
+        distance from the stamp to now is the distance from the first
+        sample to now, whatever the pipeline did in between. Reading the
+        wall clock at placement instead would charge the recording every
+        millisecond the frame spent getting here, and every span with it.
+
+        A media clock counts audio rather than seconds, so nothing can be
+        derived from it and the moment of placement is the only answer
+        there is.
+        """
+        if not self._real_time:
+            return _now()
+        return _now() - round((_monotonic() - starts_at) * 1_000_000_000)
 
     def _sample_at(self, seconds: float) -> int:
         """One instant on the transport's clock, as a recording position.
@@ -1106,8 +1189,12 @@ class VoiceConductor:
         model = _PersonaLLMService(persona=self._persona)
         replies = _PersonaReplyGate(service=model, conductor=self)
         brain = _PersonaBrain(persona=self._persona, conductor=self, replies=replies)
-        recorder = _EvidenceRecorder(num_channels=2, auto_start_recording=True)
         media = self._media
+        recorder = _EvidenceRecorder(
+            num_channels=2,
+            auto_start_recording=True,
+            real_time=media.real_time,
+        )
         timeline = _Timeline(self, media, recorder)
 
         @recorder.event_handler("on_track_audio_data")
@@ -1697,3 +1784,8 @@ def _seconds(value: float) -> Fraction:
 
 def _now() -> int:
     return time.time_ns()
+
+
+def _monotonic() -> float:
+    """The clock a real-time transport stamps its frames from."""
+    return time.monotonic()

--- a/apps/simulator/src/egma_simulator/media/__init__.py
+++ b/apps/simulator/src/egma_simulator/media/__init__.py
@@ -91,6 +91,75 @@ class RemoteParticipantLeftFrame(ControlFrame, UninterruptibleFrame):
     completed: asyncio.Event
 
 
+TRANSPORT_ARRIVAL = "egma.transport_arrival"
+"""When one inbound frame's first sample reached the transport.
+
+Seconds on the transport's own clock. A real transport reads its clock
+off the wall; a scripted one carries a media clock of its own. Either
+way the two directions are stamped from the same clock, so the recording
+they make is one timeline.
+"""
+
+TRANSPORT_PLAYOUT = "egma.transport_playout"
+"""When one outbound frame's first sample is heard at the far end.
+
+The transport paces what it is handed: audio written while earlier audio
+is still playing waits its turn. This is where the frame lands after
+that wait, not when the speech leg made it.
+"""
+
+
+def arrived_at(frame: object, seconds: float) -> None:
+    """Say when this inbound frame reached the transport."""
+    metadata = getattr(frame, "metadata", None)
+    if isinstance(metadata, dict):
+        metadata[TRANSPORT_ARRIVAL] = float(seconds)
+
+
+def played_out_at(frame: object, seconds: float) -> None:
+    """Say when this outbound frame is heard at the far end."""
+    metadata = getattr(frame, "metadata", None)
+    if isinstance(metadata, dict):
+        metadata[TRANSPORT_PLAYOUT] = float(seconds)
+
+
+def transport_time(frame: object, named: str) -> float | None:
+    """One of the two transport times, or ``None`` if nobody stamped it."""
+    metadata = getattr(frame, "metadata", None)
+    if not isinstance(metadata, dict):
+        return None
+    stamped = metadata.get(named)
+    return float(stamped) if isinstance(stamped, (int, float)) else None
+
+
+class PlayoutClock:
+    """When the transport will play the audio it is handed next.
+
+    Audio handed to a transport does not start playing when it arrives:
+    it starts when everything already queued has finished. So the first
+    frame of an utterance plays now and the rest follow it end to end,
+    which is what makes a recording of the persona the caller's own
+    experience rather than the speech leg's output rate.
+
+    ``cleared`` is a queue thrown away — an interruption — after which
+    the next frame plays immediately again.
+    """
+
+    def __init__(self) -> None:
+        self._playing_through: float | None = None
+
+    def place(self, now: float, seconds: float) -> float:
+        """Where the next ``seconds`` of audio start, and take that room."""
+        waiting = self._playing_through
+        start = now if waiting is None or waiting < now else waiting
+        self._playing_through = start + seconds
+        return start
+
+    def cleared(self) -> None:
+        """The transport dropped whatever it had not played yet."""
+        self._playing_through = None
+
+
 @dataclass(frozen=True)
 class VoiceMedia:
     """The Pipecat processors and lifecycle signals for one voice connection.

--- a/apps/simulator/src/egma_simulator/media/__init__.py
+++ b/apps/simulator/src/egma_simulator/media/__init__.py
@@ -13,12 +13,20 @@ are ``error``.
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from importlib import import_module
 from typing import Protocol
 
-from pipecat.frames.frames import ControlFrame, UninterruptibleFrame
+from pipecat.frames.frames import (
+    ControlFrame,
+    Frame,
+    InterruptionFrame,
+    OutputAudioRawFrame,
+    UninterruptibleFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 from ..contract import ERROR, NOT_ANSWERED
 
@@ -158,6 +166,40 @@ class PlayoutClock:
     def cleared(self) -> None:
         """The transport dropped whatever it had not played yet."""
         self._playing_through = None
+
+
+class PlayoutStamp(FrameProcessor):
+    """Say when a real-time transport plays out what it has been handed.
+
+    Goes after the transport's own output processor, where a frame has
+    been written out and is on its way to the far end. A transport takes
+    audio faster than it plays it — a whole utterance can go over in a
+    moment and then play for seconds — so a frame that has just been
+    written is not audio anybody has heard yet. It is audio that starts
+    once everything written before it has finished.
+
+    An interruption throws away whatever was written and not yet played,
+    so this says when that happened too, and the recording lets that
+    audio go instead of claiming the persona spoke it.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._playout = PlayoutClock()
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+        if isinstance(frame, OutputAudioRawFrame):
+            played_out_at(
+                frame,
+                self._playout.place(
+                    time.monotonic(), frame.num_frames / frame.sample_rate
+                ),
+            )
+        elif isinstance(frame, InterruptionFrame):
+            played_out_at(frame, time.monotonic())
+            self._playout.cleared()
+        await self.push_frame(frame, direction)
 
 
 @dataclass(frozen=True)

--- a/apps/simulator/src/egma_simulator/media/__init__.py
+++ b/apps/simulator/src/egma_simulator/media/__init__.py
@@ -20,6 +20,7 @@ from importlib import import_module
 from typing import Protocol
 
 from pipecat.frames.frames import (
+    AudioRawFrame,
     ControlFrame,
     Frame,
     InterruptionFrame,
@@ -118,17 +119,35 @@ that wait, not when the speech leg made it.
 
 
 def arrived_at(frame: object, seconds: float) -> None:
-    """Say when this inbound frame reached the transport."""
-    metadata = getattr(frame, "metadata", None)
-    if isinstance(metadata, dict):
-        metadata[TRANSPORT_ARRIVAL] = float(seconds)
+    """Say when this inbound frame's first sample reached the transport."""
+    _stamp(frame, TRANSPORT_ARRIVAL, seconds)
+
+
+def arrived_now(frame: AudioRawFrame) -> None:
+    """Say that this inbound frame has just finished arriving.
+
+    A real-time transport reads its clock once the frame is whole, so
+    the instant it reads is the frame's *last* sample. The stamp names
+    the first, which is that instant less the frame's own length. Getting
+    this backwards charges the recording one frame per frame, and the
+    charge lands on every latency read off it.
+    """
+    arrived_at(frame, time.monotonic() - frame.num_frames / frame.sample_rate)
 
 
 def played_out_at(frame: object, seconds: float) -> None:
-    """Say when this outbound frame is heard at the far end."""
+    """Say when this outbound frame's first sample is heard at the far end."""
+    _stamp(frame, TRANSPORT_PLAYOUT, seconds)
+
+
+def _stamp(frame: object, named: str, seconds: float) -> None:
     metadata = getattr(frame, "metadata", None)
-    if isinstance(metadata, dict):
-        metadata[TRANSPORT_PLAYOUT] = float(seconds)
+    if not isinstance(metadata, dict):
+        raise MediaBackendError(
+            f"a {type(frame).__name__} reached the recording with nowhere to "
+            "carry its transport time"
+        )
+    metadata[named] = float(seconds)
 
 
 def transport_time(frame: object, named: str) -> float | None:
@@ -218,6 +237,15 @@ class VoiceMedia:
     failed: asyncio.Event = field(default_factory=asyncio.Event)
     transport_name: str = "voice transport"
     input_recorded: Callable[[object], None] = lambda _frame: None
+    real_time: bool = True
+    """Whether the times this transport stamps are the wall clock's.
+
+    A transport that carries a call runs on the clock everybody else
+    reads, so the recording it makes can say what time its first sample
+    was. A scripted far end keeps a media clock of its own, which counts
+    the audio it has written rather than the seconds that have passed,
+    and a wall-clock instant read off it would be a made-up one.
+    """
 
 
 class MediaBackend(Protocol):

--- a/apps/simulator/src/egma_simulator/media/room.py
+++ b/apps/simulator/src/egma_simulator/media/room.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import logging
 import sys
+import time
 import uuid
 from array import array
 from collections.abc import Awaitable, Callable
@@ -14,7 +15,14 @@ from typing import Any
 
 from ..contract import ERROR
 from ..mock_tools import MockToolRefusal
-from . import MediaBackendError, RemoteParticipantLeftFrame, VoiceMedia
+from . import (
+    MediaBackendError,
+    PlayoutClock,
+    RemoteParticipantLeftFrame,
+    VoiceMedia,
+    arrived_at,
+    played_out_at,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -977,7 +985,12 @@ class JoinedRoom:
 
     def create_transport(self) -> VoiceMedia:
         """Create stock LiveKit input and output processors without rates."""
-        from pipecat.frames.frames import Frame, InputAudioRawFrame
+        from pipecat.frames.frames import (
+            Frame,
+            InputAudioRawFrame,
+            InterruptionFrame,
+            OutputAudioRawFrame,
+        )
         from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
         from pipecat.transports.livekit.transport import LiveKitParams, LiveKitTransport
 
@@ -1051,17 +1064,62 @@ class JoinedRoom:
         room = self
 
         class _Arrival(FrameProcessor):
+            """When the agent's audio reached egma, on egma's own clock.
+
+            The first thing in the pipeline that sees inbound audio, so
+            the stamp it writes is as close to arrival as this side can
+            honestly get. The recording is built on these stamps, which
+            is what makes a wait measured on the file the wait the caller
+            lived through instead of a count of what was buffered.
+            """
+
             async def process_frame(
                 self, frame: Frame, direction: FrameDirection
             ) -> None:
                 await super().process_frame(frame, direction)
                 if isinstance(frame, InputAudioRawFrame):
+                    arrived_at(frame, time.monotonic())
                     room.carrying_audio.set()
+                await self.push_frame(frame, direction)
+
+        class _Playout(FrameProcessor):
+            """When the persona's audio is heard, on the same clock.
+
+            LiveKit takes audio faster than it plays it: a whole utterance
+            can be handed over in a moment and then plays out over
+            seconds. So the frame that has just gone to the room is not
+            audio the caller has heard — it is audio that starts when
+            everything handed over before it has finished.
+
+            An interruption clears what LiveKit was holding, so what it
+            had not played is never heard at all and the recording is told
+            to let it go.
+            """
+
+            def __init__(self) -> None:
+                super().__init__()
+                self._playout = PlayoutClock()
+
+            async def process_frame(
+                self, frame: Frame, direction: FrameDirection
+            ) -> None:
+                await super().process_frame(frame, direction)
+                if isinstance(frame, OutputAudioRawFrame):
+                    played_out_at(
+                        frame,
+                        self._playout.place(
+                            time.monotonic(),
+                            frame.num_frames / frame.sample_rate,
+                        ),
+                    )
+                elif isinstance(frame, InterruptionFrame):
+                    played_out_at(frame, time.monotonic())
+                    self._playout.cleared()
                 await self.push_frame(frame, direction)
 
         return VoiceMedia(
             input=(input_transport, _Arrival()),
-            output=(transport.output(),),
+            output=(transport.output(), _Playout()),
             ended=self.ended,
             failed=self.failed,
             transport_name=f"livekit server at {self._quotable(self._url)}",

--- a/apps/simulator/src/egma_simulator/media/room.py
+++ b/apps/simulator/src/egma_simulator/media/room.py
@@ -17,11 +17,10 @@ from ..contract import ERROR
 from ..mock_tools import MockToolRefusal
 from . import (
     MediaBackendError,
-    PlayoutClock,
+    PlayoutStamp,
     RemoteParticipantLeftFrame,
     VoiceMedia,
     arrived_at,
-    played_out_at,
 )
 
 logger = logging.getLogger(__name__)
@@ -985,12 +984,7 @@ class JoinedRoom:
 
     def create_transport(self) -> VoiceMedia:
         """Create stock LiveKit input and output processors without rates."""
-        from pipecat.frames.frames import (
-            Frame,
-            InputAudioRawFrame,
-            InterruptionFrame,
-            OutputAudioRawFrame,
-        )
+        from pipecat.frames.frames import Frame, InputAudioRawFrame
         from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
         from pipecat.transports.livekit.transport import LiveKitParams, LiveKitTransport
 
@@ -1082,44 +1076,9 @@ class JoinedRoom:
                     room.carrying_audio.set()
                 await self.push_frame(frame, direction)
 
-        class _Playout(FrameProcessor):
-            """When the persona's audio is heard, on the same clock.
-
-            LiveKit takes audio faster than it plays it: a whole utterance
-            can be handed over in a moment and then plays out over
-            seconds. So the frame that has just gone to the room is not
-            audio the caller has heard — it is audio that starts when
-            everything handed over before it has finished.
-
-            An interruption clears what LiveKit was holding, so what it
-            had not played is never heard at all and the recording is told
-            to let it go.
-            """
-
-            def __init__(self) -> None:
-                super().__init__()
-                self._playout = PlayoutClock()
-
-            async def process_frame(
-                self, frame: Frame, direction: FrameDirection
-            ) -> None:
-                await super().process_frame(frame, direction)
-                if isinstance(frame, OutputAudioRawFrame):
-                    played_out_at(
-                        frame,
-                        self._playout.place(
-                            time.monotonic(),
-                            frame.num_frames / frame.sample_rate,
-                        ),
-                    )
-                elif isinstance(frame, InterruptionFrame):
-                    played_out_at(frame, time.monotonic())
-                    self._playout.cleared()
-                await self.push_frame(frame, direction)
-
         return VoiceMedia(
             input=(input_transport, _Arrival()),
-            output=(transport.output(), _Playout()),
+            output=(transport.output(), PlayoutStamp()),
             ended=self.ended,
             failed=self.failed,
             transport_name=f"livekit server at {self._quotable(self._url)}",

--- a/apps/simulator/src/egma_simulator/media/room.py
+++ b/apps/simulator/src/egma_simulator/media/room.py
@@ -6,7 +6,6 @@ import asyncio
 import contextlib
 import logging
 import sys
-import time
 import uuid
 from array import array
 from collections.abc import Awaitable, Callable
@@ -20,7 +19,7 @@ from . import (
     PlayoutStamp,
     RemoteParticipantLeftFrame,
     VoiceMedia,
-    arrived_at,
+    arrived_now,
 )
 
 logger = logging.getLogger(__name__)
@@ -1072,7 +1071,7 @@ class JoinedRoom:
             ) -> None:
                 await super().process_frame(frame, direction)
                 if isinstance(frame, InputAudioRawFrame):
-                    arrived_at(frame, time.monotonic())
+                    arrived_now(frame)
                     room.carrying_audio.set()
                 await self.push_frame(frame, direction)
 

--- a/apps/simulator/src/egma_simulator/media/scripted_transport.py
+++ b/apps/simulator/src/egma_simulator/media/scripted_transport.py
@@ -24,7 +24,13 @@ from pipecat.frames.frames import (
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 from ..speech import decode_speech, encode_speech, silence
-from . import RemoteParticipantLeftFrame, VoiceMedia
+from . import (
+    PlayoutClock,
+    RemoteParticipantLeftFrame,
+    VoiceMedia,
+    arrived_at,
+    played_out_at,
+)
 
 FRAME_SECONDS = 0.02
 TRAILING_SILENCE_SECONDS = 0.6
@@ -36,6 +42,14 @@ IDLE_SILENCE_SECONDS = 13.0
 @dataclass(frozen=True)
 class _InputChunk:
     audio: bytes
+    arrival: float = 0.0
+    """Where this piece sits on the far end's own clock.
+
+    A scripted far end keeps a media clock instead of a wall clock: its
+    audio is written out in one go and carried into the pipeline a frame
+    at a time, so the moment a frame is *pushed* says nothing about when
+    it was spoken. Its place in the stream says everything.
+    """
     hang_up_after: bool = False
 
 
@@ -69,6 +83,12 @@ class ScriptedTransport:
         self._pending: asyncio.Queue[_InputChunk] = asyncio.Queue()
         self._acks: dict[int, asyncio.Event] = {}
         self.ended = asyncio.Event()
+
+        self._queued_seconds = 0.0
+        """How much audio the far end has written out, ever."""
+        self._carried_seconds = 0.0
+        """How much of it has entered the pipeline: the far end's now."""
+        self._playout = PlayoutClock()
 
         self.heard: list[bytes] = []
         """Each complete persona utterance accepted by the transport."""
@@ -117,6 +137,17 @@ class ScriptedTransport:
         await self._active.wait()
         return await self._pending.get()
 
+    def carried(self, chunk: _InputChunk) -> None:
+        """One piece of the far end's stream is in the pipeline."""
+        self._carried_seconds = chunk.arrival + self._seconds(len(chunk.audio))
+
+    def playing_out(self, seconds: float) -> float:
+        """Where the next persona audio is heard on the far end's clock."""
+        return self._playout.place(self._carried_seconds, seconds)
+
+    def _seconds(self, audio_bytes: int) -> float:
+        return audio_bytes / 2 / self._input_rate if self._input_rate else 0.0
+
     def wait_for_ack(self, frame: InputAudioRawFrame) -> asyncio.Event:
         acknowledged = asyncio.Event()
         self._acks[frame.id] = acknowledged
@@ -136,6 +167,11 @@ class ScriptedTransport:
         self._queue_audio(silence(seconds, self._input_rate))
 
     async def persona_stopped(self) -> None:
+        # The far end takes the persona's audio as it is handed over — the
+        # carry below puts every frame of it into the stream — so when an
+        # utterance ends nothing of it is left waiting to be played, and
+        # the next one starts wherever the line has got to by then.
+        self._playout.cleared()
         spoken = bytes(self._hearing)
         self._hearing.clear()
         if spoken:
@@ -197,9 +233,11 @@ class ScriptedTransport:
             self._pending.put_nowait(
                 _InputChunk(
                     audio=piece,
+                    arrival=self._queued_seconds,
                     hang_up_after=hang_up_after and position == len(pieces) - 1,
                 )
             )
+            self._queued_seconds += self._seconds(len(piece))
 
 
 class _ScriptedInput(FrameProcessor):
@@ -229,8 +267,10 @@ class _ScriptedInput(FrameProcessor):
                 sample_rate=self._transport._input_rate,
                 num_channels=1,
             )
+            arrived_at(frame, chunk.arrival)
             acknowledged = self._transport.wait_for_ack(frame)
             self._transport.input_frames += 1
+            self._transport.carried(chunk)
             await self.push_frame(frame)
             if chunk.hang_up_after:
                 marker = RemoteParticipantLeftFrame(
@@ -254,6 +294,10 @@ class _ScriptedOutput(FrameProcessor):
             self._transport.started(output_rate=frame.audio_out_sample_rate)
         elif isinstance(frame, OutputAudioRawFrame):
             await self._transport.accepted_output(frame)
+            played_out_at(
+                frame,
+                self._transport.playing_out(frame.num_frames / frame.sample_rate),
+            )
 
         await self.push_frame(frame, direction)
 

--- a/apps/simulator/src/egma_simulator/media/scripted_transport.py
+++ b/apps/simulator/src/egma_simulator/media/scripted_transport.py
@@ -106,6 +106,7 @@ class ScriptedTransport:
             output=(self._output,),
             ended=self.ended,
             input_recorded=self.acknowledge,
+            real_time=False,
         )
 
     async def activate(self) -> None:

--- a/apps/simulator/src/egma_simulator/recording.py
+++ b/apps/simulator/src/egma_simulator/recording.py
@@ -54,8 +54,10 @@ def dual_channel_wav(
     transcript looks wrong. The shorter track is padded with quiet so a
     file never runs out halfway through the exchange.
 
-    Pipecat's recorder aligns and pads the two tracks on one timeline, so
-    two speakers talking over each other remain audible as exactly that.
+    The recorder has already placed both tracks on one timeline by the
+    clock, so two speakers talking over each other remain audible as
+    exactly that, and the distance between them is the distance the
+    caller lived through.
     """
     frames = max(len(persona_audio), len(agent_audio)) // SAMPLE_WIDTH_BYTES
     interleaved = array("h", bytes(frames * 2 * SAMPLE_WIDTH_BYTES))

--- a/apps/simulator/tests/test_live_deepgram.py
+++ b/apps/simulator/tests/test_live_deepgram.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import time
 import wave
 from pathlib import Path
 
@@ -41,7 +42,7 @@ from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from egma_simulator.blob import FilesystemBlobStore
 from egma_simulator.conductor import VoiceConductor
 from egma_simulator.conversation import ConversationControls
-from egma_simulator.media import VoiceMedia
+from egma_simulator.media import PlayoutStamp, VoiceMedia, arrived_at
 from egma_simulator.model import ScriptedModel
 from egma_simulator.persona import Persona
 from egma_simulator.spec import AuthoredPersona
@@ -113,13 +114,16 @@ class _OneSentenceInput(FrameProcessor):
         for position, audio in enumerate(chunks):
             if position == len(chunks) - 1:
                 self.ended.set()
-            await self.push_frame(
-                InputAudioRawFrame(
-                    audio=audio,
-                    sample_rate=self._band,
-                    num_channels=1,
-                )
+            frame = InputAudioRawFrame(
+                audio=audio,
+                sample_rate=self._band,
+                num_channels=1,
             )
+            # The line runs in real time here, one frame every twenty
+            # milliseconds, so the clock is the honest arrival time and
+            # the recording is built on it like any other transport's.
+            arrived_at(frame, time.monotonic())
+            await self.push_frame(frame)
             await asyncio.sleep(FRAME_SECONDS)
 
     def open(self) -> None:
@@ -141,7 +145,11 @@ class OneSentenceConnection:
         return self._input.ended.is_set()
 
     async def prepare(self) -> VoiceMedia:
-        return VoiceMedia(input=(self._input,), output=(), ended=self._input.ended)
+        return VoiceMedia(
+            input=(self._input,),
+            output=(PlayoutStamp(),),
+            ended=self._input.ended,
+        )
 
     async def open(self) -> None:
         self._input.open()

--- a/apps/simulator/tests/test_recording_timeline.py
+++ b/apps/simulator/tests/test_recording_timeline.py
@@ -1,0 +1,306 @@
+"""The recorder puts each channel where the transport says it belongs.
+
+One simulation leaves one recording, and every number egma reads off it —
+how long the caller waited, where a transcript turn seeks to — is read as
+a distance on that one timeline. So the timeline has to be time.
+
+These tests feed the recorder by hand: frames whose audio says one thing
+and whose transport clock says another. A recorder that counts samples
+puts the agent's reply where the persona's buffer happened to end. A
+recorder that reads the clock puts it where it arrived.
+"""
+
+from __future__ import annotations
+
+import sys
+from array import array
+from fractions import Fraction
+
+import pytest
+from pipecat.frames.frames import (
+    InputAudioRawFrame,
+    InterruptionFrame,
+    OutputAudioRawFrame,
+    StartFrame,
+)
+
+from egma_simulator import conductor as conductor_module
+from egma_simulator.media import arrived_at, played_out_at
+
+BAND = 24_000
+"""The recording's band, and the band both sides are fed at, so nothing
+below turns on a resampler's own rounding."""
+
+FRAME_SECONDS = 0.02
+LOUD = 8_000
+"""One sample value nothing else writes, so a track's own audio can be
+told apart from the quiet the recorder puts around it."""
+
+
+def tone(seconds: float = FRAME_SECONDS) -> bytes:
+    """Audio a listener can find, at the recording's own band."""
+    return LOUD.to_bytes(2, "little", signed=True) * round(seconds * BAND)
+
+
+def quiet(seconds: float = FRAME_SECONDS) -> bytes:
+    """An open line with nobody speaking on it."""
+    return bytes(2 * round(seconds * BAND))
+
+
+async def recorder_started() -> conductor_module._EvidenceRecorder:
+    """One recorder, recording, with nothing on either track yet."""
+    made = conductor_module._EvidenceRecorder(
+        num_channels=2, sample_rate=BAND, auto_start_recording=True
+    )
+    made._update_sample_rate(StartFrame(audio_out_sample_rate=BAND))
+    await made.start_recording()
+    return made
+
+
+async def agent_said(
+    recorder: conductor_module._EvidenceRecorder,
+    *,
+    arriving_at: float,
+    source_from: float,
+    audio: bytes,
+) -> None:
+    """One inbound frame, arriving at the transport when it says it did."""
+    frame = InputAudioRawFrame(audio=audio, sample_rate=BAND, num_channels=1)
+    seconds = Fraction(len(audio) // 2, BAND)
+    frame.metadata[conductor_module._INPUT_SOURCE_RANGE] = (
+        Fraction(source_from).limit_denominator(BAND),
+        Fraction(source_from).limit_denominator(BAND) + seconds,
+    )
+    arrived_at(frame, arriving_at)
+    await recorder._process_recording(frame)
+
+
+async def persona_said(
+    recorder: conductor_module._EvidenceRecorder,
+    *,
+    playing_at: float,
+    audio: bytes,
+) -> None:
+    """One outbound frame, heard at the far end when it says it is."""
+    frame = OutputAudioRawFrame(audio=audio, sample_rate=BAND, num_channels=1)
+    played_out_at(frame, playing_at)
+    await recorder._process_recording(frame)
+
+
+def tracks(
+    recorder: conductor_module._EvidenceRecorder,
+) -> tuple[array, array]:
+    """Both tracks, the persona first, as one recording holds them.
+
+    The same two tracks the simulation's recording handler is handed, and
+    the same final padding: Pipecat merges them only after both have been
+    brought to one length, which is what makes the file one clock.
+    """
+    recorder._align_track_buffers()
+    merged = array("h")
+    merged.frombytes(recorder.merge_audio_buffers())
+    if sys.byteorder != "little":
+        merged.byteswap()
+    return merged[1::2], merged[0::2]
+
+
+def audible(track: array, apart: float = 0.2) -> list[tuple[float, float]]:
+    """Every stretch of speech on one track, in seconds.
+
+    Two stretches are one utterance while less than ``apart`` of quiet
+    separates them, which is what lets a re-anchor put a tenth of a
+    second of quiet inside one utterance without making it two.
+    """
+    loud = [at for at, sample in enumerate(track) if abs(sample) >= LOUD // 2]
+    assert loud, "the track holds no audible audio at all"
+    stretches: list[tuple[int, int]] = []
+    began = loud[0]
+    for before, at in zip(loud, loud[1:], strict=False):
+        if at - before > apart * BAND:
+            stretches.append((began, before + 1))
+            began = at
+    stretches.append((began, loud[-1] + 1))
+    return [(began / BAND, ended / BAND) for began, ended in stretches]
+
+
+def speaking(track: array) -> tuple[float, float]:
+    """The first and last audible instant of one track, in seconds."""
+    stretches = audible(track)
+    return stretches[0][0], stretches[-1][1]
+
+
+WIRE_SECONDS = 0.05
+"""The known lag between the agent speaking and egma holding the audio."""
+
+
+async def agent_held_the_line(
+    recorder: conductor_module._EvidenceRecorder,
+    *,
+    source_from: float,
+    seconds: float,
+    speaking_up: bool,
+) -> None:
+    """The agent's inbound stream, which never stops while a call is up.
+
+    A transport carries quiet as faithfully as speech, so the agent's
+    source clock runs on whether or not anybody is talking.
+    """
+    for step in range(round(seconds / FRAME_SECONDS)):
+        at = source_from + step * FRAME_SECONDS
+        await agent_said(
+            recorder,
+            arriving_at=at + WIRE_SECONDS,
+            source_from=at,
+            audio=tone() if speaking_up else quiet(),
+        )
+
+
+async def test_each_channel_lands_where_its_transport_clock_says() -> None:
+    """The persona at its playout, the agent at its arrival, one timeline.
+
+    The shape of a real turn. The agent greets and then holds the line
+    quiet. The speech leg makes the persona's whole answer in one burst,
+    a second before the transport will play any of it. The agent replies
+    half a second after the persona stops.
+
+    Placed by buffer length the persona lands where its speech leg made
+    it and the agent's reply is padded up to that, which puts the two of
+    them a second closer together than the caller ever heard them.
+    Placed by time each one sits where the conversation put it, and the
+    half second between them is the half second that was waited.
+    """
+    recorder = await recorder_started()
+
+    await agent_held_the_line(
+        recorder, source_from=0.0, seconds=0.5, speaking_up=True
+    )
+    await agent_held_the_line(
+        recorder, source_from=0.5, seconds=1.5, speaking_up=False
+    )
+
+    persona_from = 2.0
+    for step in range(50):
+        await persona_said(
+            recorder,
+            playing_at=persona_from + step * FRAME_SECONDS,
+            audio=tone(),
+        )
+
+    await agent_held_the_line(
+        recorder, source_from=2.0, seconds=1.5, speaking_up=False
+    )
+    await agent_held_the_line(
+        recorder, source_from=3.5, seconds=0.5, speaking_up=True
+    )
+
+    # The recording's own zero is the first audio anybody put on it: the
+    # agent's greeting as it reached the transport, one wire behind the
+    # moment the agent spoke it. So the agent's audio reads back on its
+    # own source clock, and the persona's reads back one wire early.
+    def on_the_recording(stamped: float) -> float:
+        return stamped - WIRE_SECONDS
+
+    persona_track, agent_track = tracks(recorder)
+    assert audible(persona_track) == [
+        pytest.approx((on_the_recording(2.0), on_the_recording(3.0)), abs=0.01)
+    ]
+    greeted, replied = audible(agent_track)
+    assert greeted == pytest.approx((0.0, 0.5), abs=0.01)
+    assert replied == pytest.approx((3.5, 4.0), abs=0.01)
+
+    # What the file says the caller waited: the half second the agent took
+    # to answer, and the wire it took to bring the answer here. That is
+    # the whole of the difference between this number and the agent's own,
+    # and it is why the two clocks can be checked against each other.
+    persona_stopped = audible(persona_track)[0][1]
+    assert replied[0] - persona_stopped == pytest.approx(
+        0.5 + WIRE_SECONDS, abs=0.01
+    )
+
+
+async def test_a_capture_clock_that_runs_slow_does_not_slide_the_recording(
+) -> None:
+    """A channel is re-anchored when its own clock drifts off the timeline.
+
+    The agent sends twenty milliseconds of audio every twenty-one: a five
+    per cent rate error, the shape of the drift measured on a real
+    simulation. Counted out sample by sample the track falls a second
+    behind over twenty seconds of call. Placed by arrival it never falls
+    more than the re-anchor tolerance behind, whichever end of the call
+    the reader seeks to.
+    """
+    recorder = await recorder_started()
+
+    frames = 1_000
+    lagging_frame = 0.021
+    for step in range(frames):
+        await agent_said(
+            recorder,
+            arriving_at=step * lagging_frame,
+            source_from=step * FRAME_SECONDS,
+            audio=tone(),
+        )
+
+    arrived_through = (frames - 1) * lagging_frame + FRAME_SECONDS
+    _persona_track, agent_track = tracks(recorder)
+    began, ended = speaking(agent_track)
+    assert began == pytest.approx(0.0, abs=0.01)
+    assert ended == pytest.approx(arrived_through, abs=0.1)
+
+
+async def test_a_turn_seeks_to_the_place_its_audio_was_put() -> None:
+    """The transcript's seek positions are read off the same timeline.
+
+    A grader's reader opens the recording at the position the transcript
+    names. That position comes from the recorder's own map of the agent's
+    speech onto the recording, so the map has to agree with where the
+    audio went — including after a re-anchor.
+    """
+    recorder = await recorder_started()
+
+    frames = 500
+    lagging_frame = 0.021
+    for step in range(frames):
+        await agent_said(
+            recorder,
+            arriving_at=step * lagging_frame,
+            source_from=step * FRAME_SECONDS,
+            audio=tone(),
+        )
+    await recorder.close_input_at(Fraction(frames * 20, 1_000))
+
+    spoke_from = Fraction(frames - 25, 1) * Fraction(20, 1_000)
+    spoke_through = Fraction(frames, 1) * Fraction(20, 1_000)
+    began, ended = await recorder.agent_interval(
+        spoke_from, spoke_through, observed_through=spoke_through
+    )
+
+    arrived_from = (frames - 25) * lagging_frame
+    arrived_through = (frames - 1) * lagging_frame + FRAME_SECONDS
+    assert float(began) == pytest.approx(arrived_from, abs=0.1)
+    assert float(ended) == pytest.approx(arrived_through, abs=0.1)
+
+
+async def test_audio_the_transport_threw_away_is_not_in_the_recording(
+) -> None:
+    """An interruption clears a queue, and what it held was never heard.
+
+    The persona's last second sits in the transport waiting its turn when
+    the agent talks over it. The transport drops it, so the caller never
+    hears it — and a recording that keeps it would say the persona spoke
+    for a second longer than it did, and start the next wait a second
+    late.
+    """
+    recorder = await recorder_started()
+
+    for step in range(50):
+        await persona_said(
+            recorder, playing_at=step * FRAME_SECONDS, audio=tone()
+        )
+
+    cleared = InterruptionFrame()
+    played_out_at(cleared, 0.4)
+    await recorder._process_recording(cleared)
+
+    persona_track, _agent_track = tracks(recorder)
+    assert speaking(persona_track) == pytest.approx((0.0, 0.4), abs=0.01)

--- a/apps/simulator/tests/test_recording_timeline.py
+++ b/apps/simulator/tests/test_recording_timeline.py
@@ -13,6 +13,7 @@ recorder that reads the clock puts it where it arrived.
 from __future__ import annotations
 
 import sys
+import time
 from array import array
 from fractions import Fraction
 
@@ -25,13 +26,20 @@ from pipecat.frames.frames import (
 )
 
 from egma_simulator import conductor as conductor_module
-from egma_simulator.media import arrived_at, played_out_at
+from egma_simulator.media import (
+    TRANSPORT_ARRIVAL,
+    arrived_at,
+    arrived_now,
+    played_out_at,
+    transport_time,
+)
 
 BAND = 24_000
 """The recording's band, and the band both sides are fed at, so nothing
 below turns on a resampler's own rounding."""
 
 FRAME_SECONDS = 0.02
+RESYNC_TOLERANCE = conductor_module.RESYNC_TOLERANCE_SECONDS
 LOUD = 8_000
 """One sample value nothing else writes, so a track's own audio can be
 told apart from the quiet the recorder puts around it."""
@@ -47,10 +55,15 @@ def quiet(seconds: float = FRAME_SECONDS) -> bytes:
     return bytes(2 * round(seconds * BAND))
 
 
-async def recorder_started() -> conductor_module._EvidenceRecorder:
+async def recorder_started(
+    *, real_time: bool = True
+) -> conductor_module._EvidenceRecorder:
     """One recorder, recording, with nothing on either track yet."""
     made = conductor_module._EvidenceRecorder(
-        num_channels=2, sample_rate=BAND, auto_start_recording=True
+        num_channels=2,
+        sample_rate=BAND,
+        auto_start_recording=True,
+        real_time=real_time,
     )
     made._update_sample_rate(StartFrame(audio_out_sample_rate=BAND))
     await made.start_recording()
@@ -304,3 +317,141 @@ async def test_audio_the_transport_threw_away_is_not_in_the_recording(
 
     persona_track, _agent_track = tracks(recorder)
     assert speaking(persona_track) == pytest.approx((0.0, 0.4), abs=0.01)
+
+
+async def test_a_delivery_that_stalls_and_catches_up_stays_on_time() -> None:
+    """A burst is a stall catching up, and the recording holds it whole.
+
+    Pipecat queues inbound audio, so a machine that stops running the
+    loop for a second wakes to a second of frames and stamps them all at
+    once. Nothing was quiet: the agent spoke through the stall and the
+    audio is only now being handed over.
+
+    A recorder that opened a second of quiet for the stall and then wrote
+    the burst after it would put a second of nothing where the agent was
+    talking, *and* leave the channel a second late for the rest of the
+    call — the very defect this recorder exists to fix, walked back in
+    through delivery. So the quiet it opened is given back to the burst
+    as the burst catches up, and the channel comes out where its clock
+    says it is.
+    """
+    recorder = await recorder_started()
+
+    frames = 50
+    for step in range(frames):
+        await agent_said(
+            recorder,
+            arriving_at=step * FRAME_SECONDS,
+            source_from=step * FRAME_SECONDS,
+            audio=tone(),
+        )
+
+    # A second of nothing running, then a second of frames at once.
+    woke_at = frames * FRAME_SECONDS + 1.0
+    for step in range(frames):
+        await agent_said(
+            recorder,
+            arriving_at=woke_at + step * 0.0002,
+            source_from=(frames + step) * FRAME_SECONDS,
+            audio=tone(),
+        )
+
+    # Delivery back to its senses.
+    for step in range(frames):
+        await agent_said(
+            recorder,
+            arriving_at=woke_at + FRAME_SECONDS * (step + 1),
+            source_from=(2 * frames + step) * FRAME_SECONDS,
+            audio=tone(),
+        )
+
+    _persona_track, agent_track = tracks(recorder)
+    assert len(audible(agent_track)) == 1, "the recording opened a hole in speech"
+    arrived_through = woke_at + FRAME_SECONDS * frames
+    assert speaking(agent_track)[1] == pytest.approx(
+        arrived_through, abs=RESYNC_TOLERANCE
+    )
+
+
+async def test_the_recordings_zero_outlives_the_recording() -> None:
+    """Whoever files the audio reads the zero after the pipeline stops.
+
+    Pipecat empties its buffers at both ends of a recording. If the
+    timeline went with them, the file would be filed with the moment the
+    line opened as its zero, and every transcript position — measured
+    from the first sample — would seek past the words it names by the
+    whole of the wait for the first frame.
+    """
+    recorder = await recorder_started()
+    await agent_said(
+        recorder, arriving_at=1.0, source_from=0.0, audio=tone()
+    )
+
+    zero = recorder.started_unix_nano
+    assert zero
+
+    await recorder.stop_recording()
+    assert recorder.started_unix_nano == zero
+
+
+def test_a_real_time_transport_stamps_the_frames_first_sample(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A clock read when a frame is whole has already run its length.
+
+    The stamp names the frame's first sample, because that is what the
+    recorder places. Reading the clock and writing it down unchanged
+    charges the recording one frame per frame, and every latency read off
+    it carries the charge.
+    """
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+    frame = InputAudioRawFrame(audio=tone(), sample_rate=BAND, num_channels=1)
+
+    arrived_now(frame)
+
+    assert transport_time(frame, TRANSPORT_ARRIVAL) == pytest.approx(
+        1000.0 - FRAME_SECONDS
+    )
+
+
+async def test_the_wall_clock_zero_is_when_the_first_sample_arrived(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The zero is derived from the stamp, not from when work got done.
+
+    A frame can wait in the pipeline before the recorder sees it. Reading
+    the wall clock at that moment would move the recording's zero by the
+    wait, and with it every span the transcript stamps — against an
+    agent's own spans, which waited for nothing.
+    """
+    filed_at = 1_800_000_000_000_000_000
+    monkeypatch.setattr(conductor_module, "_now", lambda: filed_at)
+    monkeypatch.setattr(conductor_module, "_monotonic", lambda: 1005.0)
+
+    recorder = await recorder_started()
+    await agent_said(
+        recorder, arriving_at=1000.0, source_from=0.0, audio=tone()
+    )
+
+    assert recorder.started_unix_nano == filed_at - 5_000_000_000
+
+
+async def test_a_media_clock_has_no_wall_clock_instant_to_give(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A scripted far end counts audio, not seconds.
+
+    Its stamps are positions in a stream nobody lived through, so no
+    instant can be derived from them and the moment of filing is the only
+    honest answer.
+    """
+    filed_at = 1_800_000_000_000_000_000
+    monkeypatch.setattr(conductor_module, "_now", lambda: filed_at)
+    monkeypatch.setattr(conductor_module, "_monotonic", lambda: 1005.0)
+
+    recorder = await recorder_started(real_time=False)
+    await agent_said(
+        recorder, arriving_at=1000.0, source_from=0.0, audio=tone()
+    )
+
+    assert recorder.started_unix_nano == filed_at

--- a/apps/simulator/tests/test_recording_timeline.py
+++ b/apps/simulator/tests/test_recording_timeline.py
@@ -455,3 +455,98 @@ async def test_a_media_clock_has_no_wall_clock_instant_to_give(
     )
 
     assert recorder.started_unix_nano == filed_at
+
+
+async def test_an_interruption_settles_the_quiet_the_recorder_owes() -> None:
+    """A cut tail takes some of the owed quiet with it.
+
+    The persona speaks, the line is quiet for a while, and the transport
+    takes a second utterance it has not started playing. The agent talks
+    over it, so that whole second utterance is thrown away — and the cut
+    lands inside the quiet the recorder opened for the pause, so most of
+    that quiet is gone too.
+
+    A ledger still claiming the quiet would hand it to the next burst,
+    and the channel would be pulled back over the first utterance, which
+    the caller certainly did hear. The account is settled at the cut.
+    """
+    recorder = await recorder_started()
+
+    for step in range(10):
+        await persona_said(
+            recorder, playing_at=step * FRAME_SECONDS, audio=tone()
+        )
+
+    # A pause long enough to re-anchor, then audio the transport queues.
+    for step in range(10):
+        await persona_said(
+            recorder, playing_at=1.0 + step * FRAME_SECONDS, audio=tone()
+        )
+
+    cleared = InterruptionFrame()
+    played_out_at(cleared, 0.5)
+    await recorder._process_recording(cleared)
+    cut_at = recorder.bot_position
+
+    # The persona answers, and the transport plays it from the top: a
+    # burst of frames stamped behind where the channel has been written.
+    for step in range(10):
+        await persona_said(
+            recorder, playing_at=0.1 + step * 0.0002, audio=tone()
+        )
+
+    assert recorder.bot_position >= cut_at
+    persona_track, _agent_track = tracks(recorder)
+    assert audible(persona_track)[0] == pytest.approx((0.0, 0.2), abs=0.01)
+
+
+async def test_two_stalls_before_one_catch_up_both_close() -> None:
+    """A channel can fall behind twice before it catches up at all.
+
+    The line stalls, one frame gets through, and the line stalls again.
+    Only then does the burst arrive, carrying everything both stalls held
+    back. A recorder that remembered only the newer stall would give that
+    quiet back and leave the older gap in the file for good — and every
+    position after it, audio and transcript alike, would sit that far
+    away from the transport clock for the rest of the call.
+    """
+    recorder = await recorder_started()
+
+    # A fifth of a second of speech, delivered as it is spoken.
+    for step in range(10):
+        await agent_said(
+            recorder,
+            arriving_at=step * FRAME_SECONDS,
+            source_from=step * FRAME_SECONDS,
+            audio=tone(),
+        )
+
+    # Half a second of nothing running, then one frame gets through.
+    await agent_said(
+        recorder, arriving_at=0.70, source_from=0.20, audio=tone()
+    )
+
+    # Half a second more, then a whole second of frames at once.
+    for step in range(50):
+        await agent_said(
+            recorder,
+            arriving_at=1.22 + step * 0.0002,
+            source_from=0.22 + step * FRAME_SECONDS,
+            audio=tone(),
+        )
+
+    # Delivery back to its senses.
+    for step in range(10):
+        await agent_said(
+            recorder,
+            arriving_at=1.24 + step * FRAME_SECONDS,
+            source_from=1.22 + step * FRAME_SECONDS,
+            audio=tone(),
+        )
+
+    _persona_track, agent_track = tracks(recorder)
+    assert len(audible(agent_track)) == 1, "a stall stayed in the recording"
+    arrived_through = 1.24 + 10 * FRAME_SECONDS
+    assert speaking(agent_track)[1] == pytest.approx(
+        arrived_through, abs=RESYNC_TOLERANCE
+    )

--- a/apps/simulator/tests/test_voice.py
+++ b/apps/simulator/tests/test_voice.py
@@ -545,6 +545,49 @@ async def test_every_span_points_at_the_audio_it_names(
     )
 
 
+async def test_the_recording_is_stamped_from_its_own_first_sample(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The filed zero is the first sample, not the moment the line opened.
+
+    Every transcript position is an offset into the recording, so the
+    instant that zero stands for is what makes a seek land on the words a
+    turn names. The line opens first and the first frame arrives after
+    it, and the two are not the same moment.
+
+    The clock moves here on purpose. Pinning it, as the alignment test
+    above does to read positions off the audio, hides a zero that was
+    read at the wrong moment or thrown away before it was filed.
+    """
+    readings: list[int] = []
+    reading = 1_800_000_000_000_000_000
+
+    def a_clock_that_moves() -> int:
+        nonlocal reading
+        reading += 1_000_000_000
+        readings.append(reading)
+        return reading
+
+    monkeypatch.setattr(conductor_module, "_now", a_clock_that_moves)
+    spec = spec_for(
+        scenario="First point.",
+        greeting="Front desk, hello.",
+        replies=["Certainly."],
+    )
+    assembled = assemble(
+        spec, blobs=FilesystemBlobStore(tmp_path), speech=SCRIPTED_PAIR
+    )
+    conductor = assembled.conductor
+    assert conductor is not None
+
+    await observe(conductor, assembled, spec, controls=ConversationControls())
+
+    assert conductor.audio is not None
+    line_opened = readings[0]
+    assert conductor.audio.started_unix_nano in readings
+    assert conductor.audio.started_unix_nano > line_opened
+
+
 async def test_every_turn_is_measured_and_the_measures_never_run_backwards(
     tmp_path: Path,
 ):

--- a/apps/simulator/tests/test_voice.py
+++ b/apps/simulator/tests/test_voice.py
@@ -809,6 +809,7 @@ class _TransportLost:
             ended=media.ended,
             failed=self.failed,
             input_recorded=media.input_recorded,
+            real_time=media.real_time,
         )
 
     async def open(self) -> None:

--- a/apps/simulator/tests/test_voice.py
+++ b/apps/simulator/tests/test_voice.py
@@ -425,6 +425,14 @@ async def test_every_span_points_at_the_audio_it_names(
     span on that shared timeline. Its transcript boundary stays within one
     media frame, and the offset at the final spoken turn does not grow from
     the first. The check uses the audio, not a second transcript clock.
+
+    Two things that go wrong on a real call are done here on purpose. The
+    line stalls for a second between two of the agent's frames, so the
+    audio after it arrives a second later than the audio before it — a
+    gap, which the recording must hold as a second of quiet rather than
+    close up. And the recorder itself is held back while one early frame
+    waits, because a busy machine is not a pause in the conversation and
+    must not move anything on the file.
     """
     opened_unix_nano = 1_800_000_000_000_000_000
     monkeypatch.setattr(conductor_module, "_now", lambda: opened_unix_nano)
@@ -449,26 +457,11 @@ async def test_every_span_points_at_the_audio_it_names(
     monkeypatch.setattr(transport, "wait_for_ack", no_recorder_backpressure)
     input_processor = transport.media.input[0]
     push_frame = input_processor.push_frame
-    arrival_clock = [0.0]
-    recording_clock = [0.0]
     quiet_after_speech = 0
-    inserted_gap = False
+    stalled = False
 
-    class RecordingTime:
-        @staticmethod
-        def monotonic() -> float:
-            return recording_clock[0]
-
-        @staticmethod
-        def time() -> float:
-            return recording_clock[0]
-
-    from pipecat.audio.resamplers import soxr_stream_resampler
     from pipecat.frames.frames import InputAudioRawFrame
-    from pipecat.processors.audio import audio_buffer_processor
 
-    monkeypatch.setattr(audio_buffer_processor, "time", RecordingTime)
-    monkeypatch.setattr(soxr_stream_resampler, "time", RecordingTime)
     process_recording = conductor_module._EvidenceRecorder._process_recording
     held_one_frame = False
 
@@ -477,8 +470,6 @@ async def test_every_span_points_at_the_audio_it_names(
         if isinstance(frame, InputAudioRawFrame) and not held_one_frame:
             held_one_frame = True
             await asyncio.sleep(0.3)
-        if isinstance(frame, InputAudioRawFrame):
-            recording_clock[0] = frame.metadata["test.recorded_at"]
         await process_recording(recorder, frame)
 
     monkeypatch.setattr(
@@ -487,28 +478,32 @@ async def test_every_span_points_at_the_audio_it_names(
         briefly_hold_the_recorder,
     )
 
-    async def carry_one_transport_gap(frame, direction=None):
-        nonlocal inserted_gap, quiet_after_speech
+    async def stall_the_line_for_a_second(frame, direction=None):
+        """Hold the far end's line for a second in the middle of the call.
+
+        Everything the far end sends after the stall reaches the transport
+        a second later than what it sends before, while its own audio runs
+        on without a break. The recording must hold that second.
+        """
+        nonlocal stalled, quiet_after_speech
         if isinstance(frame, InputAudioRawFrame):
-            arrival_clock[0] += frame.num_frames / frame.sample_rate
             if carries_speech(frame.audio):
                 quiet_after_speech = max(quiet_after_speech, 1)
             elif quiet_after_speech:
                 quiet_after_speech += 1
-                if quiet_after_speech == 11:
-                    arrival_clock[0] += 1.0
-                    inserted_gap = True
-            frame.metadata["test.recorded_at"] = arrival_clock[0]
+                if quiet_after_speech == 11 and not stalled:
+                    stalled = True
+                    transport._queued_seconds += 1.0
         if direction is None:
             await push_frame(frame)
         else:
             await push_frame(frame, direction)
 
-    monkeypatch.setattr(input_processor, "push_frame", carry_one_transport_gap)
+    monkeypatch.setattr(input_processor, "push_frame", stall_the_line_for_a_second)
     observed = await observe(
         conductor, assembled, spec, controls=ConversationControls()
     )
-    assert inserted_gap
+    assert stalled
     audio = observed.assembled.audio
     assert audio is not None
     persona_audio, agent_audio, band = channels_of(
@@ -1482,20 +1477,19 @@ async def test_a_wall_clock_gap_inside_one_utterance_loses_no_audio(
     """A slow machine is not a silence, and the recorder must not treat it
     as one.
 
-    Pipecat's recorder resamples the agent's audio, and this recorder maps
-    each turn onto that recording by reading the resampler's own
-    ``delay()`` — the samples it has consumed and not yet emitted. The map
-    is only true while every consumed sample is still accounted for.
+    Pipecat's recorder resamples both directions, and a resampler holds
+    part of a frame back to give out with the next one. Every sample it
+    holds is audio the recording will carry — as long as it is still
+    there.
 
     Pipecat clears that held state after 0.2 seconds of **wall-clock**
     quiet, which is the right default for audio that really did pause. It
     is the wrong one here, and the trigger is not the conversation: a
     loaded machine can be descheduled for longer than that between two
     frames of one continuous utterance. Nothing paused; only the CPU did.
-    The clear then discards samples ``delay()`` had counted, the map grows
-    a hole where they were, and a turn boundary landing inside it cannot
-    be placed on the recording at all — a ``SpeechFault``, and a whole
-    simulation failed over audio the recording actually holds.
+    The clear then throws those samples away, and the recording loses the
+    join between two frames of speech a customer plays back — quietly, on
+    either channel, on any machine, at any load.
 
     So this feeds one unbroken utterance across a clock jump far past that
     window and counts the samples out the other side. Sixteen kilohertz in
@@ -1519,11 +1513,8 @@ async def test_a_wall_clock_gap_inside_one_utterance_loses_no_audio(
     recorder = conductor_module._EvidenceRecorder(sample_rate=24_000)
     frame = b"\x00\x01" * 320  # 20 ms at 16 kHz
 
-    # Both channels, because the two fail differently and only one of them
-    # says so. A clear on the agent's side breaks the map and raises; a
-    # clear on the persona's side raises nothing, because `bot_position`
-    # counts the buffer rather than reading a delay — it just drops the
-    # tail of an utterance out of the recording and stays quiet about it.
+    # Both channels, because a clear on either one drops the tail of an
+    # utterance out of the recording and says nothing about it.
     for channel, resampler in (
         ("agent", recorder._input_resampler),
         ("persona", recorder._output_resampler),


### PR DESCRIPTION
A simulation's recording is the evidence every audio-measured latency is read off, and it was keeping time by counting bytes. Pipecat's recorder pads whichever channel is behind up to the other one's buffer length. egma hands it the persona's audio as fast as the speech leg makes it — ahead of the transport playing any of it — so the agent's reply was padded up to that lead and landed about a second late in the file, and the lead accumulated, so the whole recording slid later than the call. Measured on the opening run: `turn_response_latency` high by 0.9–1.2 s on every turn, both channels drifting ~49 ms per second, transcript seeks several seconds out by the end of a call.

## What changed

Both channels are now placed on one absolute timeline, by time.

- **Each transport stamps what only it knows.** `TRANSPORT_ARRIVAL` goes on every inbound frame at the transport boundary — `_Arrival` in `media/room.py`, which until now only set a flag. `TRANSPORT_PLAYOUT` goes on every outbound frame *after* the transport's pacing, from `PlayoutStamp`, which sits after `transport.output()` and models the far end's queue: a frame plays when everything handed over before it has finished, not when the speech leg made it.
- **The partner padding is gone.** `_EvidenceRecorder` no longer calls Pipecat's `_process_recording` at all — `_sync_buffer_to_position` and the wall-clock gap filler with it. It writes each channel at its own stamp, with silence wherever nothing was written. The private `SOXRStreamAudioResampler.delay()` read goes too: the map from a turn's source time to its place in the recording is carried forward chunk by chunk instead.
- **Re-anchoring is bounded both ways.** A channel more than 0.1 s behind its clock is re-anchored forward (LiveKit's own tolerance), and the quiet that opens is remembered. A channel that later runs *ahead* of its clock is given that quiet back, closing the two together — which is what a delivery stall followed by a burst really is. Nothing a listener could hear is ever written over.
- **The recording's zero is its first sample,** latched from `start_recording` so Pipecat emptying its buffers at the end cannot clear it before the audio is filed. On a real-time transport that instant is derived back from the frame's own stamp rather than read when the recorder got round to the frame; a transport whose clock counts audio rather than seconds says so, and gets the moment of filing.
- **Arrival stamps name a frame's first sample.** A clock read when the frame is whole has already run its length, so `arrived_now` takes that length back off. Getting this backwards charged the recording one frame per frame.
- **Audio the transport threw away at an interruption is dropped,** because nobody heard it, and the persona's turn ends where the recording stops holding it.

The dual-channel WAV format, its storage key and playback are unchanged. The measure catalog and the reading side are untouched.

## How it is proven

`apps/simulator/tests/test_recording_timeline.py` is new and hermetic: it feeds the recorder audio with a known input lag (a persona utterance generated a second before the transport plays it) and a known rate error (20 ms of audio arriving every 21 ms), plus a delivery stall that wakes to a burst, the latched zero, the first-sample stamp and the derived wall-clock zero. Every case fails on the recorder as it was and passes on this one, checked by reverting each fix in turn.

Suites run, one at a time in `apps/simulator`: `test_recording_timeline.py` 9, `test_voice.py` 45, `test_spans.py` 35, `test_acceptance.py` 35, `test_plug_livekit.py` 156, `test_persona_silence.py` 16 — all passing, `ruff check src tests` clean.

## What is not proven here

Per ADR-0015, the persona-POV number and the agent-POV number should differ by the VAD hangover plus the wire — 0.6–0.7 s per turn on the effort's opening run. **That acceptance needs a fresh simulation and will be checked in the effort's final live run.** A recording made before this change cannot show the change: re-measuring the opening run's file against its LiveKit export reproduces the defect exactly (agent POV 3.79 / 1.52 / 2.21 / 1.90 s from the spans against persona POV 5.50 / 3.26 / 3.70 / 3.38 s off the file, a difference of 1.5–1.7 s where 0.6–0.7 s is the target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132psu7RAAfosj29TgDAhaF

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791323009&installation_model_id=431960&pr_number=300&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F300&signature=f8867bd7e11ca557391fe6febe55a449b158d255d3b69e33a7de13fa88fa4983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces count-based dual-channel recording placement with transport-clock placement and aligns transcript timestamps, interruption handling, and scripted transports with that timeline.

- Stamps inbound arrival and outbound playout at transport boundaries.
- Places each recording channel independently, including bounded re-anchoring and catch-up.
- Truncates persona audio discarded during interruption and anchors transcript timestamps to the recording’s first sample.
- Adds focused timeline, drift, interruption, resampling, and wall-clock tests.
- Repeated re-anchors currently discard earlier recoverable gaps, so later audio can remain shifted after multiple stalls.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until repeated delivery stalls retain all outstanding artificial-silence gaps so the recording cannot remain shifted after catch-up.

The new timeline behaves correctly for the covered single-stall case, but a second forward re-anchor overwrites the first gap’s recovery metadata; a later burst then closes only the latest gap and leaves subsequent recording and transcript positions late.

**Files Needing Attention:** apps/simulator/src/egma_simulator/conductor.py

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/simulator/src/egma_simulator/conductor.py | Replaces count-based recording with timestamp placement and interruption-aware cursors, but loses earlier recovery gaps when multiple forward re-anchors occur. |
| apps/simulator/src/egma_simulator/media/__init__.py | Adds transport timestamp helpers, a playout queue clock, and the shared real-time transport contract. |
| apps/simulator/src/egma_simulator/media/room.py | Stamps LiveKit input arrival and adds outbound playout stamping after the transport output processor. |
| apps/simulator/src/egma_simulator/media/scripted_transport.py | Adds deterministic arrival and playout timestamps using the scripted transport’s media clock. |
| apps/simulator/tests/test_recording_timeline.py | Adds comprehensive direct coverage for timeline placement, drift, interruption, catch-up, recording origin, and wall-clock conversion. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Inbound agent frame] --> B[Transport arrival stamp]
  B --> R[Evidence recorder]
  P[Persona TTS frame] --> O[Transport output]
  O --> C[Playout clock stamp]
  C --> R
  I[Interruption] --> C
  R --> U[Agent channel]
  R --> V[Persona channel]
  U --> W[Dual-channel WAV timeline]
  V --> W
  R --> T[Transcript positions and latency evidence]
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22egma-ai%2Fegma%22%20on%20the%20existing%20branch%20%22agent-pov-06-recorder-places-audio-by-time%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent-pov-06-recorder-places-audio-by-time%22.%0A%0AGreploop%20egma-ai%2Fegma%20PR%20%23300%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=egma-ai%2Fegma&pr=300&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22egma-ai%2Fegma%22%20on%20the%20existing%20branch%20%22agent-pov-06-recorder-places-audio-by-time%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent-pov-06-recorder-places-audio-by-time%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Fsimulator%2Fsrc%2Fegma_simulator%2Fconductor.py%3A481-482%0A**Repeated%20stalls%20lose%20timing**%0A%0AWhen%20two%20delivery%20stalls%20each%20exceed%20the%20100%20ms%20tolerance%20before%20the%20stream%20catches%20up%2C%20these%20assignments%20replace%20the%20first%20gap%E2%80%99s%20recovery%20state%20with%20the%20second%20gap.%20The%20later%20burst%20can%20reclaim%20only%20the%20latest%20artificial%20silence%2C%20leaving%20the%20earlier%20gap%20permanently%20in%20the%20recording%20and%20shifting%20later%20audio%20and%20transcript%20positions%20away%20from%20the%20transport%20clock.%20Preserve%20every%20outstanding%20re-anchor%20gap%20and%20add%20a%20test%20covering%20two%20stalls%20followed%20by%20one%20catch-up%20burst.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=egma-ai%2Fegma&pr=300&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fsimulator%2Fsrc%2Fegma_simulator%2Fconductor.py%3A481-482%0A**Repeated%20stalls%20lose%20timing**%0A%0AWhen%20two%20delivery%20stalls%20each%20exceed%20the%20100%20ms%20tolerance%20before%20the%20stream%20catches%20up%2C%20these%20assignments%20replace%20the%20first%20gap%E2%80%99s%20recovery%20state%20with%20the%20second%20gap.%20The%20later%20burst%20can%20reclaim%20only%20the%20latest%20artificial%20silence%2C%20leaving%20the%20earlier%20gap%20permanently%20in%20the%20recording%20and%20shifting%20later%20audio%20and%20transcript%20positions%20away%20from%20the%20transport%20clock.%20Preserve%20every%20outstanding%20re-anchor%20gap%20and%20add%20a%20test%20covering%20two%20stalls%20followed%20by%20one%20catch-up%20burst.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=egma-ai%2Fegma&pr=300&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["The recording keeps its own zero, and it..."](https://github.com/egma-ai/egma/commit/854355c3db5f36eea74a19da74abdb582eab72f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61035980)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Simulation platform](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/simulation-platform.md)
- Knowledge Base — [Simulator execution pipeline](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/simulator-execution.md)
- Knowledge Base — [Simulator media transports](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/simulator-media-transports.md)
</details>


<!-- /greptile_comment -->