### PR TITLE
Consolidate SDK compatibility CI and prepare 0.3.0 releases

### DIFF
--- a/.github/livekit_compatibility.py
+++ b/.github/livekit_compatibility.py
@@ -1,0 +1,199 @@
+"""Check packaged SDKs against LiveKit versions in parallel, within one CI job."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import time
+import tomllib
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+ROOT = Path(__file__).resolve().parents[1]
+PYTHON_SDK = ROOT / "sdks/python"
+# Rejection below the telemetry floor, minimum support, minor boundaries,
+# the customer pin, and the highest reviewed release.
+JS_VERSIONS = ("1.5.0", "1.5.5", "1.6.0", "1.6.4", "1.7.0", "1.7.1")
+LIVE_TESTS = ("test_live_room_detection.py", "test_live_mockable.py")
+
+
+def python_versions():
+    project = tomllib.loads((PYTHON_SDK / "pyproject.toml").read_text())
+    dependency = next(
+        item
+        for item in project["project"]["dependencies"]
+        if item.startswith("livekit-agents")
+    )
+    floor = re.search(r">=(\d+\.\d+\.\d+)", dependency)
+    if floor is None:
+        raise ValueError("livekit-agents must declare an exact minimum version")
+    lock = tomllib.loads((PYTHON_SDK / "uv.lock").read_text())
+    locked = next(
+        item["version"] for item in lock["package"] if item["name"] == "livekit-agents"
+    )
+    return tuple(dict.fromkeys((floor[1], locked))), project["dependency-groups"]["dev"]
+
+
+def run(command, log, *, cwd=ROOT):
+    subprocess.run(
+        command,
+        cwd=cwd,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        check=True,
+        timeout=600,
+        env={**os.environ, "PYTHONPATH": ""},
+    )
+
+
+def check_python(wheel, version, dev_dependencies, directory, log):
+    python = directory / "venv/bin/python"
+    run(["uv", "venv", "--python", "3.11", str(directory / "venv")], log)
+    run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(python),
+            str(wheel),
+            f"livekit-agents=={version}",
+            f"livekit-plugins-openai=={version}",
+            *dev_dependencies,
+        ],
+        log,
+    )
+    # Ensure pytest will exercise the installed wheel, never an editable checkout.
+    run(
+        [
+            str(python),
+            "-c",
+            "import egma, sys; from pathlib import Path; "
+            "from importlib.metadata import version; "
+            "assert Path(egma.__file__).is_relative_to(sys.prefix); "
+            "assert version('livekit-agents') == sys.argv[1]",
+            version,
+        ],
+        log,
+        cwd=directory,
+    )
+    run(
+        [
+            str(python),
+            "-m",
+            "pytest",
+            "-c",
+            str(PYTHON_SDK / "pyproject.toml"),
+            str(PYTHON_SDK / "tests"),
+            "-q",
+            "-o",
+            f"cache_dir={directory / 'pytest-cache'}",
+            *(f"--ignore={PYTHON_SDK / 'tests' / name}" for name in LIVE_TESTS),
+        ],
+        log,
+        cwd=directory,
+    )
+
+
+def parallel_checks(versions, check, directory):
+    """Wait for every result, retain readable logs, and fail on any failed version."""
+    results = {}
+    started = time.monotonic()
+
+    def worker(version):
+        version_dir = directory / version
+        version_dir.mkdir()
+        with (version_dir / "check.log").open("w") as log:
+            try:
+                check(version, version_dir, log)
+            except Exception as error:
+                print(f"{type(error).__name__}: {error}", file=log)
+                return False
+        return True
+
+    print(f"Checking LiveKit {', '.join(versions)} in parallel", flush=True)
+    with ThreadPoolExecutor(max_workers=len(versions)) as executor:
+        pending = {executor.submit(worker, version): version for version in versions}
+        for future in as_completed(pending):
+            version = pending[future]
+            passed = future.result()
+            results[version] = passed
+            label = f"LiveKit {version}: {'PASS' if passed else 'FAIL'}"
+            print(f"::group::{label}")
+            print((directory / version / "check.log").read_text())
+            print("::endgroup::")
+            if not passed:
+                print(f"::error::{label}")
+            print(label, flush=True)
+    print(f"Compatibility checks completed in {time.monotonic() - started:.1f}s")
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a") as output:
+            output.write("| LiveKit | Result |\n|---|---|\n")
+            for version in versions:
+                output.write(
+                    f"| {version} | {'PASS' if results[version] else 'FAIL'} |\n"
+                )
+    return all(results.values())
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("language", choices=("javascript", "python"))
+    parser.add_argument("package", type=Path)
+    args = parser.parse_args()
+    package = args.package.resolve(strict=True)
+    with TemporaryDirectory(prefix="egma-compatibility-") as temporary:
+        directory = Path(temporary)
+        if args.language == "javascript":
+            versions = JS_VERSIONS
+
+            def check(version, version_dir, log):
+                run(
+                    [
+                        "node",
+                        str(
+                            ROOT
+                            / "sdks/livekit-js/test/verify-packed-compatibility.mjs"
+                        ),
+                        str(package),
+                        version,
+                    ],
+                    log,
+                )
+        else:
+            versions, dev_dependencies = python_versions()
+
+            def check(version, version_dir, log):
+                check_python(package, version, dev_dependencies, version_dir, log)
+
+        if not parallel_checks(versions, check, directory):
+            return 1
+        if args.language == "python":
+            # The existing real-room fixture owns one fixed server port. Run it
+            # once, on the locked version, after both core suites have finished.
+            print("Running Python live tests once on the locked version", flush=True)
+            locked_dir = directory / versions[-1]
+            run(
+                [
+                    str(locked_dir / "venv/bin/python"),
+                    "-m",
+                    "pytest",
+                    "-c",
+                    str(PYTHON_SDK / "pyproject.toml"),
+                    "-q",
+                    "-o",
+                    f"cache_dir={locked_dir / 'pytest-cache'}",
+                    *(str(PYTHON_SDK / "tests" / name) for name in LIVE_TESTS),
+                ],
+                None,
+                cwd=locked_dir,
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/test_livekit_compatibility.py
+++ b/.github/test_livekit_compatibility.py
@@ -1,0 +1,54 @@
+"""A concurrent version failure must fail the job without losing other results."""
+
+import contextlib
+import io
+import os
+import sys
+import threading
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from livekit_compatibility import parallel_checks, run
+
+
+class CompatibilityTests(unittest.TestCase):
+    def test_all_versions_finish_and_any_failed_process_fails_the_job(self):
+        versions = ("1.5.5", "1.6.4", "1.7.1")
+        for failing in (None, "1.6.4"):
+            with self.subTest(failing=failing), TemporaryDirectory() as temporary:
+                directory = Path(temporary)
+                barrier = threading.Barrier(len(versions), timeout=5)
+
+                def check(version, version_dir, log, barrier=barrier, failing=failing):
+                    # No version can proceed until all have started. A serial
+                    # runner breaks the barrier and cannot pass this test.
+                    barrier.wait()
+                    run(
+                        [
+                            sys.executable,
+                            "-c",
+                            "import sys; print(sys.argv[1]); "
+                            "sys.exit(int(sys.argv[2]))",
+                            version,
+                            str(int(version == failing)),
+                        ],
+                        log,
+                    )
+
+                summary = directory / "summary.md"
+                with patch.dict(os.environ, {"GITHUB_STEP_SUMMARY": str(summary)}):
+                    with contextlib.redirect_stdout(io.StringIO()):
+                        passed = parallel_checks(versions, check, directory)
+                self.assertEqual(passed, failing is None)
+                for version in versions:
+                    self.assertIn(
+                        version, (directory / version / "check.log").read_text()
+                    )
+                    status = "FAIL" if version == failing else "PASS"
+                    self.assertIn(f"| {version} | {status} |", summary.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/release-livekit-js-sdk.yml
+++ b/.github/workflows/release-livekit-js-sdk.yml
@@ -2,8 +2,8 @@ name: Release LiveKit JavaScript SDK
 
 # Publishing is one deliberate tag push. Merging does not publish.
 #
-#   git tag livekit-js-sdk-v0.2.0
-#   git push origin livekit-js-sdk-v0.2.0
+#   git tag livekit-js-sdk-v0.3.0
+#   git push origin livekit-js-sdk-v0.3.0
 #
 # npm must trust this repository, workflow, and @egma/livekit package. GitHub
 # then supplies one short-lived OIDC credential. No long-lived npm token is
@@ -20,12 +20,9 @@ permissions:
 
 jobs:
   compatibility:
-    name: LiveKit JS ${{ matrix.livekit }} compatibility
+    name: LiveKit JS compatibility
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        livekit: ["1.5.0", "1.5.5", "1.6.0", "1.6.4", "1.7.0", "1.7.1"]
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -50,11 +47,8 @@ jobs:
           test -n "$tarball"
           echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
 
-      - name: Verify the packed SDK with LiveKit ${{ matrix.livekit }}
-        run: >-
-          node sdks/livekit-js/test/verify-packed-compatibility.mjs
-          "${{ steps.pack.outputs.tarball }}"
-          "${{ matrix.livekit }}"
+      - name: Verify all LiveKit versions in parallel
+        run: python3 .github/livekit_compatibility.py javascript "${{ steps.pack.outputs.tarball }}"
 
   release:
     name: Verify and publish

--- a/.github/workflows/release-python-sdk.yml
+++ b/.github/workflows/release-python-sdk.yml
@@ -2,8 +2,8 @@ name: Release Python SDK
 
 # Publishing is one deliberate tag push. Merging does not publish.
 #
-#   git tag python-sdk-v0.1.1
-#   git push origin python-sdk-v0.1.1
+#   git tag python-sdk-v0.3.0
+#   git push origin python-sdk-v0.3.0
 #
 # PyPI must trust this repository, workflow, and `pypi` environment. GitHub
 # then supplies one short-lived OIDC credential. No long-lived PyPI token is
@@ -56,12 +56,11 @@ jobs:
           fi
           echo "Releasing egma $packaged."
 
-      - name: Test the source tree
+      - name: Lint the Python SDK
         working-directory: sdks/python
         run: |
           uv sync --frozen
           uv run --frozen ruff check src tests
-          uv run --frozen pytest
 
       - name: Test the LiveKit fixture
         working-directory: fixtures/livekit-dumb-agent
@@ -73,6 +72,12 @@ jobs:
       - name: Build the wheel and source distribution
         working-directory: sdks/python
         run: uv build --out-dir dist
+
+      - name: Verify the wheel against both LiveKit versions in parallel
+        run: |
+          wheel="$(find sdks/python/dist -maxdepth 1 -name '*.whl' -print -quit)"
+          test -n "$wheel"
+          python3 .github/livekit_compatibility.py python "$wheel"
 
       - name: Prove the built wheel in a clean environment
         working-directory: sdks/python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,9 @@ jobs:
         # Builds the workspace, then the tests against it, then the web app.
         run: pnpm typecheck
 
+      - name: Check compatibility job failure handling
+        run: python3 -B -m unittest discover -s .github -p 'test_*.py'
+
   fast:
     name: Fast lane
     # Four CPUs guarantee the two Vitest workers below while leaving Postgres,
@@ -277,48 +280,45 @@ jobs:
       - name: Run the simulator tests
         run: pnpm test:simulator
 
-  sdk:
-    name: SDK tests
+  livekit-python-compatibility:
+    name: LiveKit Python compatibility
     if: ${{ github.ref == 'refs/heads/main' || github.base_ref == 'main' }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    # Two isolated Python environments run their core suites concurrently.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          node-version: 24
-          cache: pnpm
+          python-version: "3.11"
 
-      - name: Make the native build toolchain available
-        # Blacksmith's image carries no node-gyp, and `node-pty` publishes no
-        # Linux prebuild — so the install below compiles it, and without a
-        # compiler it dies as a bare "node-gyp: not found" underneath a package
-        # name. A gap in this runner image, not a requirement of this
-        # repository: `.github/native-toolchain.sh` says why in full, and
-        # installs nothing on an image that already has the four tools.
-        run: ./.github/native-toolchain.sh
+      - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+        with:
+          version: "0.11.33"
 
-      - run: pnpm install --frozen-lockfile
+      - name: Lint the Python SDK
+        working-directory: sdks/python
+        run: uv run --frozen ruff check --config pyproject.toml src tests ../../.github/*.py
 
-      - name: Install the Python SDK toolchain
-        run: pipx install uv
+      - name: Build the Python SDK once
+        id: pack
+        run: |
+          dir="$(mktemp -d)"
+          uv build sdks/python --wheel --out-dir "$dir"
+          wheel="$(find "$dir" -maxdepth 1 -name '*.whl' -print -quit)"
+          test -n "$wheel"
+          echo "wheel=$wheel" >> "$GITHUB_OUTPUT"
 
-      - name: Run the Python and JavaScript SDK tests
-        run: pnpm test:sdk
+      - name: Verify the minimum and locked LiveKit versions in parallel
+        run: python3 .github/livekit_compatibility.py python "${{ steps.pack.outputs.wheel }}"
 
   livekit-js-compatibility:
-    name: LiveKit JS ${{ matrix.livekit }} compatibility
+    name: LiveKit JS compatibility
     if: ${{ github.ref == 'refs/heads/main' || github.base_ref == 'main' }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    strategy:
-      fail-fast: false
-      matrix:
-        # 1.5.0 is the mock-tool floor. 1.5.5 is the monitoring floor.
-        # 1.6.4 is the exact Rentlyx pin. The remaining lanes catch a break at
-        # each supported minor boundary and at the current upper edge.
-        livekit: ["1.5.0", "1.5.5", "1.6.0", "1.6.4", "1.7.0", "1.7.1"]
+    # Share checkout/build work; all six clean installs run concurrently.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -334,6 +334,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Run the JavaScript SDK tests
+        run: pnpm test:sdk:javascript
+
       - name: Build and pack the SDK
         id: pack
         run: |
@@ -346,11 +349,8 @@ jobs:
           test -n "$tarball"
           echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
 
-      - name: Verify the packed SDK with LiveKit ${{ matrix.livekit }}
-        run: >-
-          node sdks/livekit-js/test/verify-packed-compatibility.mjs
-          "${{ steps.pack.outputs.tarball }}"
-          "${{ matrix.livekit }}"
+      - name: Verify all LiveKit versions in parallel
+        run: python3 .github/livekit_compatibility.py javascript "${{ steps.pack.outputs.tarball }}"
 
   fixture:
     name: Fixture agent tests
@@ -385,7 +385,7 @@ jobs:
 
   deploy:
     name: Deploy
-    needs: [checks, fast, browser, simulator, sdk, livekit-js-compatibility, fixture]
+    needs: [checks, fast, browser, simulator, livekit-python-compatibility, livekit-js-compatibility, fixture]
     if: >-
       github.ref == 'refs/heads/main' &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch')

--- a/fixtures/livekit-dumb-agent/uv.lock
+++ b/fixtures/livekit-dumb-agent/uv.lock
@@ -444,7 +444,7 @@ wheels = [
 
 [[package]]
 name = "egma"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "../../sdks/python" }
 dependencies = [
     { name = "livekit-agents" },

--- a/sdks/livekit-js/README.md
+++ b/sdks/livekit-js/README.md
@@ -24,6 +24,19 @@ gives a direct version error. You do not need to pin to `1.6.4`.
 The upper bound is LiveKit's next major release, not its next minor release:
 Egma uses these public v1 APIs as one compatible line. CI pins the exact
 minimum, each available minor boundary, and the latest tested v1 release.
+One compatibility job builds the package once and checks those versions in
+parallel, using a separate installation for each version.
+
+## Upgrading from 0.2
+
+Version 0.3 replaces `mockable` with `simulation` and `monitorLiveKit` with
+`monitor`. The options type is now `MonitorOptions`. Update the imports and
+calls; the old names are no longer exported.
+
+`simulation` now also exports the agent's traces. Set `EGMA_URL` and
+`EGMA_API_KEY`, or pass `endpoint` and `apiKey`, before calling it. Both
+functions require LiveKit Agents JS 1.5.5 or newer within v1. A simulation
+that cannot report its tools raises `NotReported` before the session starts.
 
 ## Run a simulation
 

--- a/sdks/livekit-js/package.json
+++ b/sdks/livekit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egma/livekit",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Test and monitor LiveKit Agents JS workers with Egma.",
   "type": "module",
   "license": "Apache-2.0",

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -370,6 +370,16 @@ claimants means are all Egma's to evolve. That is precisely what
 
 Use the recipe as the bridge, not as the small tier.
 
+## Upgrading from 0.2
+
+Version 0.3 replaces `mockable` with `simulation` and `monitor_livekit` with
+`monitor`. Update the imports and calls; the old names are no longer exported.
+
+`simulation` now also exports the agent's traces. Set `EGMA_URL` and
+`EGMA_API_KEY`, or pass `endpoint` and `api_key`, before calling it. A simulation
+that cannot report its tools raises `NotReported` before the session starts.
+The supported LiveKit range remains `>=1.6.7,<1.7`.
+
 ## Compatibility
 
 The `egma-sim-` room-name prefix is a stated contract, not an internal
@@ -389,6 +399,11 @@ testing API. Monitoring also reads LiveKit's current dynamic tracer
 provider because the public telemetry API has a setter but no getter.
 The fixture and live tests verify both seams before the supported range
 changes.
+
+CI builds the wheel once and runs the core SDK tests against the minimum
+supported LiveKit version and the version in `uv.lock`, in parallel clean
+environments. The live tests run once on the locked version after those
+checks, so they have sole use of the local LiveKit server port.
 
 The package also keeps the OpenAI Python package on major version 2.
 LiveKit Agents 1.6 does not support OpenAI 3.

--- a/sdks/python/package.json
+++ b/sdks/python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egma/sdk-python",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "pnpm's door into the Python package customers install: the real toolchain is uv. See README.md.",
   "scripts": {

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "egma"
-version = "0.2.0"
+version = "0.3.0"
 description = "Test and monitor LiveKit agents with Egma."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "egma"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "livekit-agents" },


### PR DESCRIPTION
CI currently repeats installation and packaging across six JavaScript compatibility jobs, while Python's minimum and locked LiveKit versions receive different test coverage. This change uses one compatibility job per language, builds each SDK once, and checks its versions concurrently in clean environments. Every version reports its own result, and any failed version fails the job. Python's existing live tests run once after the core suites to avoid sharing the server port.

Both packages advance to 0.3.0 so the already-merged `simulation` and `monitor` API changes can be published. The README migration notes explain the renamed exports, simulation tracing configuration, and supported LiveKit versions. Both release workflows use the same compatibility runner as PR CI.

Validation: all six JavaScript compatibility versions passed locally; both Python versions passed 189 core tests each; three real-room tests passed against an isolated local LiveKit server. The optional model-credential test remains skipped. JavaScript SDK tests, parallel execution and failure propagation regression coverage, Ruff, actionlint, and both Python lockfile checks passed. CI and Greptile review must pass before merge and release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791398527&installation_model_id=431960&pr_number=306&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F306&signature=40e9c14c6fbb26ef995aa4b42a547fa71c18e550c5105fa6f91c068719297a26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates LiveKit compatibility testing into one parallelized job per SDK language and prepares both SDKs for their 0.3.0 releases.
- Builds each SDK package once and verifies it in isolated environments across supported LiveKit versions.
- Preserves JavaScript unit tests and exercises the Python wheel at both its minimum and locked dependency versions.
- Reuses the compatibility runner in release workflows and adds regression coverage for parallel failure propagation.
- Updates package metadata, lockfiles, release examples, and migration documentation for version 0.3.0.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with compatibility coverage preserved and no actionable correctness, security, or release-version issue identified.

The consolidated runners isolate each version, aggregate failures correctly, retain the prior SDK test coverage, and use package and release metadata that consistently identifies version 0.3.0.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/livekit_compatibility.py | Introduces isolated, parallel compatibility execution with per-version logs, aggregated results, and serialized Python live tests. |
| .github/test_livekit_compatibility.py | Verifies that checks execute concurrently, all results are retained, and any failed version fails the aggregate result. |
| .github/workflows/test.yml | Replaces the combined SDK job and JavaScript matrix with dedicated Python and JavaScript compatibility jobs while preserving SDK test coverage. |
| .github/workflows/release-python-sdk.yml | Adds built-wheel compatibility verification for the minimum and locked LiveKit versions before publication. |
| .github/workflows/release-livekit-js-sdk.yml | Replaces repeated matrix packaging with one package build followed by parallel compatibility checks. |
| sdks/livekit-js/README.md | Documents the 0.3 migration, tracing configuration, and LiveKit compatibility expectations. |
| sdks/python/README.md | Documents renamed APIs, simulation tracing configuration, and the supported Python LiveKit range. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  PR[PR or release workflow] --> JSBuild[Build and pack JavaScript SDK once]
  PR --> PyBuild[Build Python wheel once]
  JSBuild --> JSRunner[JavaScript compatibility runner]
  PyBuild --> PyRunner[Python compatibility runner]
  JSRunner --> JSVersions[Six isolated LiveKit version checks in parallel]
  PyRunner --> PyMin[Minimum LiveKit core suite]
  PyRunner --> PyLocked[Locked LiveKit core suite]
  PyMin --> PyLive[Live tests once after core suites]
  PyLocked --> PyLive
  JSVersions --> JSResult[Fail job if any version fails]
  PyLive --> PyResult[Fail job if any core or live test fails]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Consolidate SDK compatibility CI and pre..."](https://github.com/egma-ai/egma/commit/ac42d148f4b043cf86696fef949cec347219b8a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61327190)</sub>

<!-- /greptile_comment -->