### PR TITLE
Polish dropdowns and edit persona settings inline

### DIFF
--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -3393,10 +3393,9 @@ describe("the complete product, walked in order in a second project", () => {
 
       await walk.getByRole("button", { name: "Save changes" }).click();
 
-      // The new version is current and the one the earlier runs pinned is still
-      // in the list beside it, which is the whole point of versioning her.
+      // The new current version stays in the header after saving.
       await saysWithin(walk, "Custom · v2");
-      await saysWithin(walk, "Current");
+      await walk.getByRole("button", { name: "Saved", exact: true }).waitFor();
       await walk.keyboard.press("Escape");
 
       // Fork copies the current version into a persona this project owns, and
@@ -5637,7 +5636,7 @@ describe("project grader model settings", () => {
 });
 
 it(
-  "uses shared persona project settings and keeps core history read-only",
+  "edits shared persona settings inline and keeps the current core version visible",
   async () => {
     const key = await anotherCustomer(
       "settings@personas.example",
@@ -5662,10 +5661,6 @@ it(
       await walk
         .getByRole("button", { name: "Everyday caller", exact: true })
         .click();
-      await walk
-        .getByRole("button", { name: "Actions for Everyday caller" })
-        .click();
-      await walk.getByRole("menuitem", { name: "Use", exact: true }).click();
       await reactHasTakenOver(walk, "form");
       expect(await walk.locator("#persona-personality").count()).toBe(0);
       await walk.selectOption("#persona-llm", "openai::gpt-4o");
@@ -5674,20 +5669,14 @@ it(
       await walk.fill("#persona-tts-speed", "0.85");
       await walk.fill("#persona-tts-voice", "my-custom-voice");
       await walk.getByRole("button", { name: "Use persona" }).click();
-      await walk.getByRole("region", { name: "Project settings" }).waitFor();
-      expect(
-        await walk
-          .getByRole("region", { name: "Project settings" })
-          .innerText(),
-      ).toContain("my-custom-voice");
+      await walk.getByRole("button", { name: "Saved", exact: true }).waitFor();
+      await walk.getByRole("region", { name: "Settings" }).waitFor();
+      expect(await walk.inputValue("#persona-tts-voice")).toBe("my-custom-voice");
       await walk.keyboard.press("Escape");
       await walk
         .getByRole("button", { name: "Everyday caller", exact: true })
         .click();
-      await walk
-        .getByRole("button", { name: "Actions for Everyday caller" })
-        .click();
-      await walk.getByRole("menuitem", { name: "Edit settings" }).click();
+      await walk.getByRole("region", { name: "Settings" }).waitFor();
       expect(await walk.inputValue("#persona-llm")).toBe("openai::gpt-4o");
       expect(await walk.inputValue("#persona-stt")).toBe(
         "deepgram::nova-3-general",
@@ -5708,7 +5697,7 @@ it(
       await walk.getByRole("alert").waitFor();
       await walk.fill("#persona-tts-voice", "my-saved-voice");
       await walk.getByRole("button", { name: "Save changes" }).click();
-      await walk.getByRole("region", { name: "Project settings" }).waitFor();
+      await walk.getByRole("button", { name: "Saved", exact: true }).waitFor();
       await walk
         .getByRole("button", { name: "Actions for Everyday caller" })
         .click();
@@ -5730,24 +5719,14 @@ it(
       );
       await walk.getByRole("button", { name: "Save changes" }).click();
       await walk.getByText("Custom · v2", { exact: true }).waitFor();
-      await walk.getByRole("button", { name: "Read", exact: true }).click();
-      await walk.getByText("Older version", { exact: true }).waitFor();
-      expect(
-        await walk.getByRole("region", { name: "Project settings" }).count(),
-      ).toBe(0);
-      expect(
-        await walk.getByRole("button", { name: "Use as new version" }).count(),
-      ).toBe(0);
-      expect(
-        await walk
-          .getByRole("button", { name: "Actions for Patient Nora" })
-          .count(),
-      ).toBe(0);
+      await walk.getByRole("button", { name: "Saved", exact: true }).waitFor();
+      expect(await walk.getByRole("region", { name: "Versions" }).count()).toBe(0);
+      expect(await walk.getByRole("button", { name: "Read", exact: true }).count()).toBe(0);
+      await walk.getByRole("region", { name: "Settings" }).waitFor();
       await walk.screenshot({
-        path: "/tmp/egma-persona-history-light.png",
+        path: "/tmp/egma-persona-settings-light.png",
         fullPage: true,
       });
-      await walk.getByRole("button", { name: "Back to v2" }).click();
       await walk
         .getByRole("button", { name: "Actions for Patient Nora" })
         .click();

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -179,9 +179,22 @@
  * computed `display` is `block`, so the declaration did nothing there.
  */
 @layer base {
+  select[data-slot="select"] {
+    appearance: none;
+    background-image: var(--select-chevron);
+    background-position: right var(--space-3) center;
+    background-size: var(--space-4);
+    background-repeat: no-repeat;
+    cursor: pointer;
+    transition: border-color var(--duration-hover) var(--ease-out);
+  }
+  @media (hover: hover) and (pointer: fine) {
+    select[data-slot="select"]:hover:not(:disabled) { border-color: var(--muted); }
+  }
   @supports (appearance: base-select) {
-    select, ::picker(select) { appearance: base-select; }
+    select, select[data-slot="select"], ::picker(select) { appearance: base-select; }
     select { align-items: center; }
+    select[data-slot="select"]::picker-icon { display: none; }
     ::picker(select) {
       margin-block: var(--space-2);
       padding: var(--space-1);
@@ -191,6 +204,25 @@
       box-shadow: var(--shadow-menu);
       color: var(--foreground);
       overscroll-behavior: contain;
+      opacity: 0;
+      transform: scale(var(--select-picker-scale));
+      transform-origin: center var(--select-picker-origin, top);
+      transition:
+        opacity var(--duration-popover-out) var(--ease-out),
+        transform var(--duration-popover-out) var(--ease-out),
+        display var(--duration-popover-out) allow-discrete,
+        overlay var(--duration-popover-out) allow-discrete;
+    }
+    :open::picker(select) {
+      opacity: 1;
+      transform: scale(1);
+      transition-duration: var(--duration-popover-in);
+    }
+    @starting-style {
+      :open::picker(select) {
+        opacity: 0;
+        transform: scale(var(--select-picker-scale));
+      }
     }
     /*
      * Eight rows, and never more than the room there is. Under 32rem of window
@@ -200,8 +232,38 @@
     @media (min-height: 32rem) {
       ::picker(select) { max-height: min(18rem, calc(50dvh - 2rem)); }
     }
-    select option { padding: var(--space-2) var(--space-3); border-radius: var(--radius-sm); }
+    select option {
+      min-height: var(--control-md);
+      align-items: center;
+      gap: var(--space-3);
+      padding: var(--space-2) var(--space-3);
+      border-radius: var(--radius-sm);
+      background: var(--surface);
+      color: var(--foreground);
+    }
+    select option::checkmark {
+      order: 1;
+      margin-inline-start: auto;
+      color: var(--accent);
+    }
+    @media (hover: hover) and (pointer: fine) {
+      select option:hover:not(:disabled) { background: var(--surface-soft); }
+    }
+    select option:focus-visible {
+      outline: 2px solid var(--focus);
+      outline-offset: -2px;
+    }
     select option:checked { background: var(--surface-active); }
+    select option:disabled { color: var(--faint); cursor: not-allowed; }
+    @media (pointer: coarse) {
+      select option { min-height: var(--tap-target); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      ::picker(select), :open::picker(select) { transform: none; }
+      @starting-style {
+        :open::picker(select) { transform: none; }
+      }
+    }
   }
 }
 

--- a/apps/web/app/projects/[projectId]/graders/grader-sheets.tsx
+++ b/apps/web/app/projects/[projectId]/graders/grader-sheets.tsx
@@ -504,11 +504,13 @@ function DefinitionRead({
   projectId,
   definitionId,
   definitionVersion,
+  header,
   children,
 }: {
   readonly projectId: string;
   readonly definitionId: string;
   readonly definitionVersion?: number;
+  readonly header?: (entry: GraderLibraryEntry | null) => ReactNode;
   readonly children: (entry: GraderLibraryEntry) => ReactNode;
 }) {
   const { answer, reload } = useProjectRead<GraderLibraryEntry>(
@@ -530,21 +532,24 @@ function DefinitionRead({
     if (answer?.status === "signed-out") window.location.replace("/sign-in");
   }, [answer]);
   if (answer === null || answer.status === "signed-out") {
-    return <Loading what="grader details" />;
+    return <>{header?.(null)}<Loading what="grader details" /></>;
   }
   if (answer.status !== "ready") {
     return (
-      <Refused
-        message={answer.refusal.message}
-        action={
-          <Button type="button" variant="secondary" onClick={reload}>
-            Try again
-          </Button>
-        }
-      />
+      <>
+        {header?.(null)}
+        <Refused
+          message={answer.refusal.message}
+          action={
+            <Button type="button" variant="secondary" onClick={reload}>
+              Try again
+            </Button>
+          }
+        />
+      </>
     );
   }
-  return children(answer.value);
+  return <>{header?.(answer.value)}{children(answer.value)}</>;
 }
 
 export function LibraryGraderSheet({
@@ -910,20 +915,21 @@ export function ActiveGraderSheet({
   return (
     <Sheet open={open} onOpenChange={(next) => !next && onClose()}>
       <SheetContent aria-describedby={undefined}>
-        <SheetHeader>
-          <SheetTitle>
-            {graderDefinitionDisplayName(
-              grader.graderDefinitionId,
-              grader.name,
-            )}
-          </SheetTitle>
-          <SheetDescription>
-            This project&apos;s scope, settings, and individual pass threshold.
-          </SheetDescription>
-        </SheetHeader>
         <DefinitionRead
           projectId={projectId}
           definitionId={grader.graderDefinitionId}
+          header={(entry) => (
+            <SheetHeader>
+              <SheetTitle>
+                {graderDefinitionDisplayName(grader.graderDefinitionId, grader.name)}
+              </SheetTitle>
+              {entry === null ? null : (
+                <SheetDescription>
+                  {entry.owner === "egma" ? "Predefined" : "Custom"} · v{entry.currentDefinitionVersion}
+                </SheetDescription>
+              )}
+            </SheetHeader>
+          )}
         >
           {(entry) => (
             <EditGraderForm

--- a/apps/web/app/projects/[projectId]/personas/persona-fields.tsx
+++ b/apps/web/app/projects/[projectId]/personas/persona-fields.tsx
@@ -14,7 +14,7 @@ import {
   type PersonaForm,
   type PersonaModelCatalogEntry,
 } from "../../../../lib/personas.ts";
-import { Field, FormRow } from "../../../../ui/form.tsx";
+import { Field } from "../../../../ui/form.tsx";
 import { NumberField } from "../../../../ui/number-field.tsx";
 import { SheetSection } from "./sheet-parts.tsx";
 
@@ -191,7 +191,7 @@ export function BehaviorFields({
 }
 
 /**
- * The complete model selection owned by a persona version.
+ * The model settings used for this persona in the current project.
  *
  * **One control per engine, and the control is the pair.** The server's catalog
  * is a list of provider-and-model pairs its adapters can actually execute, so
@@ -277,75 +277,71 @@ export function ModelFields({
   readonly onChange: (draft: ModelsDraft) => void;
 }) {
   return (
-    <SheetSection label="Models">
+    <SheetSection label="Settings">
       <div className="flex flex-col gap-4">
-        <FormRow>
-          <EngineField
-            prefix={prefix}
-            job="llm"
-            label="Language model"
-            selection={{ provider: draft.llmProvider, model: draft.llmModel }}
-            form={form}
-            disabled={disabled}
-            onSelect={(entry) =>
-              onChange({
-                ...draft,
-                llmProvider: entry.provider,
-                llmModel: entry.model,
-              })
-            }
-          />
-          <EngineField
-            prefix={prefix}
-            job="stt"
-            label="Speech-to-text"
-            selection={{ provider: draft.sttProvider, model: draft.sttModel }}
-            form={form}
-            disabled={disabled}
-            onSelect={(entry) =>
-              onChange({
-                ...draft,
-                sttProvider: entry.provider,
-                sttModel: entry.model,
-              })
-            }
-          />
-        </FormRow>
+        <EngineField
+          prefix={prefix}
+          job="llm"
+          label="Language model"
+          selection={{ provider: draft.llmProvider, model: draft.llmModel }}
+          form={form}
+          disabled={disabled}
+          onSelect={(entry) =>
+            onChange({
+              ...draft,
+              llmProvider: entry.provider,
+              llmModel: entry.model,
+            })
+          }
+        />
+        <EngineField
+          prefix={prefix}
+          job="stt"
+          label="Speech-to-text"
+          selection={{ provider: draft.sttProvider, model: draft.sttModel }}
+          form={form}
+          disabled={disabled}
+          onSelect={(entry) =>
+            onChange({
+              ...draft,
+              sttProvider: entry.provider,
+              sttModel: entry.model,
+            })
+          }
+        />
 
-        <FormRow>
-          <EngineField
-            prefix={prefix}
-            job="tts"
-            label="Text-to-speech"
-            selection={{ provider: draft.ttsProvider, model: draft.ttsModel }}
-            form={form}
-            disabled={disabled}
-            onSelect={(entry) =>
-              onChange({
-                ...draft,
-                ttsProvider: entry.provider,
-                ttsModel: entry.model,
-                voiceId: entry.recommendedVoiceId ?? "",
-              })
-            }
-          />
-          {/*
-           * The rate carries no `min`, `max` or `step`, and that is deliberate.
-           * The accepted range is the server's rule, and a bound written here
-           * as well would either refuse a rate egma would have taken or take
-           * one egma will refuse. The one authoritative refusal is the
-           * server's, and the instruction that used to explain the range here
-           * was deleted on the developer's note against this very field.
-           */}
-          <NumberField
-            id={`${prefix}-tts-speed`}
-            label="Speech rate*"
-            value={draft.speed}
-            disabled={disabled}
-            required
-            onChange={(speed) => onChange({ ...draft, speed })}
-          />
-        </FormRow>
+        <EngineField
+          prefix={prefix}
+          job="tts"
+          label="Text-to-speech"
+          selection={{ provider: draft.ttsProvider, model: draft.ttsModel }}
+          form={form}
+          disabled={disabled}
+          onSelect={(entry) =>
+            onChange({
+              ...draft,
+              ttsProvider: entry.provider,
+              ttsModel: entry.model,
+              voiceId: entry.recommendedVoiceId ?? "",
+            })
+          }
+        />
+        {/*
+         * The rate carries no `min`, `max` or `step`, and that is deliberate.
+         * The accepted range is the server's rule, and a bound written here
+         * as well would either refuse a rate egma would have taken or take
+         * one egma will refuse. The one authoritative refusal is the
+         * server's, and the instruction that used to explain the range here
+         * was deleted on the developer's note against this very field.
+         */}
+        <NumberField
+          id={`${prefix}-tts-speed`}
+          label="Speech rate*"
+          value={draft.speed}
+          disabled={disabled}
+          required
+          onChange={(speed) => onChange({ ...draft, speed })}
+        />
 
         <Field
           label="Voice*"

--- a/apps/web/app/projects/[projectId]/personas/persona-sheets.tsx
+++ b/apps/web/app/projects/[projectId]/personas/persona-sheets.tsx
@@ -6,7 +6,6 @@ import {
   createPersona,
   deletePersona,
   getPersona,
-  listPersonaVersions,
   updatePersona,
   usePersona,
 } from "@egma/platform-api/client";
@@ -36,8 +35,6 @@ import {
   type Persona,
   type PersonaForm,
   type PersonaModels,
-  type PersonaVersion,
-  type PersonaVersionPage,
 } from "../../../../lib/personas.ts";
 import {
   platformAnswer,
@@ -49,7 +46,6 @@ import { useDraftNavigation } from "../../../../ui/draft-navigation.tsx";
 import { Refused } from "../../../../ui/form.tsx";
 import { Menu, MenuDivider, MenuItem } from "../../../../ui/menu.tsx";
 import { Failure, Loading, NotFound } from "../../../../ui/page-state.tsx";
-import { ListInstant, RelativeInstant, useMinuteClock } from "../../../../ui/relative-time.tsx";
 import { useProjectRead } from "../../../../ui/resource.ts";
 import { useUnsavedChanges } from "../../../../ui/settings-read.ts";
 import {
@@ -57,7 +53,7 @@ import {
   ModelFields,
   NameFields,
 } from "./persona-fields.tsx";
-import { Reads, SheetSection, StateChip, Versions, type Read } from "./sheet-parts.tsx";
+import { Reads, SheetSection, type Read } from "./sheet-parts.tsx";
 
 /**
  * A persona, created, read and edited in the panel the boards put it in.
@@ -71,8 +67,8 @@ import { Reads, SheetSection, StateChip, Versions, type Read } from "./sheet-par
  *
  * Name and description are live metadata. Identity name, personality, and
  * language have immutable core versions. Models are saved project settings.
- * Shared personas expose settings, clone, and read-only core history. Custom
- * personas also expose current-core editing and deletion.
+ * Settings are editable directly. Custom personas also expose current-core
+ * editing and deletion, while shared identities stay read-only.
 
  */
 
@@ -544,7 +540,6 @@ export function PersonaSheet({
   readonly onDelete: (persona: Persona) => void;
 }) {
   const choices = form?.status === "ready" ? form.value : null;
-  const now = useMinuteClock();
   const draftNavigation = useDraftNavigation();
   const nameField = useRef<HTMLInputElement>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
@@ -560,27 +555,11 @@ export function PersonaSheet({
     projectId,
     personaId,
   );
-  const {
-    answer: history,
-    reload: reloadHistory,
-  } = useProjectRead<PersonaVersionPage>(
-    (project) =>
-      platformAnswer(
-        listPersonaVersions(
-          { personaId, projectId: project },
-          { client: platformClient },
-        ),
-      ),
-    projectId,
-    personaId,
-  );
-
   const [held, setHeld] = useState<Draft | null>(null);
   const [editing, setEditing] = useState(startEditing);
   const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
   const [refusal, setRefusal] = useState<Refusal | null>(null);
-  /** The frozen version this panel is reading instead of the current one. */
-  const [reading, setReading] = useState<PersonaVersion | null>(null);
 
   /**
    * The editor is filled from the read once and never overwritten by a later
@@ -626,22 +605,26 @@ export function PersonaSheet({
     wasOpen.current = open;
     if (!opening) return;
     setEditing(startEditing);
-    setReading(null);
+    setSaved(false);
     setRefusal(null);
-  }, [open, startEditing]);
+    if (answer?.status === "ready") {
+      const one = answer.value;
+      setHeld({
+        personaId: one.id,
+        versionId: one.versionId,
+        name: one.name,
+        description: one.description ?? "",
+        behavior: behaviorDraftOf(one),
+        models: modelsDraftOf(modelsOfPersona(one)),
+      });
+    }
+  }, [open, startEditing, answer]);
 
-  /**
-   * A panel that starts showing something else starts at the top of it.
-   *
-   * The body is one scrolling column and the three modes are the same column
-   * with other content in it, so without this, pressing *Read* on a version
-   * somebody had to scroll down to reach leaves them looking at the middle of
-   * the frozen version they asked for.
-   */
+  /** Opening the custom identity editor starts at its first field. */
   useEffect(() => {
     const scroller = bodyRef.current;
     if (scroller !== null) scroller.scrollTop = 0;
-  }, [reading, editing]);
+  }, [editing]);
 
   const filled = held !== null;
   useEffect(() => {
@@ -660,8 +643,8 @@ export function PersonaSheet({
     (held.name !== persona.name ||
       held.description !== (persona.description ?? "") ||
       !sameBehaviorDraft(held.behavior, behaviorDraftOf(persona)) ||
-      !sameModelsDraft(held.models, modelsDraftOf(modelsOfPersona(persona))) || persona.settings === null);
-  useUnsavedChanges(open && editing && changed && !saving, saving);
+      !sameModelsDraft(held.models, modelsDraftOf(modelsOfPersona(persona))));
+  useUnsavedChanges(open && changed && !saving, saving);
 
   /**
    * Which persona this panel is holding, readable from inside an await.
@@ -681,6 +664,7 @@ export function PersonaSheet({
   ): Promise<Persona | null> {
     const asked = { projectId, personaId };
     setSaving(true);
+    setSaved(false);
     setRefusal(null);
 
     const written = await platformAnswer(request);
@@ -702,14 +686,12 @@ export function PersonaSheet({
       setRefusal(written.refusal);
       if (written.refusal.error === "version_conflict") {
         refresh();
-        reloadHistory();
       }
       return null;
     }
 
     setHeld((current) => adopted(current, submitted, written.value));
     reload();
-    reloadHistory();
     onWritten();
     return written.value;
   }
@@ -719,7 +701,8 @@ export function PersonaSheet({
       held === null ||
       persona === null ||
       !mayAuthor ||
-      saving
+      saving ||
+      busy
     ) {
       return;
     }
@@ -766,19 +749,24 @@ export function PersonaSheet({
         ...(nameChanged ? { name: held.name } : {}),
         ...(descriptionChanged ? { description: held.description } : {}),
         ...(behaviorChanged ? { behavior: held.behavior } : {}),
-        ...(modelsChanged ? { models: held.models } : {}),
+        ...(modelsChanged || persona.settings === null ? { models: held.models } : {}),
       },
     );
-    if (written !== null) setEditing(false);
+    if (written !== null) {
+      setSaved(true);
+      setEditing(false);
+    }
   }
 
   function edit(next: Draft): void {
+    setSaved(false);
     setHeld(next);
   }
 
   /** Leaving the editor, or the panel, with a question if there is one to ask. */
   function leaveEditor(): void {
     draftNavigation.request(() => {
+      setSaved(false);
       setRefusal(null);
       setEditing(false);
       if (persona !== null && held !== null && held.personaId === persona.id) {
@@ -798,111 +786,69 @@ export function PersonaSheet({
     draftNavigation.request(() => onClose());
   }
 
-  const versions = history?.status === "ready" ? history.value.versions : [];
   const predefined = persona?.owner === "egma";
-  const totalVersions = Math.max(versions.length, persona?.version ?? 0);
-  /**
-   * Whether this panel is drawing an editor, which is four things at once and
-   * not one: somebody asked for it, the persona is available, egma knows whose
-   * panel this is, and the authoring choices have arrived.
-   */
-  const editable =
-    editing && persona !== null && role !== null && choices !== null;
+  const settingsReady = persona !== null && role !== null && choices !== null;
 
-  /** The head of the panel: what kind of record it is, and which version. */
+  /** The head keeps the current core version visible. */
   function meta(): string {
     if (persona === null) return "";
     const kind = ownerSaid(persona.owner);
-    if (reading !== null) {
-      return `${kind} · v${String(reading.version)} of ${String(totalVersions)}`;
-    }
-    if (editing) {
-      return `${kind} · v${String(persona.version)} · Editing`;
-    }
-    return `${kind} · v${String(persona.version)}`;
+    return `${kind} · v${String(persona.version)}${editing ? " · Editing" : ""}`;
   }
 
-  function versionRows() {
-    return versions.map((version) => ({
-      id: version.id,
-      version: version.version,
-      written: <RelativeInstant instant={version.createdAt} now={now} />,
-      current: version.id === persona?.versionId,
-      reading: reading?.id === version.id,
-      ...(version.id === persona?.versionId
-        ? {}
-        : { onRead: () => setReading(version) }),
-    }));
-  }
-
-  /** The read view, which every mode except editing is a shape of. */
+  /** Shared identity stays read-only while the settings below it are editable. */
   function readBody(one: Persona) {
-    const shown = reading;
-    const behavior = shown === null ? behaviorDraftOf(one) : behaviorDraftOf(shown);
-    const models = modelsOfPersona(one);
-
     return (
-      <>
-        <SheetSection label="Who they are">
-          <Reads
-            reads={behaviorReads(
-              behavior,
-              /*
-               * A frozen version carries no name and no description — identity
-               * is live — so printing today's description under "this version
-               * is frozen" would be a sentence that is not true of it.
-               */
-              shown === null ? describedAs(one.description) : null,
-            )}
-          />
+      <SheetSection label="Who they are">
+        <Reads
+          reads={behaviorReads(behaviorDraftOf(one), describedAs(one.description))}
+        />
+      </SheetSection>
+    );
+  }
+
+  function settingsBody(one: Persona, draft: Draft) {
+    if (role === null) {
+      return (
+        <SheetSection label="Settings">
+          <Reads reads={modelReads(modelsOfPersona(one), choices)} />
         </SheetSection>
-
-        {shown === null ? <SheetSection label={one.settings === null ? "Default models" : "Project settings"}>
-          <Reads reads={modelReads(models, choices)} />
-        </SheetSection> : null}
-
-        {(
-          <>
-            <Reads
-              reads={[
-                {
-                  label: "Created",
-                  value: <ListInstant instant={one.createdAt} />,
-                },
-                {
-                  label: "Updated",
-                  value: <ListInstant instant={one.updatedAt} />,
-                },
-              ]}
-            />
-
-            {history === null || history.status === "signed-out" ? (
-              <Loading what="this persona's history" />
-            ) : history.status === "ready" ? (
-              <SheetSection label="Versions">
-                <Versions rows={versionRows()} />
-              </SheetSection>
-            ) : (
-              <Failure
-                message={history.refusal.message}
-                onRetry={reloadHistory}
-              />
-            )}
-          </>
-        )}
-      </>
+      );
+    }
+    if (form === null || form.status === "signed-out") {
+      return (
+        <SheetSection label="Settings">
+          <Loading what="the supported persona models" />
+        </SheetSection>
+      );
+    }
+    if (form.status !== "ready") {
+      return (
+        <SheetSection label="Settings">
+          <Failure message={form.refusal.message} onRetry={reloadForm} />
+        </SheetSection>
+      );
+    }
+    return (
+      <ModelFields
+        prefix="persona"
+        draft={draft.models}
+        form={form.value}
+        disabled={!mayAuthor || saving || busy}
+        onChange={(models) => edit({ ...draft, models })}
+      />
     );
   }
 
   /** Shared personas expose settings; custom personas also expose core fields. */
-  function editBody(draft: Draft, choices: PersonaForm) {
+  function editBody(draft: Draft) {
     return (
       <>
-        {predefined ? null : <><NameFields
+        <NameFields
           prefix="persona"
           name={draft.name}
           description={draft.description}
-          disabled={saving}
+          disabled={!mayAuthor || saving || busy}
           note={COPY.nameNote}
           onName={(name) => edit({ ...draft, name })}
           onDescription={(description) => edit({ ...draft, description })}
@@ -910,15 +856,8 @@ export function PersonaSheet({
         <BehaviorFields
           prefix="persona"
           draft={draft.behavior}
-          disabled={saving}
+          disabled={!mayAuthor || saving || busy}
           onChange={(behavior) => edit({ ...draft, behavior })}
-        /></>}
-        <ModelFields
-          prefix="persona"
-          draft={draft.models}
-          form={choices}
-          disabled={saving}
-          onChange={(models) => edit({ ...draft, models })}
         />
       </>
     );
@@ -932,30 +871,24 @@ export function PersonaSheet({
      */
     if (role === null) return null;
     const why = mayAuthor || whyNot === undefined ? {} : { why: whyNot };
-    const inert = !mayAuthor || saving || busy;
-
-    if (reading !== null) {
-      return <SheetFooter><span className="text-sm text-faint">Core history is read-only.</span><Button type="button" size="lg" variant="secondary" onClick={() => setReading(null)}>Back to v{String(one.version)}</Button></SheetFooter>;
-    }
-
-    if (editable) {
+    if (settingsReady) {
       return (
         <SheetFooter>
           <Button
             type="submit"
             size="lg"
             busy={saving}
-            disabled={!mayAuthor || !changed || saving}
+            disabled={!mayAuthor || (!changed && one.settings !== null) || saving || busy}
             {...why}
           >
-            {saving ? "Saving…" : one.settings === null ? "Use persona" : "Save changes"}
+            {saving ? "Saving…" : saved && !changed ? "Saved" : one.settings === null ? "Use persona" : "Save changes"}
           </Button>
           <Button
             type="button"
             size="lg"
             variant="secondary"
             disabled={saving}
-            onClick={leaveEditor}
+            onClick={editing ? leaveEditor : leave}
           >
             Cancel
           </Button>
@@ -1001,23 +934,6 @@ export function PersonaSheet({
       );
     }
 
-    if (editing && role !== null) {
-      if (form === null || form.status === "signed-out") {
-        return (
-          <SheetBody ref={bodyRef}>
-            <Loading what="the supported persona models" />
-          </SheetBody>
-        );
-      }
-      if (form.status !== "ready") {
-        return (
-          <SheetBody ref={bodyRef}>
-            <Failure message={form.refusal.message} onRetry={reloadForm} />
-          </SheetBody>
-        );
-      }
-    }
-
     return (
       <form
         className="flex min-h-0 flex-1 flex-col gap-5"
@@ -1037,7 +953,8 @@ export function PersonaSheet({
               }
             />
           )}
-          {editable && choices !== null ? editBody(held, choices) : readBody(one)}
+          {editing && !predefined ? editBody(held) : readBody(one)}
+          {settingsBody(one, held)}
         </SheetBody>
         {footer(one)}
       </form>
@@ -1047,18 +964,17 @@ export function PersonaSheet({
   /**
    * The record's own actions, in the head beside the close.
    *
-   * **Every one of a record's actions is in one menu**, which is what makes a
-   * sheet's head the same shape on every surface in the product. Shared cores
-   * stay read-only while their project settings remain editable.
+   * Custom identity editing, cloning, and deletion remain in the menu.
+   * Shared cores stay read-only while settings are edited in the body.
    */
   function actions(one: Persona): ReactNode {
-    if (role === null || editing || reading !== null) return undefined;
+    if (role === null || editing) return undefined;
     const inert = !mayAuthor || saving || busy;
     return (
       <SheetMenu label={`Actions for ${one.name}`}>
         {(close) => (
           <>
-            {(
+            {predefined ? null : (
               <MenuItem
                 disabled={inert}
                 onClick={() => {
@@ -1066,14 +982,14 @@ export function PersonaSheet({
                   setEditing(true);
                 }}
               >
-                {one.settings === null ? "Use" : predefined ? "Edit settings" : "Edit"}
+                Edit
               </MenuItem>
             )}
             <MenuItem
               disabled={inert}
               onClick={() => {
                 close();
-                onFork(one);
+                draftNavigation.request(() => onFork(one));
               }}
             >
               Clone
@@ -1083,7 +999,7 @@ export function PersonaSheet({
                 disabled={inert}
                 onClick={() => {
                   close();
-                  onDelete(one);
+                  draftNavigation.request(() => onDelete(one));
                 }}
               />
             )}
@@ -1110,10 +1026,12 @@ export function PersonaSheet({
           {persona === null ? null : (
             <span className="flex flex-wrap items-center gap-2">
               <span className="text-sm text-faint">{meta()}</span>
-              {reading === null ? null : <StateChip>Older version</StateChip>}
             </span>
           )}
         </SheetHeader>
+        <span className="sr-only" role="status">
+          {saved && !changed ? "Persona saved." : ""}
+        </span>
         {body()}
       </SheetContent>
     </Sheet>

--- a/apps/web/app/projects/[projectId]/personas/sheet-parts.tsx
+++ b/apps/web/app/projects/[projectId]/personas/sheet-parts.tsx
@@ -12,8 +12,8 @@ import { ownerSaid, type Persona } from "../../../../lib/personas.ts";
  * **They are here rather than in `apps/web/ui/` because they are one screen's
  * arrangement, not a shared behaviour.** The sheet itself, its head, its body,
  * its footer and its motion are `components/ui/sheet.tsx`; what is below is how
- * *a persona* fills one: a labelled group, a read pair, the frozen-version
- * list, and the chip that says which kind of persona a row is.
+ * *a persona* fills one: a labelled group, a read pair,
+ * and the chip that says which kind of persona a row is.
  *
  * Every measurement is read off page `L-0` of the Paper file (boards `RA4-0`
  * through `S6H-0`) with `get_computed_styles`, and every value is spent as a
@@ -34,7 +34,7 @@ import { ownerSaid, type Persona } from "../../../../lib/personas.ts";
  *   it. Nothing here re-pads the panel.
  */
 
-/** A labelled group inside a sheet: `WHO THEY ARE`, `MODELS`, `VERSIONS`. */
+/** A labelled group, separated from the previous group by a hairline. */
 export function SheetSection({
   label,
   children,
@@ -43,12 +43,11 @@ export function SheetSection({
   readonly children: ReactNode;
 }) {
   return (
-    <section className="flex min-w-0 flex-col gap-3" aria-label={label}>
-      {/*
-       * 12px letter-spaced capitals, which is the one thing on these boards
-       * that is genuinely the micro step rather than the caption step.
-       */}
-      <h3 className="m-0 text-2xs font-normal tracking-(--tracking-label) text-faint uppercase">
+    <section
+      className="flex min-w-0 flex-col gap-4 border-border not-first:border-t not-first:pt-5"
+      aria-label={label}
+    >
+      <h3 className="m-0 text-sm font-medium text-foreground">
         {label}
       </h3>
       {children}
@@ -129,77 +128,4 @@ export function PersonaTypeChip({
   readonly owner: Persona["owner"];
 }) {
   return <StateChip>{ownerSaid(owner)}</StateChip>;
-}
-
-/** One row of the frozen-version list. */
-export type VersionRow = {
-  readonly id: string;
-  readonly version: number;
-  readonly written: ReactNode;
-  /** The version this persona is on now. */
-  readonly current: boolean;
-  /** The version this sheet is reading, when it is reading an older one. */
-  readonly reading: boolean;
-  readonly onRead?: () => void;
-};
-
-/**
- * Every version this persona has been, newest first.
- *
- * **It is a section of the sheet rather than a second panel over it.** The
- * history used to be a sheet of its own opened from a page that was already a
- * sheet's worth of reading; the boards fold it in, because "which version is
- * this and what were the others" is one question and not two.
- *
- * A row that can be read is a button rather than a link: reading an older
- * version does not change the address, it changes what this same sheet is
- * showing.
- */
-export function Versions({ rows }: { readonly rows: readonly VersionRow[] }) {
-  return (
-    <ol className="m-0 flex list-none flex-col border border-border p-0">
-      {rows.map((row) => (
-        <li
-          className={cn(
-            "flex min-h-9 min-w-0 flex-wrap items-center justify-between gap-x-3",
-            "border-border px-3 py-1 not-first:border-t",
-            /*
-             * The wash stays here, and only here. It is the *current* mark —
-             * the state `DESIGN.md` gives the wash — and this list is the one
-             * place on the surface that still says "this is the one in force".
-             * The open row on the list behind it is grey for the opposite
-             * reason: it is a row somebody opened, not a value in force.
-             */
-            (row.current || row.reading) && "bg-surface-active",
-          )}
-          key={row.id}
-        >
-          <span className="flex min-w-0 items-baseline gap-2">
-            <span className="font-mono text-sm text-foreground">
-              v{row.version}
-            </span>
-            <span className="text-sm text-muted-foreground">{row.written}</span>
-          </span>
-          {row.reading ? (
-            <span className="text-sm text-faint">Reading</span>
-          ) : row.current ? (
-            <span className="text-sm text-faint">Current</span>
-          ) : row.onRead === undefined ? null : (
-            <button
-              className={cn(
-                "cursor-pointer border-0 bg-transparent p-0 text-sm text-foreground",
-                "underline underline-offset-[3px]",
-                "transition-colors duration-(--duration-hover) ease-out",
-                "pointer-hover:text-primary",
-              )}
-              onClick={row.onRead}
-              type="button"
-            >
-              Read
-            </button>
-          )}
-        </li>
-      ))}
-    </ol>
-  );
 }

--- a/apps/web/components/ui/select.tsx
+++ b/apps/web/components/ui/select.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { cva, type VariantProps } from "class-variance-authority";
 import type { ComponentProps } from "react";
 
@@ -21,7 +23,7 @@ import { cn } from "@/lib/utils";
  * under `components/ui`, `data-slot`, `cn` over the caller's classes, every
  * value a theme key — and its Radix dependency is not.
  *
- * The chevron is the browser's. `globals.css` restyles the open picker itself
+ * The chevron is shared in both themes. `globals.css` restyles the open picker
  * where a browser supports `appearance: base-select`, which is where that
  * belongs: one rule for every select in the product rather than a drawn arrow
  * on each one.
@@ -50,7 +52,7 @@ import { cn } from "@/lib/utils";
  */
 const selectVariants = cva(
   [
-    "w-full rounded-input border border-input bg-surface px-3",
+    "w-full min-w-0 rounded-input border border-input bg-surface pl-3 pr-10",
     "text-base text-foreground",
     "disabled:cursor-not-allowed disabled:opacity-60",
     /* "Pointer targets are at least 44px on coarse pointers." */
@@ -71,9 +73,27 @@ const selectVariants = cva(
   },
 );
 
+/** The browser can flip the picker above the field when there is more room. */
+function followPickerOrigin(select: HTMLSelectElement): void {
+  if (!globalThis.CSS?.supports("appearance", "base-select")) return;
+  requestAnimationFrame(() => {
+    if (!select.isConnected || !select.matches(":open")) return;
+    const selected = select.selectedOptions[0];
+    if (!selected) return;
+    const field = select.getBoundingClientRect();
+    const option = selected.getBoundingClientRect();
+    select.style.setProperty(
+      "--select-picker-origin",
+      option.bottom <= field.top ? "bottom" : "top",
+    );
+  });
+}
+
 function Select({
   className,
   size,
+  onPointerDown,
+  onKeyDown,
   ...props
 }: Omit<ComponentProps<"select">, "size"> &
   VariantProps<typeof selectVariants>) {
@@ -84,6 +104,14 @@ function Select({
       data-slot="select"
       className={cn(selectVariants({ size }), className)}
       {...props}
+      onPointerDown={(event) => {
+        onPointerDown?.(event);
+        if (!event.defaultPrevented) followPickerOrigin(event.currentTarget);
+      }}
+      onKeyDown={(event) => {
+        onKeyDown?.(event);
+        if (!event.defaultPrevented) followPickerOrigin(event.currentTarget);
+      }}
       /* After the spread, so a caller passing nothing cannot erase the hint. */
       aria-describedby={props["aria-describedby"] ?? hint}
     />

--- a/apps/web/test/graders-pages.test.tsx
+++ b/apps/web/test/graders-pages.test.tsx
@@ -1222,7 +1222,7 @@ describe("the project Graders surface", () => {
       ...standardAnswers(),
       [`GET /v1/grader-library/${EXPECTED_BEHAVIORS_GRADER_DEFINITION_ID}`]: {
         status: 200,
-        body: EXPECTED_DEFINITION,
+        body: { ...EXPECTED_DEFINITION, definitionVersion: 3, currentDefinitionVersion: 3 },
       },
       "PATCH /v1/graders/grd_expected": { status: 200, body: changed },
     });
@@ -1230,6 +1230,8 @@ describe("the project Graders surface", () => {
     await chooseRowMenuItem("Expected behaviors", "Edit");
 
     const sheet = await screen.findByRole("dialog", { name: "Expected behaviors" });
+    expect(await within(sheet).findByText("Predefined · v3")).toBeTruthy();
+    expect(within(sheet).queryByText("This project's scope, settings, and individual pass threshold.")).toBeNull();
     /* The caption that answered a question nobody asked is gone. */
     expect(within(sheet).queryByText("Fixed by Egma")).toBeNull();
     expect(within(sheet).getByText("Scope")).toBeTruthy();

--- a/apps/web/test/personas.test.tsx
+++ b/apps/web/test/personas.test.tsx
@@ -702,48 +702,93 @@ describe("one persona's sheet", () => {
     });
   }
 
-  it("reads a Custom persona one item per line, dated, with its versions last", async () => {
-    ritaOpen();
+  it("opens inline settings while keeping identity readable and the current version visible", async () => {
+    const { asked } = ritaOpen();
     render(<PersonasPage />);
     const sheet = await openRow("Impatient Rita");
 
     expect(within(sheet).getByText("Custom · v3")).toBeTruthy();
-
     expect(readsUnder(sheet, "Who they are")).toEqual([
-      "Description",
-      "Identity name",
-      "Personality",
-      "Language",
+      "Description", "Identity name", "Personality", "Language",
     ]);
     expect(within(sheet).getByText("Rita")).toBeTruthy();
+    const settings = within(sheet).getByRole("region", { name: "Settings" });
+    expect((within(settings).getByLabelText("Language model*") as HTMLSelectElement).value).toBe("openai::gpt-4o-mini");
+    expect((within(settings).getByLabelText("Speech rate*") as HTMLInputElement).value).toBe("1");
+    expect((within(sheet).getByRole("button", { name: "Save changes" }) as HTMLButtonElement).disabled).toBe(true);
+    expect(within(sheet).queryByText("Created")).toBeNull();
+    expect(within(sheet).queryByText("Updated")).toBeNull();
+    expect(within(sheet).queryByRole("region", { name: "Versions" })).toBeNull();
+    expect(within(sheet).queryByText("Project settings")).toBeNull();
+    expect(asked.some(request => request.path.includes("/versions"))).toBe(false);
+  });
 
-    expect(readsUnder(sheet, "Project settings")).toEqual([
-      "Language model",
-      "Speech-to-text",
-      "Text-to-speech",
-      "Speech rate",
-      "Voice",
-    ]);
-    expect(within(sheet).getByText("OpenAI · gpt-4o-mini")).toBeTruthy();
-    expect(within(sheet).getByText("1×")).toBeTruthy();
+  it("saves inline settings without changing the persona core", async () => {
+    const updatedModels = { ...RECOMMENDED_MODELS, llm: { provider: "openai", model: "gpt-4o" } };
+    const saved = { ...RITA, settings: { ...RITA.settings!, models: updatedModels } };
+    const { asked } = ritaOpen({
+      "GET /v1/personas/prs_1": [{ status: 200, body: RITA }, { status: 200, body: saved }],
+      "PATCH /v1/personas/prs_1": { status: 200, body: saved },
+    });
+    render(<PersonasPage />);
+    const sheet = await openRow("Impatient Rita");
+    fireEvent.change(within(sheet).getByLabelText("Language model*"), { target: { value: "openai::gpt-4o" } });
+    fireEvent.click(within(sheet).getByRole("button", { name: "Save changes" }));
+    await waitFor(() => expect(asked.find(request => request.method === "PATCH")?.body).toEqual({ projectId: "prj_1", models: updatedModels }));
+    await waitFor(() => expect((within(sheet).getByRole("button", { name: "Saved" }) as HTMLButtonElement).disabled).toBe(true));
+    expect(within(sheet).getByRole("status").textContent).toBe("Persona saved.");
+    expect(within(sheet).getByText("Custom · v3")).toBeTruthy();
+    fireEvent.change(within(sheet).getByLabelText("Voice*"), { target: { value: "different-voice" } });
+    expect(within(sheet).queryByRole("button", { name: "Saved" })).toBeNull();
+    expect(within(sheet).getByRole("status").textContent).toBe("");
+    expect((within(sheet).getByRole("button", { name: "Save changes" }) as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.change(within(sheet).getByLabelText("Voice*"), { target: { value: RECOMMENDED_MODELS.tts.voiceId } });
+    fireEvent.click(within(sheet).getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Impatient Rita" })).toBeNull());
+    const reopened = await openRow("Impatient Rita");
+    expect((within(reopened).getByRole("button", { name: "Save changes" }) as HTMLButtonElement).disabled).toBe(true);
+    expect(within(reopened).getByRole("status").textContent).toBe("");
+  });
 
-    /*
-     * Created and Updated are ordinary fields, and they come before the
-     * version list rather than as a line of small print under everything.
-     */
-    const terms = [...sheet.querySelectorAll("dt")].map(
-      (term) => term.textContent,
-    );
-    expect(terms).toContain("Created");
-    expect(terms).toContain("Updated");
+  it("protects inline settings and resets a discarded draft when reopened", async () => {
+    ritaOpen();
+    render(<PersonasPage />);
+    const sheet = await openRow("Impatient Rita");
+    fireEvent.change(within(sheet).getByLabelText("Voice*"), { target: { value: "different-voice" } });
+    fireEvent.click(within(sheet).getByRole("button", { name: "Cancel" }));
+    const confirmation = await screen.findByRole("dialog", { name: "Leave without saving?" });
+    fireEvent.click(within(confirmation).getByRole("button", { name: "Discard changes" }));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Impatient Rita" })).toBeNull());
+    const reopened = await openRow("Impatient Rita");
+    expect((within(reopened).getByLabelText("Voice*") as HTMLInputElement).value).toBe(RECOMMENDED_MODELS.tts.voiceId);
+    expect((within(reopened).getByRole("button", { name: "Save changes" }) as HTMLButtonElement).disabled).toBe(true);
+  });
 
-    const dates = within(sheet).getByText("Created").closest("dl");
-    const versions = within(sheet).getByRole("region", { name: "Versions" });
-    expect(dates).toBeTruthy();
-    expect(
-      dates!.compareDocumentPosition(versions) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
+  it.each(["Clone", "Delete"])("protects inline settings before %s", async (action) => {
+    const { asked } = ritaOpen();
+    render(<PersonasPage />);
+    const sheet = await openRow("Impatient Rita");
+    fireEvent.change(within(sheet).getByLabelText("Voice*"), { target: { value: "different-voice" } });
+    await openSheetMenu("Impatient Rita");
+    fireEvent.click(await screen.findByRole("menuitem", { name: action }));
+    const confirmation = await screen.findByRole("dialog", { name: "Leave without saving?" });
+    fireEvent.click(within(confirmation).getByRole("button", { name: "Keep editing" }));
+    expect((within(sheet).getByLabelText("Voice*") as HTMLInputElement).value).toBe("different-voice");
+    expect(asked.every(request => request.method === "GET")).toBe(true);
+    expect(screen.queryByRole("dialog", { name: "Delete Impatient Rita?" })).toBeNull();
+  });
+
+  it("keeps inline settings disabled for viewers", async () => {
+    apiAnswers({
+      ...screenWith("viewer", [RITA]),
+      "GET /v1/personas/prs_1": { status: 200, body: RITA },
+    });
+    render(<PersonasPage />);
+    const sheet = await openRow("Impatient Rita");
+    for (const label of ["Language model*", "Speech-to-text*", "Text-to-speech*", "Speech rate*", "Voice*"]) {
+      expect((within(sheet).getByLabelText(label) as HTMLInputElement).disabled).toBe(true);
+    }
+    expect((within(sheet).getByRole("button", { name: "Save changes" }) as HTMLButtonElement).disabled).toBe(true);
   });
 
   it("carries Edit, Clone and Delete in the sheet's own ⋮", async () => {
@@ -833,20 +878,7 @@ describe("one persona's sheet", () => {
     expect((within(sheet).getByLabelText("Personality*") as HTMLTextAreaElement).value).toBe(current.personality);
   });
 
-  it("reads an older core version without project models or restoration", async () => {
-    const { asked } = ritaOpen({});
-    render(<PersonasPage />);
-    const sheet = await openRow("Impatient Rita");
-    fireEvent.click(within(sheet).getAllByRole("button", { name: "Read" })[0]!);
-    expect(await within(sheet).findByText("Custom · v1 of 3")).toBeTruthy();
-    expect(within(sheet).getByText("Rita, as she was first written.")).toBeTruthy();
-    expect(within(sheet).getByText("Core history is read-only.")).toBeTruthy();
-    expect(within(sheet).queryByRole("button", { name: "Use as new version" })).toBeNull();
-    expect(within(sheet).queryByText("Language model")).toBeNull();
-    expect(asked.some((one) => one.method === "PATCH")).toBe(false);
-  });
-
-  it("offers project settings and cloning for a Predefined persona", async () => {
+  it("offers inline settings and cloning while keeping a shared identity read-only", async () => {
     apiAnswers({
       ...screenWith("admin", [RITA, PREDEFINED]),
       "GET /v1/personas/prs_0": { status: 200, body: PREDEFINED },
@@ -862,23 +894,42 @@ describe("one persona's sheet", () => {
       within(menu)
         .getAllByRole("menuitem")
         .map((item) => item.textContent),
-    ).toEqual(["Use", "Clone"]);
+    ).toEqual(["Clone"]);
     fireEvent.keyDown(menu, { key: "Escape" });
 
-    /* No footer, no history, and nothing about who it is shared with. */
-    expect(sheet.querySelector("[data-slot=sheet-footer]")).toBeNull();
-    expect(within(sheet).getByRole("region", { name: "Versions" })).toBeTruthy();
-    expect(within(sheet).queryByRole("region", { name: "Used by" })).toBeNull();
-    expect(within(sheet).queryByText(/shared with/iu)).toBeNull();
-    expect(within(sheet).getByText("Created")).toBeTruthy();
+    expect(within(sheet).getByRole("button", { name: "Use persona" })).toBeTruthy();
+    expect(within(sheet).getByRole("region", { name: "Settings" })).toBeTruthy();
+    expect(within(sheet).queryByLabelText("Identity name*")).toBeNull();
+    expect(within(sheet).queryByRole("region", { name: "Versions" })).toBeNull();
+    expect(within(sheet).queryByText("Created")).toBeNull();
+    expect(within(sheet).queryByText("Updated")).toBeNull();
+    fireEvent.click(within(sheet).getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("dialog", { name: "Leave without saving?" })).toBeNull();
   });
 
-  it.each(["Use", "Edit settings"])(
-    "recovers %s after the model catalog request fails",
+  it("adopts a library persona with the selected settings", async () => {
+    const updatedModels = { ...RECOMMENDED_MODELS, llm: { provider: "openai", model: "gpt-4o" } };
+    const saved = { ...PREDEFINED, settings: { id: "ppr_0", models: updatedModels, createdAt: PREDEFINED.createdAt, updatedAt: PREDEFINED.updatedAt } };
+    const { asked } = apiAnswers({
+      ...screenWith("admin", [PREDEFINED]),
+      "GET /v1/personas/prs_0": [{ status: 200, body: PREDEFINED }, { status: 200, body: saved }],
+      "POST /v1/personas/prs_0/use": { status: 200, body: saved },
+    });
+    render(<PersonasPage />);
+    const sheet = await openRow("Everyday caller");
+    fireEvent.change(within(sheet).getByLabelText("Language model*"), { target: { value: "openai::gpt-4o" } });
+    fireEvent.click(within(sheet).getByRole("button", { name: "Use persona" }));
+    await waitFor(() => expect(asked.find(request => request.method === "POST")?.body).toEqual({ projectId: "prj_1", models: updatedModels }));
+    expect(await within(sheet).findByRole("button", { name: "Saved" })).toBeTruthy();
+    expect(within(sheet).getByText("Predefined · v1")).toBeTruthy();
+  });
+
+  it.each(["library", "active"])(
+    "recovers inline %s settings after the model catalog request fails",
     async (action) => {
       const persona: Persona = {
         ...PREDEFINED,
-        settings: action === "Use" ? null : {
+        settings: action === "library" ? null : {
           id: "ppr_0",
           models: RECOMMENDED_MODELS,
           createdAt: PREDEFINED.createdAt,
@@ -898,8 +949,6 @@ describe("one persona's sheet", () => {
       });
       render(<PersonasPage />);
       const sheet = await openRow("Everyday caller");
-      await openSheetMenu("Everyday caller");
-      fireEvent.click(await screen.findByRole("menuitem", { name: action }));
 
       const failure = await within(sheet).findByRole("alert");
       expect(within(failure).getByText(
@@ -910,7 +959,7 @@ describe("one persona's sheet", () => {
 
       const model = await within(sheet).findByLabelText("Language model*");
       expect((model as HTMLSelectElement).value).toBe(
-        action === "Use" ? "openai::gpt-5.6-terra" : "openai::gpt-4o-mini",
+        action === "library" ? "openai::gpt-5.6-terra" : "openai::gpt-4o-mini",
       );
       expect(within(sheet).queryByRole("alert")).toBeNull();
       expect(asked.filter(request => request.path === "/v1/persona-form?projectId=prj_1")).toHaveLength(2);

--- a/apps/web/test/presentation.test.ts
+++ b/apps/web/test/presentation.test.ts
@@ -101,7 +101,7 @@ describe("the shared form controls", () => {
   it("centers every enhanced select instead of relying on the browser default", async () => {
     const css = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
 
-    expect(css).toMatch(/select, ::picker\(select\) \{ appearance: base-select; \}/);
+    expect(css).toMatch(/select, select\[data-slot="select"\], ::picker\(select\) \{ appearance: base-select; \}/);
     expect(css).toMatch(/select \{ align-items: center; \}/);
   });
 

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -275,6 +275,9 @@
   --control-md: 36px;
   --control-lg: 44px;
   --control-height: var(--control-lg);
+  /* The same light chevron dresses native select triggers in every browser. */
+  --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='m4 6 4 4 4-4' fill='none' stroke='%233c3c3c' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  --select-picker-scale: 0.97;
   --tap-target: 44px;
 
   /*
@@ -471,6 +474,7 @@
   --surface-active: #43241c;
   --foreground: #f2f2ed;
   --muted: #a3a39b;
+  --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='m4 6 4 4 4-4' fill='none' stroke='%23a3a39b' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
   /*
    * Lifted from `#82827b`, which failed AA on the surface it is most often
    * drawn on.


### PR DESCRIPTION
Persona settings now open as editable fields in the detail sheet. Users can change models, voice, and speech rate without entering a separate editor. Sections have dividers, the heading is “Settings,” and dates and the bottom version list are removed. The current version stays under the title; the active grader sheet now uses the same version subtitle.

The shared dropdown has a thin chevron, clear selected rows, and fast opening and closing motion. This reaches persona, grader, run, and other form controls through one component. Keyboard selection, native form behavior, touch targets, viewport bounds, and reduced motion are preserved. Browsers without support for styled native pickers use the new trigger with their system popup.

Validation:
- Affected UI tests: personas, graders, run history, shared components, design system, and presentation (188 passed).
- Web production build, web type checks, and lint passed.
- Browser checks: direct persona save, grader menu, run filter, light/dark and mobile layouts, keyboard selection, full popup exit, flipped placement, and reduced motion.
- Full test suites are left to CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791403630&installation_model_id=431960&pr_number=308&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F308&signature=644938e4d10baba69a4f0c68c80b5fe1b43412a9a2cb6d5444767391c4069958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes persona model, voice, and speech-rate settings directly editable in the detail sheet, simplifies persona metadata and history presentation, adds the active grader version subtitle, and polishes the shared native select control.
- Preserves authorization and unsaved-change protections for inline persona settings.
- Removes persona dates and version-history UI while retaining the current version beneath the title.
- Adds themed select chevrons, picker states, compact transitions, viewport-aware transform origins, and coarse-pointer sizing.
- Updates browser and component tests for the revised persona, grader, and select behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete correctness, security, accessibility, or repository-rule violations identified.

Persona drafts are initialized and isolated correctly, save and permission guards remain in place, active graders use the displayed current version, and the shared select preserves native interaction behavior across its callers.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/personas/persona-sheets.tsx | Reworks persona sheets around always-visible inline project settings while preserving draft protection, permissions, core editing, cloning, and deletion. |
| apps/web/components/ui/select.tsx | Adds a client-side picker-origin adjustment and preserves caller and native event behavior for the shared select. |
| apps/web/app/globals.css | Introduces themed native-select trigger and base-select picker presentation, interaction states, sizing, and motion handling. |
| apps/web/app/projects/[projectId]/graders/grader-sheets.tsx | Moves the active grader header into the definition read lifecycle and displays its current definition version. |
| apps/web/app/projects/[projectId]/personas/persona-fields.tsx | Renames and vertically reorganizes persona model controls as the inline Settings section. |
| apps/web/app/projects/[projectId]/personas/sheet-parts.tsx | Updates section styling and removes the now-unused persona version-history presentation. |
| apps/web/test/personas.test.tsx | Replaces history-oriented assertions with coverage for inline saves, adoption, permissions, retries, and unsaved-change protection. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Open persona detail sheet] --> B[Load persona, role, and model catalog]
  B --> C[Show identity details]
  B --> D[Show inline settings]
  D --> E{User may author?}
  E -->|No| F[Render disabled settings]
  E -->|Yes| G[Edit models, voice, or speech rate]
  G --> H[Track unsaved changes]
  H --> I[Save through usePersona or updatePersona]
  I --> J[Adopt response and reload persona]
  J --> K[Show Saved state]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Polish shared dropdowns and edit persona..."](https://github.com/egma-ai/egma/commit/2f6e9ad83be7578eba15a28f830024717834822c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61348062)</sub>

<!-- /greptile_comment -->