### PR TITLE
Simplify web comments and correct stale explanations

### DIFF
--- a/apps/web/app/design-system/proof.tsx
+++ b/apps/web/app/design-system/proof.tsx
@@ -96,16 +96,7 @@ import { Actions, SearchField, Section, Toolbar } from "../../ui/section.tsx";
 import { SettingsNav } from "../../ui/settings-nav.tsx";
 import { AppShell, ProductPage } from "../../ui/shell.tsx";
 
-/*
- * This page's own layout, which was a route CSS Module until ticket 19.
- *
- * It stays in this file rather than moving to `ui/` because it is one route's
- * layout rather than product behaviour, and `DESIGN.md` asks a route page to
- * "compose shared components and add only route-specific layout". It is named
- * once rather than written nine times because nine copies drift. Tailwind reads
- * `.tsx` files as text, so a class named in a constant here is generated
- * exactly as one written in the markup is.
- */
+/* Shared class strings for this proof page's route-specific layout. */
 
 /** One proof card: a group on Pure Paper, wearing the card radius. */
 const PANEL = [
@@ -126,32 +117,11 @@ const PANEL_WIDE = [...PANEL, "col-span-full max-[760px]:col-auto"];
 const KICKER =
   "m-0 mb-3 text-sm uppercase tracking-(--tracking-label) text-muted-foreground";
 
-/**
- * The heading that names one component inside a panel.
- *
- * It is weight 500, because it is a heading and `DESIGN.md` reserves 500 for
- * "section, state, or dialog titles that need stronger hierarchy" — the same
- * rule that separates it from `KICKER` above.
- *
- * Every `<h3>` on the page reads it, including the six on the older panels that
- * wrote the same three utilities out by hand. Naming it once is the rule this
- * file states at the top — "named once rather than written nine times because
- * nine copies drift" — and a constant that only the newest sections obeyed
- * would have been a seventh copy with extra steps.
- */
+/** Use the same section-heading weight for every component specimen. */
 const SUBHEAD =
   "m-0 text-sm font-medium uppercase tracking-(--tracking-label) text-muted-foreground";
 
-/**
- * One inset demonstration: a component shown on the canvas colour inside a
- * panel, so the panel around it reads as a list of them.
- *
- * Both users of it are here rather than in two constants. It started as the
- * frame for the two responsive and reduced-motion previews, and each primitive
- * specimen wants the same frame — and two identical strings are the drift this
- * file names at the top. `PREVIEW_HEAD` stays separate because only the two
- * previews carry a titled header.
- */
+/** Inset frame shared by component specimens and responsive previews. */
 const PREVIEW = "min-w-0 rounded-input border border-border bg-background p-4";
 const PREVIEW_HEAD = [
   "mb-4 flex items-baseline justify-between gap-3 text-sm text-foreground",
@@ -452,17 +422,7 @@ export function DesignSystemProof() {
               </div>
             </div>
 
-            {/*
-              * The numeric field, which the base has no primitive for.
-              *
-              * Its whole reason for existing is that a bound and a unit belong
-              * on the control rather than in a sentence beside it, so the proof
-              * has to show all three shapes at once: a percentage, a value in
-              * seconds whose step is not a whole number, and a plain count with
-              * no unit at all. A field that only ever appeared with a unit
-              * would leave the unit-less layout unproven, and that is the one
-              * the grader threshold uses.
-              */}
+            {/* Show numeric controls with percentages, fractional seconds, and no unit. */}
             <div className="flex flex-col gap-4">
               <h3 className={SUBHEAD}>
                 Numeric fields
@@ -698,17 +658,9 @@ export function DesignSystemProof() {
                 panel.
               </p>
               {/*
-                * Said out loud on the proof surface, because it is the decision
-                * a reviewer is most likely to want to argue with.
-                *
-                * The two grader views are separate addresses. A tab set claims
-                * `role="tab"`, a panel that updates in place, and a roving tab
-                * order — none of which is true of a link that loads a new page
-                * — and it costs the link its middle-click, its copy-link, and
-                * its place in the tab order. So the grader strip stays a
-                * navigation of links marked with `aria-current="page"`, and
-                * this is where a real tab set is proven instead.
-                */}
+               * Use tabs for in-place panels. Grader page navigation uses ordinary links
+               * with aria-current so browser link behavior remains available.
+               */}
               <p className="m-0 max-w-[68ch] text-sm text-muted-foreground">
                 The two grader views are not a tab set. They are separate
                 addresses, so they stay a navigation of links.
@@ -760,21 +712,7 @@ export function DesignSystemProof() {
                     </TabsContent>
                   </Tabs>
                 </div>
-                {/*
-                  * The third shape the component draws, and the one nothing in
-                  * the product uses yet.
-                  *
-                  * A vertical rail marks the current tab down its trailing edge
-                  * instead of under it, which is a separate set of rules from
-                  * the two above — and rules no page would have caught. It is
-                  * here so the shape is proven rather than dead: a strip of
-                  * evidence views is the layout it is waiting for.
-                  *
-                  * The disabled tab is the other half. "Disable rather than
-                  * hide" is this product's decision, so a set that can hold an
-                  * unavailable choice has to show what one looks like: still
-                  * read, still named, and not reachable by the arrow keys.
-                  */}
+                {/* Preview the vertical tab indicator and disabled-tab behavior. */}
                 <div className={PREVIEW}>
                   <Tabs defaultValue="turns" orientation="vertical">
                     <TabsList variant="line">
@@ -1207,17 +1145,9 @@ export function DesignSystemProof() {
           <p className={KICKER}>Responsive, theme and motion checks</p>
           <div className="grid grid-cols-2 gap-6 max-[760px]:grid-cols-1 max-[760px]:gap-4">
             {/*
-              * **The dark theme, beside the light one rather than instead of
-              * it.** Every shared component has to support both, and the way
-              * that rule is broken is never on purpose — it is a colour written
-              * where a token belonged, and it only shows when the two are held
-              * against each other. The account menu's switch still flips the
-              * whole document; this frame is what makes a difference visible
-              * without leaving the page.
-              *
-              * `data-theme` on a `<div>` works because `tailwind-theme.css`
-              * binds the dark values to the attribute as well as to `:root`.
-              */}
+             * Preview dark tokens beside light tokens. The theme stylesheet supports
+             * data-theme on a nested frame as well as on the document root.
+             */}
             <section
               className={cn(PREVIEW, "col-span-2 max-[760px]:col-span-1")}
               aria-label="Dark theme component preview"
@@ -1288,33 +1218,10 @@ export function DesignSystemProof() {
             </section>
 
             {/*
-              * The reduced-motion frame, and the two controls that demonstrate it.
-              *
-              * The stylesheet this replaces said it in two rules that reached
-              * the shadcn base button by element name — `.reducedFrame button`
-              * for the transition, and the same selector with
-              * `:active:not(:focus-visible):not(:disabled)` to cancel the
-              * press. That reach is what ticket 19 removes.
-              *
-              * The two rules say one thing: **inside this frame a button is
-              * drawn in its reduced-motion form** — no spatial press, and the
-              * colour feedback kept and made linear, which is the "useful
-              * opacity or color feedback" `DESIGN.md` asks every movement to
-              * have.
-              *
-              * It is written on the two controls rather than kept as a
-              * `[&_button]:` variant, because that variant is the same
-              * element-selector reach in another notation: it would still catch
-              * a button a nested shared component happens to render, which is
-              * how the original rule came to dress the base button in the first
-              * place. The two also need different class lists — the base button
-              * changes only its easing, the trigger states its whole transition
-              * — so one blanket rule could not say both.
-              *
-              * The tooltip half of this frame is not here at all:
-              * `tailwind-theme.css` keys it on `data-preview="reduced-motion"`,
-              * which is why that attribute stays exactly as it is.
-              */}
+             * Apply reduced-motion preview classes directly to these controls so nested
+             * components are not restyled by broad button selectors. Keep color feedback
+             * without spatial movement. Tooltip previews use data-preview in the theme.
+             */}
             <section
               className={PREVIEW}
               aria-label="Reduced motion component preview"

--- a/apps/web/app/device/approve/page.tsx
+++ b/apps/web/app/device/approve/page.tsx
@@ -9,18 +9,8 @@ import { Select } from "@/components/ui/select";
 import { AuthShell, LinkLine, Notice, StatePage } from "../../ui.tsx";
 
 /**
- * Approving a terminal, and saying what it is being let into.
- *
- * The page states the organization and the project plainly, because granting a
- * terminal access to the wrong customer's data is the mistake this screen
- * exists to prevent. The project is a choice when there is more than one and a
- * plain fact when there is not — a level of hierarchy with one thing in it is
- * clutter rather than information.
- *
- * Nothing here is a secret and nothing is shown twice. The key the terminal
- * ends up holding is minted when the terminal collects it and never passes
- * through this window at all, which is the entire reason the flow is shaped
- * this way instead of asking somebody to copy a key across.
+ * Show the organization and selected project before authorizing the terminal.
+ * The terminal collects the API key separately; this page never receives it.
  */
 
 type Pending = {
@@ -38,16 +28,8 @@ type State =
   | { at: "unreachable" };
 
 /*
- * The facts about what is being approved: a list, a row, the name of a fact,
- * and the fact itself. A row is 56px so that the one row carrying a control
- * has room for a 44px target without the rows around it changing height.
- *
- * **The padding is 4px because the row's height is 56px and not the other way
- * round.** Box-sizing counts padding inside a `min-height`, so the 12px this
- * row used to pay left 32px for a 44px select and the Project row came out
- * 68px tall beside a 56px Organization row — the exact thing the sentence
- * above promises does not happen. Four is what a 44px control leaves, and its
- * whole job is to keep a wrapped name off the hairline.
+ * Keep row padding small enough for a 44px select inside the 56px minimum
+ * row height. Larger vertical padding would make that row taller.
  */
 const FACT_LIST = "m-0 border-t border-border";
 const FACT_ROW =

--- a/apps/web/app/device/denied/page.tsx
+++ b/apps/web/app/device/denied/page.tsx
@@ -1,16 +1,8 @@
 import { LinkLine, StatePage } from "../../ui.tsx";
 
 /**
- * Nothing was authorized, and this page says what to do about it.
- *
- * Two things arrive here and they need the same answer: a code that was denied
- * on purpose, and a code egma does not recognise — a character misread, or a
- * code from a terminal that has since been closed. Either way the terminal is
- * still waiting and the way forward is a fresh code, so that is what the page
- * says rather than leaving somebody staring at an error they cannot act on.
- *
- * A code that simply sat too long is a different page, because it means the
- * product did not break, it timed out.
+ * Denied and unknown device codes both direct the user to request a fresh code.
+ * Expired codes have a separate page.
  */
 export default function DeviceDeniedPage() {
   return (

--- a/apps/web/app/device/page.tsx
+++ b/apps/web/app/device/page.tsx
@@ -9,17 +9,8 @@ import { Field } from "../../ui/form.tsx";
 import { AuthForm, AuthShell } from "../ui.tsx";
 
 /**
- * The code from your terminal.
- *
- * The terminal opens a browser on this page with the code already in the
- * address, so the ordinary path is: read the field, see it already says what
- * the terminal says, click continue. Nobody retypes eight characters between
- * two windows.
- *
- * The field is still a field, because somebody whose browser did not open — a
- * headless machine, a remote box, a copy-pasted line — needs somewhere to type
- * it. What they type is tidied up on the way through: a hyphen, a space or
- * lower case is a thing people do, not a thing to refuse.
+ * Prefill the terminal code from the URL, but allow manual entry when the
+ * browser was not opened automatically. Normalize case, spaces, and hyphens.
  */
 export default function DeviceCodePage() {
   const [code, setCode] = useState("");

--- a/apps/web/app/forgot-password/page.tsx
+++ b/apps/web/app/forgot-password/page.tsx
@@ -10,22 +10,9 @@ import { Field } from "../../ui/form.tsx";
 import { AuthForm, AuthShell, LinkLine, Notice, StatePage } from "../ui.tsx";
 
 /**
- * Asking for a way back in.
- *
- * **The page says the same thing however it went**, because the API does: an
- * address with an account here and one without get one status and one sentence,
- * so this form is never a way to ask an egma who its customers are. A page that
- * said "no such account" would give away exactly what the API refuses to.
- *
- * Where the link then arrives is the deployment's own business and not a second
- * setting: a platform with mail configured posts it, and one without writes the
- * whole message to its log, which is where a solo self-hoster reads it.
- *
- * **Where the person was headed is sent along with the address.** Somebody who
- * got here from a terminal's approval page has to end up back on it, and the
- * message is the one hop no page survives — it opens a fresh tab, minutes
- * later. So the API is told, and it writes the destination into the link it
- * sends.
+ * Keep the same confirmation for known and unknown email addresses. Forward
+ * the intended destination so the reset link can return the user to their task.
+ * Delivery availability is handled by the API; reset links are not logged here.
  */
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState("");

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,19 +1,7 @@
 /*
- * The one stylesheet the application loads.
- *
- * Order is the whole file. Tailwind arrives first and brings its layers with
- * it; then `tailwind-theme.css` declares egma's values in an unlayered
- * `:root`, which beats anything Tailwind put in `@layer theme`, and hands
- * those same declarations to Tailwind by reference in the same file — so a
- * utility and the one remaining stylesheet read one value rather than two
- * copies of it.
- *
- * The element rules below sit in `@layer base`, beside Tailwind's own reset and
- * after it, so they overrule the reset where the two disagree and a utility
- * class overrules them in turn. That is the ordinary arrangement and it is what
- * lets a shadcn component say `text-base` on a `<button>` and be obeyed. The
- * one rule kept outside every layer is focus, and it is called out where it is
- * written.
+ * Load Tailwind before Egma's unlayered theme values. Put element defaults
+ * in the base layer so utilities can override them; focus rules remain
+ * unlayered to take precedence over ordinary utility declarations.
  */
 
 /*
@@ -47,19 +35,9 @@
   ::selection { background: var(--surface-active); color: var(--foreground); }
 
   /*
-   * Tailwind's reset flattens the browser's own defaults — no list markers, no
-   * link underline, no margins anywhere. The CSS Modules pages were written
-   * against those defaults and are still the product until they are migrated,
-   * so the defaults are given back here. This is deliberately in
-   * `@layer base` and deliberately says `revert`: a utility class still wins,
-   * so a shadcn surface that asks for `list-none` or `m-0` gets it, and a page
-   * that asks for nothing keeps the rendering it shipped with.
-   *
-   * Heading *sizes* are deliberately not among them. Tailwind's reset makes
-   * `h1`-`h6` inherit their size, the browser's own sizes are not on the
-   * accepted type scale, and every heading in this application already takes
-   * its size from a class. So a heading here has no size of its own, and a new
-   * one that is given no class will come out at body size rather than wrong.
+   * Restore browser defaults for these elements in the base layer so utilities
+   * can still override them. Keep heading sizes inherited; components apply
+   * the accepted type scale.
    */
   a { text-decoration: revert; }
   ul, ol, menu { list-style: revert; padding: revert; }
@@ -69,21 +47,8 @@
 }
 
 /*
- * Focus, outside every layer on purpose.
- *
- * "Focus is always visible" is not a default a component may talk its way out
- * of, and shadcn components routinely carry `outline-none` and a ring of their
- * own. An unlayered rule beats every utility whatever its specificity, so this
- * is the product's focus indicator everywhere, and a pasted component cannot
- * quietly remove it.
- *
- * **It names roles as well as elements.** The element names alone missed every
- * menu item in the product: Radix draws one as `<div role="menuitem">`, so the
- * one surface a keyboard user crosses by arrow key was the one surface with no
- * Ember ring on it. It was not invisible — the highlighted item paints the
- * quiet neutral surface — but "focus is always visible" means the product's own
- * indicator, not a different answer in one place. The element names stay: a
- * `<button>` is still reached as a button whatever role it is given.
+ * Keep focus indicators unlayered so ordinary utility rules cannot remove
+ * them. Include ARIA widget roles as well as native interactive elements.
  */
 :is(
   button, a, input, select, textarea, summary,
@@ -93,23 +58,9 @@
 ):focus-visible { outline: 2px solid var(--focus); outline-offset: 3px; }
 
 /*
- * A text field's focus is quiet: its hairline darkens to ink, in place.
- *
- * (Developer decision, 2026-08-24, recorded in `DESIGN.md`.) A person typing
- * has already been told where they are by the caret, and the 2px Ember ring
- * around every box in a form made a sheet flash orange with each Tab. The ring
- * stays everywhere it is the only answer — buttons, links, selects,
- * checkboxes, radios, menu items, tabs — because those controls carry no caret
- * and nothing else on them moves.
- *
- * **It answers `:focus`, not `:focus-visible`.** A field clicked into and a
- * field tabbed into are the same field being typed in, and one of the two
- * showing no state at all would make the border mean "reached by keyboard"
- * rather than "this is where your typing goes".
- *
- * The specificity is deliberate rather than lucky: `:is(input, textarea)` with
- * a `:not()` and `:focus` outweighs the ring rule above, so a text field
- * cannot end up wearing both.
+ * Text fields use an ink border instead of an outer ring. Apply it on focus
+ * for pointer and keyboard input. The selector outranks the general focus
+ * rule so fields do not receive both treatments.
  */
 :is(input, textarea):not(
   [type="checkbox"], [type="radio"], [type="button"], [type="submit"],
@@ -119,64 +70,14 @@
   border-color: var(--border-strong);
 }
 
-/*
- * Inside a menu the ring turns inward.
- *
- * The panel holds its items on 4px of padding and scrolls, so a ring drawn 3px
- * *outside* a full-width item is clipped on both sides and reads as two stripes
- * rather than a rectangle. A negative offset puts the whole ring on the item.
- *
- * This is a design call rather than a fact, and it is called out in the pull
- * request for the developer to overrule: -2px, so the ring sits just inside the
- * item's own edge without touching the text.
- */
+/* Inset menu-item focus rings so the scrolling panel does not clip them. */
 :is([role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"], [role="option"]):focus-visible { outline-offset: -2px; }
 
 /*
- * The open select picker, where the browser lets the product draw it.
- *
- * **Opting into `base-select` makes the picker the product's box to size, and
- * the first version of this block did not size it.** Before the opt-in the
- * browser drew its own popup and the operating system bounded and scrolled it.
- * After the opt-in the picker is a real box in the top layer, and Chrome's
- * defaults for a box nobody sized are `max-height: stretch` with
- * `position-try-order: most-block-size` — read together, "make it as tall as
- * the space allows". A project with thirty test suites therefore opened a
- * picker 584px tall in a 700px window, its lower edge flush with the window
- * and its last row sliced in half. It did scroll. Nothing said so, and a row
- * cut by the window edge reads as a broken render rather than as an invitation
- * to keep going. A short list never showed it, which is why it reached
- * production.
- *
- * **So the picker is bounded the way every other menu in this product is
- * bounded.** `ui/menu.tsx` caps its panel to the space available less a gap
- * and scrolls the rest; that rule was written for the Radix popover and simply
- * never carried across to the one menu the browser draws. The cap here is
- * eight rows, and it is held under `min()` with half the viewport so a short
- * window cannot be handed a picker taller than the room the picker has. Below
- * 32rem of viewport there is no cap at all and Chrome's `stretch` takes it
- * back, which is the right answer when eight rows would not have fitted
- * anyway. Every placement was measured open, at six viewport heights against a
- * trigger at the top, the middle and the foot of each: all eighteen stay
- * inside the window.
- *
- * **The block margins are equal, and an unequal pair was tried first.** The
- * idea was a small gap under the trigger and a larger one at the window edge.
- * It does not survive the flip: when Chrome places the picker above a trigger
- * near the foot of the window, the two swap, so the large gap lands against
- * the trigger and the small one against the window edge — the flush edge this
- * change exists to remove, moved to the top. Measured across twenty-five
- * placements, the unequal pair left 1px at the window edge in its worst case,
- * an equal 12px left 1px, and an equal 8px left 5px with 7px still under the
- * trigger. So 8px, both sides. `stretch` subtracts margins, so the gap is real
- * rather than drawn. (Raised by Greptile on the pull request, and its reading
- * of the flip was right.)
- *
- * `overscroll-behavior` keeps a wheel that reaches the end of the list from
- * carrying on into the page behind the open picker.
- *
- * `align-items` belongs to the select and not to the picker: the picker's
- * computed `display` is `block`, so the declaration did nothing there.
+ * Style custom select pickers only where base-select is supported. Use equal
+ * block margins so spacing survives placement above or below the trigger.
+ * Cap height on taller viewports; shorter ones retain browser sizing. Contain
+ * overscroll, and put align-items on the select because its picker uses block layout.
  */
 @layer base {
   select[data-slot="select"] {

--- a/apps/web/app/invite/loading.tsx
+++ b/apps/web/app/invite/loading.tsx
@@ -1,27 +1,8 @@
 import { StatePage } from "../ui.tsx";
 
 /**
- * What the router draws between the press and
- * `/invite` arriving.
- *
- * **This one is not a product page and must not borrow the product's frame.**
- * An invitation is opened by somebody who is not signed in yet, so the page
- * behind this boundary composes the access surface — `AuthShell` through
- * `StatePage` — and never `ProductStatePage`, which would draw an organization
- * switcher and product navigation for a person who has neither. The fallback
- * follows the page it stands in for.
- *
- * **No indicator, deliberately.** The page's own waiting state is this exact
- * header and nothing under it, so adding a card here would put one on screen
- * for the length of the route change and take it away the moment the page
- * mounted. Same words, same shape, nothing added that the page then removes.
- *
- * **Its reach is honestly small.** An invitation link is followed from an
- * email, which is a cold document load rather than a route change, and this
- * page reads nothing on the server — so nothing streams and this boundary
- * usually never renders. It is here because the route can also be reached from
- * inside the application, and because a data-fetching segment without a
- * boundary is a hole whether or not it is a common one.
+ * Match the invitation page's access shell and waiting header. Do not show
+ * project navigation before the recipient has a session or add a transient card.
  */
 export default function InviteLoading() {
   return (

--- a/apps/web/app/invite/page.tsx
+++ b/apps/web/app/invite/page.tsx
@@ -15,20 +15,9 @@ import { SessionLoading } from "../../ui/session-loading.tsx";
 import { AuthForm, AuthShell, LinkLine, Notice, StatePage } from "../ui.tsx";
 
 /**
- * The page a colleague lands on.
- *
- * It says what they are joining and at what, and then asks for the one thing it
- * needs: a password. The address is the invitation's and is shown rather than
- * asked for, because that is the address the link lets in — there is nothing to
- * type and nothing to get wrong.
- *
- * **An expired link and an already-accepted one say different things**, because
- * they mean opposite things to the person holding one: ask for another, versus
- * you are already in, sign in.
- *
- * Somebody who already has an account gets a button instead of a form. That is
- * the person who was removed from an organization and asked back, and without it
- * they would be told their email address is taken by an account they cannot use.
+ * Show the invitation's fixed email address, organization, and role. New users
+ * set a password; existing signed-in users can accept directly. Distinguish
+ * expired invitations from already accepted ones.
  */
 
 type Lookup = {
@@ -56,14 +45,8 @@ export default function InvitePage() {
   const [submitting, setSubmitting] = useState(false);
   const [attempt, setAttempt] = useState(0);
   /**
-   * The address a confirmation link was posted to, once one has been.
-   *
-   * **This is the likeliest page in the product to meet it, not the least.**
-   * An invitation can only be delivered by an instance with a mail transport,
-   * and that is exactly the instance on which the provider requires the
-   * address to be confirmed and issues no session for a new identity. So the
-   * colleague who accepted an invitation was the one being walked into a
-   * product they could not open, and turned around at the sign-in door.
+   * Email awaiting verification when invitation acceptance creates an identity
+   * without a session.
    */
   const [confirming, setConfirming] = useState<string | null>(null);
   /** Accepted with a session in hand, and on the way to the product. */
@@ -92,17 +75,8 @@ export default function InvitePage() {
       }
 
       /*
-       * Somebody already signed in is offered the button rather than the form.
-       * Somebody signed in as a different person is told so by the refusal, and
-       * that is better than this page guessing what they meant.
-       *
-       * **Through the bounded read, like every other session read.** This one
-       * decides whether the page leaves `loading`, and `loading` now draws the
-       * cover with the document behind it inert — so a server that accepts the
-       * connection and then says nothing would leave the invited colleague on
-       * a page they cannot retry from, navigate away from, or accept on. It
-       * also stops this page hand-checking the shape of an answer the rest of
-       * the product reads through one type.
+       * Use a bounded session read to choose the acceptance form. Let the API
+       * reject acceptance by the wrong signed-in identity.
        */
       const me = await readSession();
       if (!current) return;

--- a/apps/web/app/loading.tsx
+++ b/apps/web/app/loading.tsx
@@ -1,18 +1,8 @@
 import { SessionLoading } from "../ui/session-loading.tsx";
 
 /**
- * What the router draws between the press and `/` arriving.
- *
- * It is the entrance's own waiting state, which is now the same one the
- * entrance shows while the session read is in flight — so the route change and
- * the read behind it are one wait rather than two screens replacing each other.
- * **It has no delay, and that is a trade rather than an oversight.** The other
- * route fallbacks in this application wait `--duration-popover-in` before
- * drawing anything, so a warm route is never covered by a box that appears and
- * vanishes. This one is opaque on its first frame instead: a shell is mounted
- * at the root address, and a fifth of a second of transparency here is a fifth
- * of a second of the dashboard showing to somebody who may not be signed in.
- * Being early costs a brief mark on a warm load; being late costs the guess.
+ * Cover the root immediately while session resolution and redirect are pending.
+ * Unlike delayed route fallbacks, this must not briefly expose the product shell.
  */
 export default function EntranceLoading() {
   return <SessionLoading label="Opening Egma" />;

--- a/apps/web/app/new-project/page.tsx
+++ b/apps/web/app/new-project/page.tsx
@@ -30,32 +30,9 @@ import {
 import { useUnsavedChanges } from "../../ui/settings-read.ts";
 
 /**
- * Where a project comes from.
- *
- * **This address names no project, deliberately, because it is the one page an
- * organization with none can reach.** Signup provisions the first project, so
- * that state is rare — but an organization whose only project was never made,
- * or whose admin is standing in front of an empty product shell, has to have
- * somewhere to go. Every other Settings page lives under a project and could
- * not serve this.
- *
- * It is `/new-project` and deliberately not `/projects/new`, which would read
- * better and would be wrong: the shell reads the project out of the address, so
- * the second form would have the selector announcing a project called `new` and
- * the navigation linking into one. An address that lies to the shell is worse
- * than an address that reads a little flatter.
- *
- * **A name is all it asks for.** The slug is derived from the name on the
- * server and numbered past whatever is already there, so nobody has to think
- * about slugs to make a project — and the numbering is deterministic, so two
- * admins racing get `outbound` and `outbound-2` rather than a suffix neither
- * could have guessed. An admin who wants a particular word changes it
- * afterwards in project Settings.
- *
- * What is created is the whole thing: the project, the persona a first test
- * gets when it names none, and the Expected behaviors project grader. That is
- * the server's business and not this page's — but it is why this page can
- * send somebody straight into the new project rather than to a checklist.
+ * Use /new-project so organizations without a project can reach creation and
+ * the shell does not interpret new as a project ID. Submit the name; the server
+ * derives a unique slug and creates the project with its default project grader.
  */
 export default function NewProjectPage() {
   return (
@@ -117,9 +94,8 @@ function NewProject() {
       return;
     }
 
-    // Straight into the new project, at the landing every project has. It is
-    // usable from this moment: it has the Predefined persona every project can
-    // use and its fixed-scope Expected behaviors project grader.
+    // Open the new project, which has its seeded Expected behaviors grader
+    // and access to shared Egma-provided personas.
     includeProject(written.value);
     await refreshSession();
     router.push(projectLanding(written.value.id));

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -14,19 +14,8 @@ import { SessionLoading } from "../ui/session-loading.tsx";
 import { ProductStatePage } from "../ui/shell.tsx";
 
 /**
- * The root address is an entrance, not a second product page.
- *
- * A current session enters the product at **Agents**, under the first project
- * its membership reaches — you start with the system you are testing, and a
- * generic home page would be a page with nothing on it. Everybody else reaches
- * the sign-in page directly instead of first opening a protected page and
- * finding a sign-in link there.
- *
- * **This is the one address that chooses a project for you**, and it is the
- * right one to: an entrance with nothing in it has to pick a door. Every
- * address it sends somebody to names its project explicitly from then on, so
- * the choice is made once, in the open, and lands in the address bar where a
- * person can see it and change it.
+ * Resolve the session at the root, then redirect to the first accessible
+ * project's landing page or sign-in. Subsequent product URLs carry the project ID.
  */
 export default function RootPage() {
   const router = useRouter();
@@ -69,20 +58,8 @@ export default function RootPage() {
   }, [attempt, router]);
 
   /*
-   * Nothing is guessed while the read is in flight. The product shell this
-   * used to draw in the meantime was a dashboard shown to somebody who may
-   * have no account open at all.
-   *
-   * **The entrance covers itself rather than leaving it to the shell**, and
-   * the reason is what happens after the answer arrives: `/` is the one
-   * address that never stops here, and the shell's own cover comes down the
-   * moment the session settles — which is the moment *before* the redirect
-   * lands, not after it.
-   *
-   * `signed-out` is written beside `null` for that same reason, and it is a
-   * lock rather than a live branch: the redirect above returns before
-   * `setAnswer`, so no render reaches this holding that status today. It costs
-   * one word, and it is the one state that must never uncover.
+   * Keep the entrance covered until its redirect completes. The shared shell
+   * may finish its session read before this page has navigated.
    */
   if (answer === null || answer.status === "signed-out") {
     return <SessionLoading label="Opening Egma" />;
@@ -110,20 +87,9 @@ export default function RootPage() {
           * `Actions` is the shared group a page's controls stand in.
           */}
         {/*
-          * A way forward rather than a dead end. Signup provisions a project, so
-          * an organization reaching this state is rare — and the person looking
-          * at it is standing in front of a product shell with nothing in it,
-          * which is exactly when being told what to do next matters. A viewer
-          * or a member sees the same control, genuinely disabled, and the
-          * sentence that says who to ask.
-          *
-          * **A disabled control is genuinely inert or it is a lie.** A link
-          * cannot be disabled: `aria-disabled` on an anchor greys it out and it
-          * still follows on click and still takes the keyboard. So when this is
-          * not theirs it stops being a link and becomes a disabled button,
-          * which carries the reason where a keyboard and a screen reader can
-          * reach it.
-          */}
+         * Use a disabled button for users who cannot create projects. aria-disabled
+         * on an anchor alone would not prevent navigation.
+         */}
         <Actions>
           {role === "admin" ? (
             <Button asChild>

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/connections/[connectionId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/connections/[connectionId]/loading.tsx
@@ -1,18 +1,7 @@
 import { Loading } from "../../../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../../../ui/shell.tsx";
 
-/**
- * What the router draws between the press and
- * `/projects/:projectId/agents/:agentId/connections/:connectionId` arriving.
- *
- * **It says Agents, because that is what arrives.** This address draws the
- * agents list with the connection panel over it. The fallback cannot draw the
- * panel — the connection's name is in an answer that has not come back — so it
- * draws the screen underneath rather than a word that is replaced a moment
- * later.
- *
- * `agents/loading.tsx` carries the reasoning every one of these shares.
- */
+/** Match the Agents list behind the connection sheet while route data loads. */
 export default function ConnectionLoading() {
   return (
     <div data-slot="route-loading">

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/connections/fields.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/connections/fields.tsx
@@ -12,20 +12,8 @@ import type {
 } from "../../../../../../lib/connection-options.ts";
 
 /**
- * The fields one connection shape asks for, drawn from what the server said
- * they are.
- *
- * **Nothing here knows what a Retell agent id or a LiveKit URL is.** The server
- * sends a key, a label, a kind, whether it is required and a sentence of help,
- * and this draws a control for it. That is what keeps the form and the gate in
- * step: a shape that gains a key gains a box with nothing edited here, and a
- * shape that loses one loses its box the same way.
- *
- * `kind` decides the control and nothing else. The gate on the server is still
- * the only thing that admits a value, so a form that drew a plain box for a URL
- * cannot get a bad URL past anything — which is why a `json` field is a text
- * area rather than a validating editor, and why an `e164` field says what the
- * shape looks like rather than trying to enforce it.
+ * Render controls from catalog field definitions. The server owns validation;
+ * field kind selects the input shape without duplicating provider-specific rules.
  */
 
 export type Draft = {

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/connections/livekit-agent-name.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/connections/livekit-agent-name.tsx
@@ -17,17 +17,8 @@ export type LiveKitAgentNameForm = {
 };
 
 /**
- * The LiveKit part of an existing connection's form: the worker's name, and
- * whether it is there.
- *
- * There is nothing else left to decide here. Egma dispatches the named worker
- * for every simulation, so the record names the agent it graded — where a
- * nameless connection would hand each room to whichever worker was listening —
- * and the name is not a preference.
- *
- * The field is lifted out of the generic field list and drawn on its own so
- * the panel can say what a wrong name costs, which is that the agent never
- * joins the room.
+ * Show the LiveKit worker name separately because simulations dispatch that
+ * named worker. An incorrect name can leave the room without the agent under test.
  */
 export function liveKitAgentNameForm({
   connectionType,

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/connections/new/loading.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/connections/new/loading.tsx
@@ -1,17 +1,7 @@
 import { Loading } from "../../../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../../../ui/shell.tsx";
 
-/**
- * What the router draws between the press and
- * `/projects/:projectId/agents/:agentId/connections/new` arriving.
- *
- * **It says Agents, because that is what arrives.** This address draws the
- * agents list with the connect panel over it. The fallback cannot draw the
- * panel, so it draws the screen underneath rather than a title that is
- * replaced a moment later.
- *
- * `agents/loading.tsx` carries the reasoning every one of these shares.
- */
+/** Match the Agents list behind the connection setup sheet while the route loads. */
 export default function NewConnectionLoading() {
   return (
     <div data-slot="route-loading">

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/page.tsx
@@ -1,20 +1,6 @@
 import { redirect } from "next/navigation";
 
-/**
- * The agent's own page, retired — its address lands on the list.
- *
- * **The row is the agent** (founder ruling, 2026-08-24). Everything this page
- * held is already on the agents list or in a panel over it: the name and its
- * rename, the connections and the sheet each one opens, and delete. What was
- * left was a second reading of the same row and the only monitoring switch in
- * the product, and monitoring moved to Transcripts, where the calls it pulls
- * actually land.
- *
- * The address stays because links to it are in the CLI, in the documentation
- * and in people's notes. It redirects rather than rendering the list in place:
- * this address named a record that no longer has a surface, so leaving it in
- * the browser bar would be an address that claims to be somewhere it is not.
- */
+/** Keep existing agent-detail links usable by redirecting them to the Agents list. */
 export default async function AgentPage({
   params,
 }: {

--- a/apps/web/app/projects/[projectId]/agents/archive.tsx
+++ b/apps/web/app/projects/[projectId]/agents/archive.tsx
@@ -8,24 +8,9 @@ import { Dialog } from "@/ui/dialog.tsx";
 import { Form, FormActions, Problem } from "@/ui/form.tsx";
 
 /**
- * The confirmation in front of the one destructive thing these screens offer.
- *
- * **It says "Delete", and the write underneath still archives.** (Founder
- * ruling, 2026-08-24.) A person removing an agent means delete, and the
- * sentence beside the button is what keeps that honest: it says what stops and
- * says that stored transcripts stay stored. The soft write is why the history
- * an organization is answerable for survives a mistake — that is an argument
- * for how Egma stores it, not for making somebody read the word "archive"
- * when they meant delete.
- *
- * **It names the thing, which `DESIGN.md` asks of every destructive dialog**,
- * and it says what stops. What it cannot say is a number: the counts of
- * archived connections and cancelled runs are in the *answer*, and this sentence
- * is written before the write is made. So it says what will happen rather than
- * inventing an arithmetic it does not have.
- *
- * The button inside is the filled failure-colour one, which is the only place
- * in the product that draws it.
+ * The UI says Delete; the API archives the record. The confirmation explains
+ * what stops and that stored transcripts remain. Permission enforcement is
+ * server-side, with disabled controls explaining unavailable actions.
  */
 export function ArchiveConfirm({
   title,

--- a/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
@@ -687,14 +687,9 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
   }
 
   /**
-   * Flip the pull switch through the one commit `startMonitoring` is.
-   *
-   * `agentId` is the egma agent the flow started from, when there is one.
-   * Without it the server resolves the platform agent by (project, platform,
-   * platform agent id) and registers one under `name` when nothing answers —
-   * watching an unregistered agent means registering it (ADR-0015). The
-   * stored key is spent only when an egma agent is named, because that is the
-   * only entry shape the omitted-key preflight accepts.
+   * Start monitoring through the API. With no Egma agent ID, the server finds
+   * or registers the platform agent. Reusing a stored credential requires an
+   * explicit Egma agent ID.
    */
   async function startRetellMonitoringWatch(target: {
     readonly agentId: string | null;
@@ -793,15 +788,8 @@ export function ConnectAgentSheet(props: ConnectAgentSheetProps) {
   }
 
   /**
-   * Every picked lane, written onto **one** egma agent, in one pass.
-   *
-   * The first lane registers the agent (or finds the one that is already
-   * there); every lane after it is an addition to *that* agent. Two egma agents
-   * for one Retell voice agent would split a team's results history in half,
-   * which is the failure this loop exists to prevent.
-   *
-   * A lane that will not save stops the pass and says so, rather than carrying
-   * on and leaving a half-connected agent nobody asked for.
+   * Save selected connection types under one Egma agent. Stop on refusal and
+   * retain progress for retry; earlier successful writes are not rolled back.
    */
   async function finishRetellLanes(): Promise<void> {
     if (goal === "" || selectedRetellAgent === undefined) return;

--- a/apps/web/app/projects/[projectId]/agents/connection-facts.tsx
+++ b/apps/web/app/projects/[projectId]/agents/connection-facts.tsx
@@ -11,42 +11,13 @@ import {
 import { connectionsOnRow, type ListedConnection } from "@/lib/agents.ts";
 
 /**
- * How egma reaches an agent, said on the row rather than one click away.
- *
- * **The cell names the ways in and lets a person open one.** That is what the
- * board draws (`6ZJ-0`): each connection is its own underlined link, and
- * following it opens that connection over the list a person is already reading
- * rather than sending them two pages away and back. An agent egma cannot reach
- * at all says so here, in words, rather than at the moment a run refuses to
- * start.
- *
- * **It used to be a line of facts per connection** — environment, product
- * label, modality — stacked one under another, which made a row with three
- * connections three times as tall as its neighbour and gave a person nothing to
- * press. The resolved comment threads on the decision page ruled the other way:
- * consistent row heights, two names then an overflow chip, and link text in the
- * text colour. Those four facts have not gone anywhere; they are what the
- * connection sheet opens onto.
- *
- * Everything is drawn from what the list read already carried. There is no
- * second request behind any of it.
+ * Open connection sheets from the agent row using the list response; no
+ * additional request is needed to build these links.
  */
 
 /**
- * Every way into one agent, or the fact that there is none.
- *
- * **"No connections yet" is a state of the agent, not an empty cell.** An agent
- * nobody has wired is an agent egma cannot test, and a row that simply left the
- * space blank would leave that to be found out at the start of a run. It is
- * quiet rather than a warning, because being unwired is a fact about setup and
- * not a failure anybody has had yet.
- *
- * **The overflow chip counts rather than lists, and opens what it counts.**
- * Two links, then "+3" — and pressing the chip drops a popover holding every
- * connection this agent has, each one a link to its own sheet (`IZJ-0`). It is
- * links and nothing else: no rename, no delete, no facts. There is no agent
- * page behind it any more, so a chip that only navigated would now have
- * nowhere honest to go.
+ * Show two connection links and an overflow popover containing all connections.
+ * Use an explicit empty label when the agent has none.
  */
 export function ConnectionsOnRow({
   connections,

--- a/apps/web/app/projects/[projectId]/agents/connection-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/agents/connection-sheet.tsx
@@ -42,30 +42,9 @@ import {
 } from "./[agentId]/connections/livekit-agent-name.tsx";
 
 /**
- * One way egma reaches an agent, read and changed in the panel the board draws
- * (`77F-0`).
- *
- * **It opens over whatever a person was reading.** The list stays behind it, so
- * following a connection off a row and coming back is not two page loads;
- * `DESIGN.md` records the side sheet as where one record is created, read and
- * edited. The address `/agents/:agent/connections/:connection` still works and
- * opens exactly this, so every link in the docs and the CLI still lands
- * somewhere honest.
- *
- * **Read first, edit on purpose, and manage from the ⋮.** Reading is plain
- * labelled rows with no controls in front of them; Edit connection and Delete
- * connection live in a menu in the head, and the footer exists only while
- * something is being edited.
- *
- * **The destructive action says "Delete", and the write underneath archives**
- * (founder ruling, 2026-08-24). The word matches what a person meant; the
- * sentence in the confirmation is what says what actually happens to stored
- * transcripts. See `archive.tsx`.
- *
- * **The credential is never in this panel, on either side.** A read answers
- * whether one is present and a hint of which it is; it never answers with the
- * secret, so there is nothing here to show and nothing to merge. Replacing one
- * is not a control this product has yet.
+ * Read and edit a connection in a sheet over the Agents list, including when
+ * opened by a direct URL. Show edit and delete actions in the header menu;
+ * Delete archives the connection. Reads expose credential hints, not secret values.
  */
 
 type Answered = { readonly connection: ListedConnection };
@@ -125,14 +104,8 @@ export function ConnectionSheet({
   const [refused, setRefused] = useState<Refusal | null>(null);
   const [nameProblem, setNameProblem] = useState<string | null>(null);
   /**
-   * Where the reason a footer control is not available is written.
-   *
-   * **It is a line of the panel, not a line of the footer.** `Button`'s own
-   * `why` draws the sentence beside the control, which is right in a toolbar
-   * and wrong in a 440px footer: two disabled controls would put two long
-   * sentences between Edit and Archive. The controls still name it, and still
-   * carry it as a `title`, so a pointer, a keyboard and a screen reader all
-   * reach it.
+   * Put the disabled-action reason in the sheet body and reference it from
+   * controls, avoiding repeated long text in the narrow footer.
    */
   const whySaid = useId();
 
@@ -365,16 +338,9 @@ export function ConnectionSheet({
             }}
           >
             {/*
-              * **The head is the name and a ⋮, and no subtitle** (`ITZ-0`).
-              * The old "Retell phone · Voice" line under the name said what
-              * the Access row says two lines below it, and the first thing a
-              * panel says should be the record rather than its category.
-              *
-              * **Managing lives in the menu, and reading lives in the body.**
-              * Edit and Delete used to stand in the footer under a record
-              * nobody had asked to change yet, which made every read of a
-              * connection look like a form.
-              */}
+             * Keep the header to the name and actions menu. Connection facts belong in
+             * the body; the footer appears when editing.
+             */}
             <SheetHeader
               {...(connection === null || role === null || editing !== null
                 ? {}
@@ -470,29 +436,9 @@ function ReadRow({
 }
 
 /**
- * The record, read.
- *
- * **Six kinds of row and no more** (`ITZ-0`, `JYY-0`, `K40-0`): Name, Access,
- * Modality, the rows the catalog names for what is stored, the Config block,
- * and Created. Updated-at, Env and Platform left with the 2026-08-24 boards —
- * Platform because Access already says which product this is, Updated-at
- * because nobody reads a connection to find out when it was touched, and Env
- * because the product stopped speaking that word (the column stays where it
- * is, unspoken).
- *
- * **The phone number is not a row.** It shows inside the Config block and
- * nowhere else, so the panel does not say the same fact twice in two shapes.
- *
- * **The labelled rows come from the catalog and the raw block comes from the
- * record**, and both are drawn because they answer different questions. A row
- * says what a value *is* — "Retell agent ID" — in the registry's own words.
- * The block says what egma actually stored. A key from a newer server has no
- * label in this browser, so it is listed by its own name and loses nothing
- * while clients and servers roll forward separately.
- *
- * **A credential is never here.** A read answers whether one is present and a
- * hint of which it is; the hint is drawn as its last characters and the secret
- * is not in the answer at all.
+ * Show catalog-labeled facts and stored config. Keep phone numbers in Config
+ * to avoid repetition; retain unknown config keys by name. Credential values
+ * are absent from the read model.
  */
 function ReadConnection({
   connection,

--- a/apps/web/app/projects/[projectId]/agents/copy-block.tsx
+++ b/apps/web/app/projects/[projectId]/agents/copy-block.tsx
@@ -4,18 +4,7 @@ import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 
-/**
- * A block of text the person is meant to take away, with the button that takes
- * it.
- *
- * Setup surfaces hand work over that Egma cannot do itself, and each one is
- * read with a keyboard in one hand and somebody else's editor in the other.
- * **What is on screen has to be the exact bytes copied away**, so the block
- * never prettifies what it was given.
- *
- * It lives on its own because one shape drawn twice becomes two shapes, and
- * the day they differed would be the day a customer pasted the older one.
- */
+/** Display exactly the text that the copy button places on the clipboard. */
 type CopyState = "idle" | "copying" | "copied" | "failed";
 
 export function CopyBlock({

--- a/apps/web/app/projects/[projectId]/agents/loading.tsx
+++ b/apps/web/app/projects/[projectId]/agents/loading.tsx
@@ -2,38 +2,9 @@ import { Loading } from "../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../ui/shell.tsx";
 
 /**
- * What the router draws between pressing **Agents** and this page arriving.
- *
- * **This file, and the two dozen beside it, exist because the transition had
- * no state at all.** Without a `loading.tsx` the App Router has nowhere to put
- * a pending route, so it holds the *previous* page on screen until the next
- * one is ready: press a navigation item on a slow connection and nothing
- * happens, for as long as it takes. That is the one state `DESIGN.md` will not
- * allow — "make every state truthful" — and it is also the state a person
- * reads as a broken application.
- *
- * The boundary earns its place twice over. `<Link>` prefetches a dynamic route
- * only as far as its nearest loading boundary, so adding one is also what lets
- * the router answer the press from cache.
- *
- * **The frame is here and the data is not, which is the whole point.** The
- * sidebar never moves — it belongs to `ProductShellBoundary` in the root
- * layout, above every route — and this adds the page's own header on top of
- * it, so a press is answered by arriving somewhere named rather than by a bare
- * indicator floating in an empty column. Every word is the page's own: the
- * eyebrow or breadcrumbs, the title and what is being waited for are copied
- * from the page this stands in for, **including the header's shape**, because
- * an eyebrow that becomes a breadcrumb row on arrival is a header that moves.
- *
- * What a fallback cannot carry is the page's toolbar, its controls, or a
- * second navigation column, none of which it can know before the page mounts.
- * So the header lands first and the rest fills in under it. That is
- * progressive arrival rather than a jump, and it is the honest limit of a
- * fallback that has not seen the data.
- *
- * The whole composition arrives as one thing, after a wait, and neither is
- * written here: `tailwind-theme.css` keys both to the `route-loading` slot
- * below.
+ * Match the Agents header while route content loads; the shared shell remains
+ * mounted. Do not invent data-dependent controls. The route-loading theme slot
+ * provides the fallback delay and entrance.
  */
 export default function AgentsLoading() {
   return (

--- a/apps/web/app/projects/[projectId]/agents/new/loading.tsx
+++ b/apps/web/app/projects/[projectId]/agents/new/loading.tsx
@@ -1,18 +1,7 @@
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
-/**
- * What the router draws between the press and
- * `/projects/:projectId/agents/new` arriving.
- *
- * **It says Agents, because that is what arrives.** This address draws the
- * agents list with the connect panel over it, so a fallback headed "Register an
- * agent" would name a page that no longer exists and would be replaced by a
- * different title a moment later. A fallback cannot draw the panel — it has no
- * data and no session — so it draws the screen the panel opens over.
- *
- * `agents/loading.tsx` carries the reasoning every one of these shares.
- */
+/** Match the Agents list behind the setup sheet while the route loads. */
 export default function NewAgentLoading() {
   return (
     <div data-slot="route-loading">

--- a/apps/web/app/projects/[projectId]/agents/new/page.tsx
+++ b/apps/web/app/projects/[projectId]/agents/new/page.tsx
@@ -6,19 +6,7 @@ import { AppShell } from "@/ui/shell.tsx";
 
 import { AgentsScreen } from "../screen.tsx";
 
-/**
- * Registering an agent — the address, which is now a state of the list.
- *
- * **It stayed an address on purpose.** The form moved into a side sheet over
- * the agents list, and this route could have gone with it; what stopped that is
- * every place that already points here. The CLI prints this path, the
- * documentation links it, the browser walk follows it, and somebody has it in a
- * bookmark. So the address opens exactly what it always opened — the first step
- * of connecting an agent — and the list it is drawn over is the thing the
- * person will land on when they are finished.
- *
- * `screen.tsx` carries the reasoning for the panel itself.
- */
+/** Preserve direct setup links by opening the connection sheet over the Agents list. */
 export default function RegisterAgentPage() {
   const { projectId } = useParams<{ projectId: string }>();
   return (

--- a/apps/web/app/projects/[projectId]/agents/rename-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/agents/rename-sheet.tsx
@@ -19,18 +19,8 @@ import { platformAnswer, platformClient } from "@/lib/platform-client.ts";
 import { Field, Help, Refused } from "@/ui/form.tsx";
 
 /**
- * Changing an agent's name, in the surface every other rename in the product
- * already uses.
- *
- * **The row menu needed somewhere to send Rename.** The agent detail page held
- * the only name box in the application and it is retired, so this is the house
- * rename sheet — the same shape as a suite's and a persona's — rather than a
- * new idea invented for one row (`DESIGN.md`: one record is created, read and
- * edited in a side sheet).
- *
- * **The name is the only thing here.** Prompt, model and tools live at the
- * provider, and an agent's platform binding is a fact about how Egma reaches
- * it rather than something a rename may quietly move.
+ * Rename only the Egma agent label. Platform binding, prompt, model, and tools
+ * are outside this form.
  */
 export function RenameAgentSheet({
   projectId,

--- a/apps/web/app/projects/[projectId]/agents/row-menu.tsx
+++ b/apps/web/app/projects/[projectId]/agents/row-menu.tsx
@@ -12,22 +12,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 /**
- * The ⋮ at the end of a row, and the two or three things it offers.
- *
- * **It lives in the table's own trailing slot**, a fixed 48px lane that every
- * row carries whether or not it has a menu, so the triggers line up in one
- * column down the table (`6ZM-0`). The lane belongs to `ui/data-table.tsx`;
- * what is here is the control that stands in it.
- *
- * **The glyph is drawn rather than borrowed.** The boards draw three filled
- * dots (`71L-0`); every icon in the icon set is line art on a 24 grid, and a
- * ring is not a dot. Three circles is less code than restyling one.
- *
- * **A destructive item a person may not use is disabled and says why, in the
- * menu.** A disabled control takes no focus and answers no hover, so a tooltip
- * on one is a reason only a pointer can reach — and here not even that. The
- * sentence is a line of the panel, and the item names it, which is what makes
- * disabling rather than hiding worth doing.
+ * Use the table's trailing action slot so row menus align. Render unavailable
+ * actions disabled and associate them with an explanation inside the menu.
  */
 
 export function RowMenuGlyph() {

--- a/apps/web/app/projects/[projectId]/agents/screen.tsx
+++ b/apps/web/app/projects/[projectId]/agents/screen.tsx
@@ -49,39 +49,9 @@ import { ConnectionSheet } from "./connection-sheet.tsx";
 import { RenameAgentSheet } from "./rename-sheet.tsx";
 
 /**
- * The agents of one project: the landing page of the product, and the one
- * screen every agent and connection panel opens over.
- *
- * **You start with the system you are testing.** An agent is the customer's
- * voice agent — the thing egma exists to establish trust in — so this is what a
- * signed-in person sees first, rather than a home page assembled out of
- * fragments of everything else.
- *
- * **One screen, and every panel is a state of it.** Connecting an agent,
- * reading a connection and changing one all happen in a side sheet over this
- * list (`DESIGN.md`, Side sheets). The three addresses that used to be pages
- * of their own — `agents/new`, `connections/new`, `connections/:id` — still
- * work and each opens the panel it names, and the agent's own address, whose
- * page is retired, lands on this list. So a link in the CLI, the docs or
- * somebody's notes still arrives somewhere honest.
- *
- * **Opening a panel never navigates.** Every control here changes query state
- * on the address the person is already at (the founder's blanket ruling of
- * 2026-08-24); the old addresses survive as deep-link aliases and nothing
- * else.
- *
- * **Which panel is open is in the address, and nowhere else.** Back closes a
- * sheet, a copied link opens one, and a reload keeps it. State held in this
- * component instead would disagree with the address the first time somebody
- * pressed Back.
- *
- * The project is in the address and in the request, every time.
- *
- * **Search is asked of the server, never applied to what came back.** A filter
- * that only reached the page already fetched would answer differently depending
- * on how far somebody had scrolled — a list of four hundred agents would find
- * nothing in the three hundred it had not loaded, and would say so as though
- * the project did not hold it.
+ * Project agent list with setup and connection sheets controlled by URL query
+ * state. Direct setup URLs remain supported. Keep project selection in requests
+ * and use server search so results include records beyond the loaded page.
  */
 
 /** The panel a route insists on, whatever the query string says. */
@@ -136,15 +106,8 @@ export function AgentsScreen({
   );
 
   /**
-   * Pages fetched after the first, kept beside it rather than folded into it,
-   * so that asking again always starts from a clean first page — **and each one
-   * remembers the project it was fetched for.**
-   *
-   * That is not belt and braces. Changing project does not remount this screen:
-   * it is the same route with another project in it, so this state outlives the
-   * change and a read still in flight comes back into a view that has moved on.
-   * Carrying the project in the value means a page fetched for somewhere else
-   * can never be *rendered* here, whatever wrote it and whenever it landed.
+   * Tag appended pages with their project so retained state or late responses
+   * from a previous project cannot appear in the current list.
    */
   const [after, setAfter] = useState<{
     readonly project: string;
@@ -304,17 +267,8 @@ export function AgentsScreen({
       : null;
 
   /**
-   * One page for every role, and the control that changes data is disabled
-   * rather than removed. A viewer sees what egma can do here and is told
-   * plainly that this part is not theirs; the server refuses their write either
-   * way, which is where the boundary actually is.
-   *
-   * It is disabled for the same reason on a project this organization does not
-   * hold: there is no project here to connect an agent to.
-   *
-   * **While the role is unknown there is no control at all.** A disabled one
-   * would have to say why, and every sentence it could say would be a claim
-   * about somebody egma has not identified yet.
+   * Hide actions until the role is known. Then show unavailable actions disabled
+   * with a reason; the server still enforces write permission.
    */
   const mayConnect = mayAuthor && answer?.status !== "missing";
   const whyNot = mayAuthor
@@ -368,15 +322,8 @@ export function AgentsScreen({
   }
 
   /**
-   * The one action this screen is for, and the same control wherever it stands.
-   *
-   * **It changes query state and never navigates** (the founder's blanket
-   * ruling of 2026-08-24: opening any sheet never redirects or reloads the
-   * page). The panel was always drawn over this list; sending the browser to
-   * `/agents/new` to draw it meant a reload in the middle of the product's
-   * first job. `/agents/new` survives as a deep-link alias that renders the
-   * same panel in place, so every CLI message and every piece of documentation
-   * still lands where it always did.
+   * Open setup through query state on the current list URL. /agents/new remains
+   * a supported direct link to the same sheet.
    */
   const connect = () =>
     role === null ? undefined : mayConnect ? (
@@ -574,16 +521,8 @@ export function AgentsScreen({
   }
 
   /**
-   * A project with nothing in it is the whole screen, and it has one thing on
-   * it.
-   *
-   * So the toolbar is not drawn there: a search box for a project with nothing
-   * to search is a control that carries no meaning, and a second Connect an
-   * agent above the one in the middle of the empty state would leave somebody
-   * choosing between two identical primary buttons. Everywhere else — while the
-   * read is in flight, over a list, over a search that matched nothing — the
-   * toolbar stays exactly where it was, because a search box that vanished
-   * under the keystroke that filled it would be unusable.
+   * Hide the toolbar only for an empty project. Keep it during loading and
+   * zero-result searches so the search control does not disappear while typing.
    */
   const nothingHereYet =
     answer?.status === "ready" &&

--- a/apps/web/app/projects/[projectId]/awaiting.tsx
+++ b/apps/web/app/projects/[projectId]/awaiting.tsx
@@ -6,18 +6,8 @@ import { Empty } from "../../../ui/page-state.tsx";
 import { AppShell, PageBody, PageHeader, ProductPage } from "../../../ui/shell.tsx";
 
 /**
- * A product area the shell navigates to and the browser cannot work in yet.
- *
- * **Scaffolding, and deliberately visible as such.** The navigation names four
- * product areas and Personas from the day the shell exists, because that is
- * what tells somebody what egma is for — and a navigation item that lands on a
- * framework's own 404 page would say the opposite. Each of these is replaced
- * whole by the ticket that builds its area, and the last one to go takes this
- * file with it.
- *
- * It says what the area is and where the work can be done today. It never
- * pretends to be loading and never shows an empty list, because both would read
- * as *this project has none of those*.
+ * Placeholder for an unavailable product area. Currently unused by routes;
+ * do not describe it as a loading state or an empty collection.
  */
 export function AwaitingArea({
   area,

--- a/apps/web/app/projects/[projectId]/graders/grader-sheets.tsx
+++ b/apps/web/app/projects/[projectId]/graders/grader-sheets.tsx
@@ -72,18 +72,8 @@ const COPY = {
     "From 0 to 1. A simulation passes this grader at or above this score.",
   reads: "The evidence this grader needs from a simulation.",
   /**
-   * The three sentences the create sheet says, and nothing it cannot keep.
-   *
-   * `framing` sends a rule that belongs to one test to the surface that owns
-   * it, because a project-wide grader shaped around one test grades every
-   * other conversation against a question they were never asked.
-   *
-   * `evidence` is what the judge can actually see. Written before the boxes,
-   * because an instruction the evidence cannot answer is the one way this form
-   * fails, and the author cannot know that after the fact.
-   *
-   * `productionCost` is the bill beside the coverage. A custom grader here is
-   * always an LLM judge, so one sampled transcript is one judge call.
+   * Explain where test-specific rules belong, what evidence the grader reads,
+   * and the provider usage involved in production grading.
    */
   framing:
     "This grader judges every conversation in its scope. For something one " +
@@ -94,16 +84,7 @@ const COPY = {
   productionCost: "Each sampled transcript costs one judge call.",
 } as const;
 
-/**
- * One chip, and every chip on this surface is this one.
- *
- * It is the shared `Badge` with two things said about it: the count shape's
- * 22px height, which is the small chip this product already draws beside a row
- * of facts, and no fill, because `DESIGN.md` asks a chip for a hairline and a
- * word. The verdict shape is deliberately not used here — it letter-spaces and
- * capitalises, and `llm_as_judge` is an identifier that must read exactly as
- * the API writes it.
- */
+/** Use an unfilled count badge so identifiers retain their original case. */
 function GraderChip({
   variant = "neutral",
   mono = false,
@@ -1051,16 +1032,7 @@ function EditGraderForm({
             <GraderModalityChips modalities={grader.modalities} />
           </Fact>
         </Facts>
-        {/*
-         * **A scope nobody here can change is read in the same lane the facts
-         * above it are.** It used to be two sentences under a "Fixed by Egma"
-         * caption, which answered a question nobody asked — the controls are
-         * simply not there — while saying the two evidence sources in a shape
-         * that matched neither the list behind the sheet nor the form that
-         * replaces this block on an editable grader. The caption is gone
-         * (developer decision, 2026-08-25) and the two lines are the two
-         * columns of the list, word for word.
-         */}
+        {/* Display fixed scope using the same labels as the grader list. */}
         <Section title="Scope">
           {grader.scopeEditable ? (
             <ScopeFields
@@ -1129,21 +1101,9 @@ function EditGraderForm({
 }
 
 /**
- * Writing one custom grader, as the boundary a binary judge needs.
- *
- * **The sheet asks for a boundary rather than for a paragraph**, because that
- * is what the judge already is: it answers met or not met against one
- * criterion, and code maps that answer to exactly 1 or 0. Three required
- * texts — what to decide, what passes, what fails — and the server compiles
- * them into the one immutable prompt. Nothing here composes that prompt: two
- * clients writing the template would eventually write two different judges.
- *
- * What is not asked for is as deliberate as what is. There is no mechanism
- * toggle, because create is LLM-judge only and a predefined code grader
- * arrives through Use in the library. There are no modality checkboxes,
- * because the judge's evidence is text and both modalities are stored: a
- * voice-only stamp would silently leave later chat simulations ungraded. The
- * pass threshold stays exactly as it was.
+ * Collect grading instructions, pass/fail conditions, scope, settings, and
+ * threshold. The server builds the immutable custom grader definition; this
+ * form does not duplicate its prompt template.
  */
 export function CreateCustomGraderSheet({
   projectId,

--- a/apps/web/app/projects/[projectId]/graders/page.tsx
+++ b/apps/web/app/projects/[projectId]/graders/page.tsx
@@ -133,19 +133,8 @@ export default function GradersPage() {
 }
 
 /**
- * The row's own name, and the thing that opens it.
- *
- * **A grader is read and edited in a sheet, so the row's name is a button
- * rather than a link.** The boards open the sheet from anywhere on the row; a
- * real control carrying the name is what makes that reachable by keyboard, and
- * it takes the product's Ember focus ring from `globals.css` without asking.
- * The name keeps the row's ordinary weight and turns Ember under a pointer,
- * which is the feedback the shared table already gives a row somebody is
- * pointing at.
- *
- * The row as a whole answers the pointer through the shared table's
- * `onRowActivate`; this button stays because it is the keyboard path and the
- * one control the accessibility tree holds for the action.
+ * Keep a real button on the grader name for keyboard access to the sheet;
+ * onRowActivate provides the larger pointer target.
  */
 function RowOpener({
   name,
@@ -175,35 +164,15 @@ function RowOpener({
 }
 
 /**
- * The score a simulation has to reach, as a measure: two places, tabular.
- *
- * **It reads from the lane's left edge, like every other fact in the table.**
- * The column was right-aligned for a morning, and the figures ended up under
- * the tail of a header three times their width — an indent, to an eye that
- * scans this table's five other columns by their shared left edge — welded to
- * the ⋮ lane across a void of spare paper. Right alignment earns its keep when
- * values differ in width; every value here is `N.NN` in tabular numerals, so
- * the digits line up down the column from either edge and the left one is the
- * edge the rest of the table already reads from.
+ * Use left-aligned tabular numerals with two decimal places for grader pass thresholds.
  */
 function PassThreshold({ value }: { readonly value: number }) {
   return <span className="tabular-nums">{value.toFixed(2)}</span>;
 }
 
 /**
- * **The name lane is stated; the facts share what is left.**
- *
- * `ui/data-table.tsx` gives the slack to the columns that ask for no width, so
- * a list that states a width for all but one of them hands that one column
- * every spare pixel. Every fact on a grader is short — a chip, "All", "20%",
- * "0.80" — so the column that took the slack drew a lane of empty paper mid-
- * table, and the measures ended up pushed against the ⋮ lane far to its right.
- *
- * Personas can state five widths because the column it leaves out is
- * Description, which is prose and fills whatever it is given. This list has no
- * such column, so it states only the 260px name lane the boards give every list
- * and lets the five facts divide the rest between them in proportion to what
- * each one has to say.
+ * Fix the name column width and share remaining space among the short fact
+ * columns, avoiding one column that absorbs all unused width.
  */
 function activeColumns(
   mayAuthor: boolean,

--- a/apps/web/app/projects/[projectId]/monitoring/page.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/page.tsx
@@ -2,19 +2,7 @@ import { redirect } from "next/navigation";
 
 import { transcriptsPath } from "../../../../lib/transcripts.ts";
 
-/**
- * The monitoring area's own address, which lands on the transcript list.
- *
- * **It forwards rather than drawing anything**, and that is what keeps the
- * landing a decision rather than an accident: there is exactly one page under
- * this area today, the navigation points straight at it, and somebody who typed
- * or bookmarked the area gets the same page as somebody who clicked.
- *
- * `monitoring/dashboard` is **reserved and undecided**. Nothing ships there,
- * nothing links to it, and nothing here claims it — a forward that guessed at a
- * dashboard would be this file deciding a question the effort deliberately left
- * open.
- */
+/** Redirect the monitoring area URL to the project's Traces list. */
 export default async function MonitoringPage({
   params,
 }: {

--- a/apps/web/app/projects/[projectId]/monitoring/start/page.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/start/page.tsx
@@ -3,14 +3,8 @@ import { redirect } from "next/navigation";
 import { monitoringSetupPath } from "../setup-path.ts";
 
 /**
- * The old Start-monitoring address, kept as a forwarding deep link.
- *
- * **There is one setup flow.** Agents owns Connect agent and the provider-
- * specific Monitoring goal. This route carries an old link into that flow
- * instead of rendering a second monitoring form.
- *
- * `?agent=` rides through. It still names the agent the setup flow should
- * begin from; `goal=monitoring` states why the person entered the flow.
+ * Forward existing setup links to Agents with goal=monitoring, retaining
+ * the selected agent query parameter.
  */
 export default async function StartMonitoringPage({
   params,

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/loading.tsx
@@ -7,20 +7,7 @@ import { transcriptsPath } from "../../../../../../lib/transcripts.ts";
 import { Loading } from "../../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../../ui/shell.tsx";
 
-/**
- * What the router draws between the press and
- * `/projects/:projectId/monitoring/transcripts/:transcriptId` arriving.
- *
- * The page's own wait once said a bare “Loading…”; this page's client
- * branch now draws this same frame instead, so the subject is named here
- * rather than left bare. The title and the crumbs are still the copy
- * module's.
- *
- * Its header is the page's own down to its shape — the same eyebrow or the
- * same crumbs, never one standing in for the other — so nothing is redrawn a
- * second way when the page arrives. `agents/loading.tsx` carries the
- * reasoning every one of these shares.
- */
+/** Match the transcript page's waiting header and breadcrumbs using shared copy. */
 export default function TranscriptLoading() {
   const { projectId } = useParams<{ projectId: string }>();
 

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx
@@ -42,15 +42,8 @@ import {
   type Step,
 } from "../../../../../../lib/transcripts.ts";
 /*
- * Two things this page used to keep its own copy of, taken from where the rest
- * of the product already keeps them.
- *
- * `SPEAKERS` labelled a transcript's two sides here and in `ui/evidence.tsx`,
- * with the same two words written out twice. `shownScore` turned a score into
- * a figure here and in `ui/run-status.tsx`, with the same rounding and the
- * same dash for a proportion of nothing. Two copies of a rule about how a
- * score reads is two chances for a simulation's page and a production
- * transcript's page to start saying it differently.
+ * Use shared speaker labels and score formatting across transcript and
+ * simulation evidence views.
  */
 import { SPEAKERS } from "../../../../../../ui/evidence.tsx";
 import {
@@ -75,19 +68,9 @@ import {
   StatePage,
 } from "../../../../../ui.tsx";
 
-/* ------------------------------------------------------------------------ *
- * The page's own layout, which is the only thing it styles for itself.
- *
- * These were 54 class names in `app/ui.module.css`, the last CSS Module in the
- * application. Everything a shared component owns is now composed rather than
- * dressed — the header, the chips, the arrows, the notice — and what is left
- * here is the arrangement of one wide evidence page: strips of facts, a
- * transcript beside an inspector, and three readings of the same steps.
- *
- * They are constants rather than repeated class lists because each one is
- * applied in three or more places and a strip that agreed with its neighbour in
- * four rules out of five would look right.
- * ------------------------------------------------------------------------ */
+/*
+ * Reusable class strings for this page's fact strips, transcript, and inspector layout.
+ */
 
 /**
  * The word above one fact: the compact uppercase caption, in the mono face.
@@ -115,17 +98,8 @@ const FACT_VALUE = "text-sm font-normal tabular-nums [overflow-wrap:anywhere]";
 const FACT = "flex min-w-0 flex-col gap-1 border-e border-border p-4 last:border-e-0";
 
 /**
- * The five facts above the exchange, and the measures beside them.
- *
- * Below 620px it is two columns, and the hairlines turn from a row of uprights
- * into a grid: every fact grows a top edge, the two on the first row give
- * theirs back, and the second of each pair drops the upright it no longer has a
- * neighbour for. An odd count leaves one fact alone on the last row, and it
- * takes the whole row rather than half of it.
- *
- * Every width is written out rather than composed, because Tailwind finds class
- * names by reading this file as text: a class built from a template literal is
- * a class that is never generated.
+ * Below 620px, arrange facts in two columns and let an odd final fact span
+ * both. Keep complete Tailwind class names literal so they are generated.
  */
 const SUMMARY_STRIP = cn(
   "mt-6 grid grid-cols-5 overflow-clip rounded-card border border-border bg-surface",
@@ -210,18 +184,8 @@ const VIEWS: readonly { readonly id: View; readonly label: string }[] = [
 ];
 
 /**
- * One production exchange, read as a **transcript**.
- *
- * Re-homed under the project with the rest of the monitoring section, and
- * unchanged in everything it draws: the turns with their timings, the steps
- * inside each one, the measures, and its grades.
- *
- * **Two things have to be in the address for this page to open at all**, and
- * both are now there. The window, because a name is not a prefix of the store's
- * filing order and the read endpoint refuses a lookup that bounded nothing —
- * the row in the list carries the answer, so nobody types it. And the project,
- * because a transcript belongs to one: the address names it, the request sends
- * it, and a link somebody was sent opens the same page for them.
+ * Read production or simulation evidence as a transcript. The URL must carry
+ * the project and bounded time window required by the trace-read API.
  */
 export default function TranscriptPage({
   params,
@@ -386,25 +350,9 @@ export default function TranscriptPage({
     <AppShell>
       <ProductPage wide>
         {/*
-          The product's own page header, rather than one this page drew for
-          itself. It used to carry a heading that grew to 56px — type
-          `DESIGN.md` reserves for auth, onboarding and public pages — so the
-          settled transcript did not even match its own loading state, which
-          has always been drawn by the shared header underneath
-          `ProductStatePage`.
-
-          **The trail moved into the title bar with it.** It used to be drawn
-          above the bar as a sibling of `<main>`, where it had none of the
-          page's gutters and sat over the bar rather than in it; `breadcrumbs`
-          is where the shared header keeps a trail, and it is what every other
-          record page in this product hands it.
-
-          Where the trace came from goes into the lead, because a page with a
-          real trail draws no label above its title — and this is the only
-          place the page states which source and which environment this
-          exchange belongs to. It is a fact about the record, the same kind as
-          the two beside it.
-        */}
+         * Use the shared page header and its breadcrumb slot to match the loading
+         * state. Show source and environment as record facts in the lead.
+         */}
         <PageHeader
           title={DETAIL.title}
           breadcrumbs={[
@@ -455,24 +403,10 @@ export default function TranscriptPage({
         />
 
         {/*
-          The audio of this exchange, where egma is the one who had it.
-
-          **Beside the turns, because this is where the doubt is.** Somebody
-          reading a transcript who cannot tell a misbehaving agent from a bad
-          transcription is already looking at the turn; sending them to the run
-          to hear it would put the evidence a page away from the doubt.
-
-          Above the views rather than inside the transcript one, so that
-          switching to the timeline never leaves audio playing behind a panel
-          with no controls on it — a hidden `<audio>` keeps going, and a person
-          hunting for the sound would have no way to stop it.
-
-          `simulationId` is present only for an exchange egma conducted, which
-          is the one question this page can answer for itself; whether that
-          conversation recorded anything is the recording route's answer, and a
-          refusal there shows nothing at all rather than a control that does
-          nothing.
-        */}
+         * Keep audio controls outside the view panels so playback remains controllable
+         * when changing views. Resolve recordings only for simulation traces; the
+         * recording route determines availability.
+         */}
         {typeof detail.simulationId === "string" ? (
           <RecordingPlayer
             simulationId={detail.simulationId}
@@ -482,15 +416,9 @@ export default function TranscriptPage({
         ) : null}
 
         {/*
-          The views, and the way through the problems.
-
-          On a phone the two do not fit on one line — three tab labels and a
-          pair of 44px targets is wider than the screen, and the toolbar was
-          pushing the whole document sideways whenever an exchange had
-          something wrong in it. So the strip becomes a reversed column: the
-          tabs keep the rule they sit on, and the navigator takes the line
-          above them rather than being squeezed into the same one.
-        */}
+         * Stack the problem navigator above the view tabs on narrow screens so their
+         * combined controls do not cause horizontal overflow.
+         */}
         <div
           className={cn(
             "mt-8 flex items-center justify-between gap-5 border-b border-border",
@@ -647,27 +575,9 @@ function Summary({ facts }: { facts: TraceFacts }) {
 }
 
 /**
- * What this exchange measured — the metrics display.
- *
- * **Above the grades and apart from them, because a metric records an observed
- * fact and a grader gives a score.** Nothing here is green or red: a duration is not good or bad
- * until somebody has written down a bound, and the section below is where that
- * decision shows up. Putting them in one block would make every number look like
- * a check that passed.
- *
- * **Every number here came off the platform's one shared measure module**, which
- * is also the only module a future metric-based grader may read — and that
- * includes the **reduction**, the single measurement a bound is held against. This page
- * renders what it was handed and derives nothing. Taking the maximum here would
- * look harmless and would be a second implementation of exactly the number a
- * grader could use: correct while both happen to take the maximum, silently
- * wrong the first day a grader reduces by p90 instead. A developer who found the
- * page and the grade evidence disagreeing would be right to stop believing both.
- *
- * A measure the spans do not carry is absent rather than shown empty, and an
- * exchange with none says so in a sentence — "nothing was measured" is a fact
- * about the telemetry that arrived, and a blank strip would read as a page that
- * failed to load.
+ * Render API measures without recalculating reductions. Metrics describe
+ * observations; grades apply criteria, so keep them separate and do not color
+ * metrics as verdicts. Show a clear state when no measures are available.
  */
 function Measures({ measured }: { measured: readonly Measured[] }) {
   return (

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/loading.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/loading.tsx
@@ -2,20 +2,7 @@ import { LIST } from "../../../../../lib/transcript-copy.ts";
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
-/**
- * What the router draws between the press and
- * `/projects/:projectId/monitoring/transcripts` arriving.
- *
- * Monitoring reads production traffic over a time window, so it is slow by
- * nature and the sidebar points straight here rather than at the forwarding
- * address above it.
- *
- * Its header is the page's own down to its shape — the same eyebrow or the
- * same crumbs, never one standing in for the other — so nothing is redrawn a
- * second way when the page arrives. `agents/loading.tsx` carries the
- * reasoning every one of these shares. The list screen carries no label above
- * its title now, so neither does this.
- */
+/** Match the Traces list title while the route loads. */
 export default function TranscriptsLoading() {
   return (
     <div data-slot="route-loading">

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/screen.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/screen.tsx
@@ -67,43 +67,10 @@ import { monitoringSetupPath } from "../setup-path.ts";
 import { TraceSheet, type OpenTrace } from "./trace-sheet.tsx";
 
 /**
- * **Monitoring**: what this project's agents did in production, newest first.
- *
- * *This project* is read out of the address and sent with the request, so a
- * copied link opens the project it names rather than whichever one the reader's
- * browser happened to be resolved into.
- *
- * **Production and nothing else.** A simulation is read under the run that
- * produced it, beside the frozen test, the persona, the graders and the
- * mock-tools record — drawing it a second time and poorer, in a mixed list,
- * would be a wrong door. So the request narrows to production at the server and
- * the table carries no column saying so: every row here is production by
- * definition, and a column repeating a constant is furniture.
- *
- * The first consumer of the **public v1 contract** rather than of a private one
- * built for it: what a customer integrates against is what egma's own screen is
- * drawn from, so a contract that cannot answer a question a person actually has
- * fails here first, while it is still cheap to change.
- *
- * Three things about the request are the store's discipline showing through,
- * and each is load-bearing:
- *
- * - **A window is always sent.** The read surface refuses a request that names
- *   none, because the store is filed by time and a read that bounded nothing
- *   would be a read of everything. The last day is this page's answer to that,
- *   not the endpoint's default — there is no default, on purpose.
- * - **Paging is by token.** The answer carries where it stopped, and asking for
- *   more means handing that back. An offset would re-sort and re-scan the rows
- *   already read, and would skip or repeat one the moment something arrived
- *   mid-page.
- * - **The chosen window lives in the address**, the same way one transcript's
- *   window does. Somebody who widened to thirty days and reloaded should still
- *   be looking at thirty days, and somebody sending "look at last week" should
- *   be able to send the address they are looking at.
- *
- * Signed in with a browser session like every other page here, on the origin
- * the page was served from. There is no API key in a browser and there never
- * will be.
+ * List this project's production traces newest first through the public API.
+ * Send source=production, projectId, a bounded window, and page tokens. Keep
+ * window selection in the URL; the page supplies the default 24-hour window.
+ * Authenticate requests with the browser session.
  */
 
 type State =
@@ -144,17 +111,8 @@ function traceFreeAddress(address: URL): string {
 }
 
 /**
- * The screen, which is not the route.
- *
- * **It lives beside `page.tsx` rather than inside it**, the way `agents` and
- * `tests` already arrange theirs. Next validates the export list of a route
- * module and refuses one that exports anything but its own reserved fields, so
- * a second entry point for the retired Start-monitoring address cannot live in
- * a page file — and the convention it was breaking is the reason there is a
- * convention.
- *
- * The retired Start-monitoring address now forwards to the Agents-owned setup
- * flow. This screen keeps no second setup panel.
+ * Keep the reusable screen outside the Next route module's restricted exports.
+ * Agent setup is owned by the Agents flow.
  */
 export function TranscriptsScreen({
   projectId,
@@ -422,24 +380,9 @@ export function TranscriptsScreen({
   }
 
   /**
-   * Whether this project has **ever** recorded anything, asked only when the
-   * window on screen holds nothing.
-   *
-   * It is the difference between the two confident sentences a quiet page can
-   * say, and the window alone cannot tell them apart. An empty last hour means
-   * *nothing in this hour* for a project with a week of traffic and *set up your
-   * export* for a project on its first day, and a developer who has just signed
-   * up lands on the default window rather than on the widest — so deciding by
-   * the window alone would put a click between them and the one page written
-   * for them.
-   *
-   * One row is the whole answer, so it asks for one. It is not asked at all
-   * unless the page is empty, and not even then when the window on screen is
-   * already the widest — the list read has just answered the same question.
-   *
-   * `undefined` is still out, `null` is a read that refused, and a number is an
-   * answer. The three are kept apart because `quietState` may never read a
-   * refusal as a zero.
+   * When the selected window is empty, probe one production row in the widest
+   * supported window. This checks recent history, not all-time history.
+   * Keep pending, failed, and zero-result reads distinct.
    */
   const emptyHere = state.status === "loaded" && shownRows.length === 0;
   const alreadyWidest = isWidestWindow(choice ?? DEFAULT_WINDOW);
@@ -488,21 +431,8 @@ export function TranscriptsScreen({
       : probed;
 
   /**
-   * Which of the four quiet states this page is in, or none.
-   *
-   * Nothing at all while either supporting read is still out, and that wait is
-   * deliberate: guessing would put the setup teaching on screen for a moment in
-   * front of somebody whose real trouble is a key that names the organization,
-   * and guidance that flickers between two different instructions is worse than
-   * guidance that arrives a beat late.
-   *
-   * **A read that answered a refusal counts as nothing, never as a zero.** An
-   * `Answer` that is not `ready` is `null` here, and `quietState` reads `null`
-   * as "no answer" — so a failed grader read means this page says one thing
-   * less, rather than announcing that no grader watches production on the
-   * strength of an answer it never got. That is the same rule `ui/page-state`
-   * states between failed and empty, applied to the reads that only decide what
-   * a page says about itself.
+   * Wait for supporting reads before selecting empty-state guidance. A refused
+   * read is unknown, not a zero count.
    */
   const counted = <T,>(answer: Answer<T> | null, count: (value: T) => number) =>
     answer !== null && answer.status === "ready" ? count(answer.value) : null;
@@ -564,21 +494,8 @@ export function TranscriptsScreen({
   }, [legacyAgentId, legacySetup, projectId, replace]);
 
   /**
-   * The one action this screen offers, and the same control wherever it sits.
-   *
-   * **Agents owns setup.** This page only states the user's goal. The address
-   * opens Connect agent on Agents with Monitoring selected, so first setup and
-   * later setup use one provider-specific flow instead of two forms that can
-   * disagree.
-   *
-   * **One page for every role, and the control that changes data is disabled
-   * rather than removed.** Setup requires `configure_monitoring`, which a
-   * viewer does not have. A viewer sees what egma can do here and is told
-   * plainly that this part is not theirs.
-   *
-   * **While the role is unknown there is no control at all.** A disabled one
-   * would have to say why, and every sentence it could say would be a claim
-   * about somebody egma has not identified yet.
+   * Open agent setup with the monitoring goal. Hide the action while role is
+   * unknown, then disable it with a reason when configure_monitoring is unavailable.
    */
   const whyNotMonitor = `Your ${String(role)} role cannot set up monitoring. Ask an organization admin to change your role.`;
   const setUpMonitoring =
@@ -691,11 +608,7 @@ export function TranscriptsScreen({
   );
 }
 
-/**
- * Nothing has ever arrived here, which is the state monitoring exists for — so
- * it is where the one monitoring verb lives (board `JGS-0`). The
- * provider-specific teaching is inside the picker, once.
- */
+/** Offer monitoring setup when the bounded recent-history probe finds no traces. */
 function SetUp({ action }: { readonly action: ReactNode }) {
   return (
     <Empty title={QUIET.setUp.title} lead={QUIET.setUp.lead} action={action} />
@@ -708,22 +621,9 @@ function Nothing() {
 }
 
 /**
- * The columns, in the order they are shown, each beside what fills it.
- *
- * One list rather than a header row and a body row that have to be kept in the
- * same order by hand — a table whose eighth heading names its ninth value is a
- * bug nobody sees in a diff.
- *
- * The order is a judgement about scanning. The agent leads because it is the
- * quickest way to find the family of calls somebody means. The call's time,
- * duration and turn latency follow as one compact timing story, then the exact
- * trace id. The id remains the row's primary control: it opens the sheet and is
- * where focus returns when that sheet closes.
- *
- * The trace-id control carries the project and the window this exchange
- * happened in, taken from the two instants this very row is showing. That is
- * what makes the transcript a place somebody can be sent: the endpoint under
- * it requires both, and this row already knows the answers, so nobody has to.
+ * Define headers and cells together to keep their order aligned. The trace-ID
+ * control opens the sheet and restores focus on close; its detail URL carries
+ * the project and the trace's time window.
  */
 function columnsFor(
   projectId: string,

--- a/apps/web/app/projects/[projectId]/personas/loading.tsx
+++ b/apps/web/app/projects/[projectId]/personas/loading.tsx
@@ -1,16 +1,7 @@
 import { Loading } from "../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../ui/shell.tsx";
 
-/**
- * What the router draws between the press and
- * `/projects/:projectId/personas` arriving.
- *
- * A sidebar destination.
- *
- * Its header is the page's own down to its shape — the title bar and nothing
- * above the list — so nothing is redrawn a second way when the page arrives.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
- */
+/** Match the Personas list title while the route loads. */
 export default function PersonasLoading() {
   return (
     <div data-slot="route-loading">

--- a/apps/web/app/projects/[projectId]/personas/page.tsx
+++ b/apps/web/app/projects/[projectId]/personas/page.tsx
@@ -52,23 +52,8 @@ import {
 import { PersonaTypeChip } from "./sheet-parts.tsx";
 
 /**
- * The personas of one project: one screen, and everything else drawn over it.
- *
- * **A persona is a first-class thing, not a field on a test.** Egma supplies a
- * Predefined persona to every project, and a project can author a Custom
- * persona or fork the shared one. They are used by many tests, which makes a
- * comparison between two prompt variants honest — the same person meets both.
- *
- * **One address, and the panels are state.** Creating, reading and editing a
- * persona all happen in the side sheet over this list, with no route change and
- * no reload: the list stays exactly where it was, Escape closes what is over
- * it, and nothing that is only a change of view puts a step in the browser's
- * history. It is the arrangement the boards draw, and the one the Graders
- * surface already uses.
- *
- * **One list, and it ends at its last row.** There is no second list of
- * archived personas and no footer line pointing at one: a deleted persona
- * leaves every list for good, and the API refuses to be asked for one.
+ * List Egma-provided and Custom personas for this project. Create, read, and
+ * edit in sheets over the list. Deleted personas are excluded from lists and pickers.
  */
 
 /** How long a person stops typing for before egma asks the server. */
@@ -85,16 +70,8 @@ export default function PersonasPage() {
 }
 
 /**
- * The row's own name, and the thing that opens it.
- *
- * **A persona is read and edited in a sheet, so the row's name is a button
- * rather than a link.** The boards open the sheet from anywhere on the row; a
- * real control carrying the name is what makes that reachable by keyboard, and
- * it takes the product's Ember focus ring from `globals.css` without asking.
- *
- * The row as a whole answers the pointer through the shared table's
- * `onRowActivate`; this button stays because it is the keyboard path and the
- * one control the accessibility tree holds for the action.
+ * Keep a button on the persona name for keyboard access to the sheet;
+ * onRowActivate supplies the larger pointer target.
  */
 function RowOpener({
   name,
@@ -241,32 +218,14 @@ function ProjectPersonas({ projectId }: { readonly projectId: string }) {
   const [deleting, setDeleting] = useState<Persona | null>(null);
 
   /**
-   * The open record, and only while it is this project's.
-   *
-   * **It is a rendering rule rather than a cleanup, because cleanup is one
-   * commit too late.** A child's effects run before its parent's, so a sheet
-   * still drawn on the render where the project changed would ask the new
-   * project for the old project's persona before the effect below could close
-   * it — and the new project has never heard of that id, so the panel would
-   * fill with "not found" over a list that is perfectly fine. Not drawing it
-   * is what stops the request from being made at all.
+   * Do not render a sheet for another project, even before cleanup effects run.
+   * Otherwise its child could request the old persona ID in the new project.
    */
   const openedHere = opened !== null && opened.project === projectId ? opened : null;
 
   /**
-   * Another project, and nothing of the last one carried over.
-   *
-   * Every panel here is about one project's record: a sheet on a persona the
-   * next project does not have, a confirmation about deleting it, or — worst
-   * of the three — a half-typed new persona, which would quietly be created in
-   * whichever project somebody switched to. `running` goes with them because a
-   * fork that was in flight drops its answer on a project change and would
-   * otherwise leave every row menu disabled for good.
-   *
-   * **A dirty editor has already been protected before this runs.** The
-   * project control navigates through `draftNavigation.push`, so somebody with
-   * unsaved work has already been asked and has already answered. Asking again
-   * here would be one decision and two questions.
+   * Clear project-specific sheets, confirmations, and pending-action state on
+   * project change. The shared draft-navigation guard already handles unsaved work.
    */
   useEffect(() => {
     setCreating(false);
@@ -278,14 +237,8 @@ function ProjectPersonas({ projectId }: { readonly projectId: string }) {
   }, [projectId]);
 
   /**
-   * One page for every role, and the control that changes data is disabled
-   * rather than removed. A viewer sees what egma can do here and is told
-   * plainly that this part is not theirs; the server refuses their write
-   * either way, which is where the boundary actually is.
-   *
-   * **While the role is unknown there is no control at all.** A disabled one
-   * would have to say why, and every sentence it could say would be a claim
-   * about somebody egma has not identified yet.
+   * Hide actions until the role is known, then show unavailable writes disabled
+   * with a reason. The server enforces permissions.
    */
   const mayAuthor =
     role !== null && canAuthor(role) && answer?.status !== "missing";
@@ -301,16 +254,8 @@ function ProjectPersonas({ projectId }: { readonly projectId: string }) {
   }
 
   /**
-   * A fork, and where it lands.
-   *
-   * `forkPersona` copies the name verbatim and takes no name of its own, so a
-   * fork of "Impatient Rita" is a second row also called "Impatient Rita".
-   * Landing in the editor with that name selected is what makes renaming the
-   * next keystroke instead of a thing somebody has to notice later.
-   *
-   * Whatever comes back is not this screen's to show if the screen has moved to
-   * another project — the same rule the list's paging follows, on the write
-   * path.
+   * A clone keeps the original label, so open its editor with the name selected.
+   * Ignore a result that arrives after switching projects.
    */
   async function fork(persona: Persona): Promise<void> {
     const asked = projectId;

--- a/apps/web/app/projects/[projectId]/personas/persona-fields.tsx
+++ b/apps/web/app/projects/[projectId]/personas/persona-fields.tsx
@@ -19,30 +19,9 @@ import { NumberField } from "../../../../ui/number-field.tsx";
 import { SheetSection } from "./sheet-parts.tsx";
 
 /**
- * The fields a persona is authored in, in the three groups the boards draw.
- *
- * **One set of fields, two sheets.** Create and edit ask for exactly the same
- * things — the boards `RKF-0` and `S6H-0` are the same form with a different
- * head, a different footer, and one extra line of small print. Writing them
- * twice is how the two come to disagree about a placeholder, and this surface
- * has eleven fields to disagree about.
- *
- * **The label grammar is the product's, and it is kept by two halves.** A
- * mandatory label ends in `*`, drawn Ember by `LabelText`; an optional one ends
- * in `[optional]`. The star is never only a picture, so every starred control
- * here also carries `aria-required`. `DESIGN.md` calls a starred label with no
- * required semantics a bug rather than a style choice.
- *
- * **A field says what to write, and nothing about how egma stores it.** The
- * release-defaults note, the speed instruction and the version arithmetic that
- * used to sit in these groups were deleted on the developer's own reading of
- * the boards. What a save does to the version number is said once, in the one
- * line under the name block, where the distinction it draws is the point.
- *
- * The ids are prefixed because the create sheet and the read sheet can both be
- * mounted at once — one opening while the other finishes closing — and two
- * elements answering to `#persona-name` would leave every label pointing at
- * whichever the document happened to hold first.
+ * Share persona fields between create and edit sheets. Prefix control IDs
+ * because both sheets can overlap during transitions. Required labels must
+ * also carry aria-required; optional labels use the product's optional marker.
  */
 
 /** Which sheet these fields are in, and so which ids they answer to. */
@@ -191,19 +170,9 @@ export function BehaviorFields({
 }
 
 /**
- * The model settings used for this persona in the current project.
- *
- * **One control per engine, and the control is the pair.** The server's catalog
- * is a list of provider-and-model pairs its adapters can actually execute, so
- * choosing from those pairs cannot produce a combination that does not exist.
- * The provider and the model used to be two selects that had to be kept in step
- * by hand; the boards draw one, and one is also the honest count of decisions
- * being made.
- *
- * Credentials do not appear here at all. The voice belongs to the text-to-speech
- * provider that speaks it, so changing that engine takes the new engine's
- * recommended voice with it — keeping the old one would leave a persona
- * pointing at a voice its new provider has never heard of.
+ * Edit model settings for the persona in this project. Each engine control
+ * selects a catalog provider/model pair. Changing the speech engine also
+ * selects its recommended voice so the voice matches the provider.
  */
 function EngineField({
   prefix,

--- a/apps/web/app/projects/[projectId]/personas/persona-sheets.tsx
+++ b/apps/web/app/projects/[projectId]/personas/persona-sheets.tsx
@@ -56,20 +56,10 @@ import {
 import { Reads, SheetSection, type Read } from "./sheet-parts.tsx";
 
 /**
- * A persona, created, read and edited in the panel the boards put it in.
- *
- * **The list stays on screen behind it, and the address never moves.** Create,
- * read and edit are three things this one panel is showing, not three places
- * anybody is — so none of them is a route. Somebody who opens a persona,
- * changes their mind and presses Escape is back where they were, with the list
- * they were reading still scrolled where they left it, and no step in the
- * browser's history that says nothing about where they are.
- *
- * Name and description are live metadata. Identity name, personality, and
- * language have immutable core versions. Models are saved project settings.
- * Settings are editable directly. Custom personas also expose current-core
- * editing and deletion, while shared identities stay read-only.
-
+ * Create, read, and edit a persona in a sheet over the list. Name and
+ * description are metadata; identity, personality, and language are versioned
+ * behavior. Project settings are editable inline. Egma-provided behavior is
+ * read-only; Custom personas also support current-version edits and deletion.
  */
 
 /** The words this surface repeats, written once. */
@@ -426,25 +416,8 @@ type Submitted = {
 };
 
 /**
- * The server's answer, taken into the draft.
- *
- * **The invariant, stated once: adoption may touch exactly the fields the
- * request carried, and among those, only where the draft still holds what was
- * sent.** Everything outside the submitted set is left alone, always.
- *
- * Both halves are load-bearing and each was learned the hard way.
- *
- * - *Only the submitted fields.* One save sends only fields that changed. A
- *   reply carries the whole persona, but for a field the request never
- *   mentioned that value is a **stale read, not an answer**.
- * - *Only where the draft still holds what was sent.* A save takes a moment,
- *   and somebody typing during that moment has written something the server
- *   has never seen. Its reply cannot speak for text it never saw.
- *
- * What is left is the case adoption exists for: a field this request sent,
- * untouched since, which egma stored in a form of its own — such as trimmed
- * text — and which the author should be looking at rather than their own
- * draft of it.
+ * Adopt a server value only for a submitted field whose draft still matches
+ * what was sent. Preserve unsubmitted fields and edits made while saving.
  */
 function adopted(
   current: Draft | null,
@@ -1039,15 +1012,9 @@ export function PersonaSheet({
 }
 
 /**
- * Deleting one persona, and the one question it asks.
- *
- * **Delete is the product's word and the confirmation names who it is about.**
- * Underneath, the row is stamped rather than removed, so every simulation that
- * pinned this persona still reads exactly what it heard — but that is storage,
- * not something a person authoring a test is asked to hold in their head. What
- * they are told is what actually changes for them: the persona leaves every
- * list and picker, and a test that still names them has to name somebody else
- * before it can be written or run again.
+ * Delete removes the persona from lists and pickers while preserving pinned
+ * versions for existing simulations. Tests referencing it need another persona
+ * before they can be saved or run.
  */
 export function DeletePersonaDialog({
   persona,

--- a/apps/web/app/projects/[projectId]/personas/sheet-parts.tsx
+++ b/apps/web/app/projects/[projectId]/personas/sheet-parts.tsx
@@ -7,31 +7,8 @@ import { cn } from "@/lib/utils";
 import { ownerSaid, type Persona } from "../../../../lib/personas.ts";
 
 /**
- * The parts a persona's side sheet and its list are written from.
- *
- * **They are here rather than in `apps/web/ui/` because they are one screen's
- * arrangement, not a shared behaviour.** The sheet itself, its head, its body,
- * its footer and its motion are `components/ui/sheet.tsx`; what is below is how
- * *a persona* fills one: a labelled group, a read pair,
- * and the chip that says which kind of persona a row is.
- *
- * Every measurement is read off page `L-0` of the Paper file (boards `RA4-0`
- * through `S6H-0`) with `get_computed_styles`, and every value is spent as a
- * theme key rather than as a number: `DESIGN.md` keeps the numbers, this file
- * keeps the shapes.
- *
- * Two board values are deliberately not copied literally, both because
- * `DESIGN.md`'s scale decides:
- *
- * - The boards write a sheet's small print at **12px and 13px**. The type scale
- *   starts at 14px and the 12px micro label belongs to letter-spaced capitals
- *   alone, so every one of those is drawn at `text-sm` in the faint colour —
- *   which is the same instruction the developer's own note asked for, "reduce
- *   the size and colour of these texts which are of explanatory nature", inside
- *   the scale the product actually has.
- * - The boards pad a sheet by **28px**. That is off `DESIGN.md`'s spacing list,
- *   and `components/ui/sheet.tsx` already rounds it to the 24px step that is on
- *   it. Nothing here re-pads the panel.
+ * Persona-specific content built from shared sheet primitives and theme
+ * values. Use the design system's type and spacing scale.
  */
 
 /** A labelled group, separated from the previous group by a hairline. */
@@ -64,18 +41,8 @@ export type Read = {
 };
 
 /**
- * A group of facts, as a definition list — **one item per line**.
- *
- * **A definition list because that is what it is**: a screen reader reads each
- * value with the name of the value, which a stack of `<div>`s does not give.
- *
- * The two-column grid these used to sit in is gone by the developer's own
- * reading of the boards — "can you show each item in one line for MODELS as
- * well". A 440px panel gives a pair of columns about 190px each, which is
- * narrower than half the values in it: a model name, a voice id and a sentence
- * of personality all wrapped, and the eye had to find the second column's
- * baseline again on every row. One lane down the sheet reads as a list, which
- * is what it is.
+ * Use a definition list with one fact per line so long model and voice names
+ * remain readable in the narrow sheet.
  */
 export function Reads({ reads }: { readonly reads: readonly Read[] }) {
   return (

--- a/apps/web/app/projects/[projectId]/runs/[runId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/runs/[runId]/loading.tsx
@@ -6,19 +6,7 @@ import { projectPath } from "../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
-/**
- * What the router draws between the press and
- * `/projects/:projectId/runs/:runId` arriving.
- *
- * A run is opened while it is still moving, often repeatedly. The wait is
- * short and the flash it would otherwise make is exactly what the entrance
- * delay in the theme is for.
- *
- * Its header is the page's own down to its shape — the same eyebrow or the
- * same crumbs, never one standing in for the other — so nothing is redrawn a
- * second way when the page arrives. `agents/loading.tsx` carries the
- * reasoning every one of these shares.
- */
+/** Match the run page's header and breadcrumbs while the route loads. */
 export default function RunLoading() {
   const { projectId } = useParams<{ projectId: string }>();
 

--- a/apps/web/app/projects/[projectId]/runs/[runId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/runs/[runId]/page.tsx
@@ -56,16 +56,9 @@ import {
 import { RunScenarioWorkbench } from "./run-scenario-workbench.tsx";
 
 /**
- * One run: what it froze, what happened, and how far grading has got.
- *
- * Execution state and grading state stay separate. Grade scores belong to each
- * simulation trace. Egma does not create a run-level pass or fail result.
- *
- * **Execution follows the numbered feed.** Each event is applied at most once.
- * Duration and grading projections do not exist in that feed, so the bounded
- * simulation pages already opened are refreshed without changing their order or
- * the selected row. A follower that misses a poll still asks from the last event
- * number it applied and misses nothing.
+ * Keep run execution and grading progress separate; grades belong to simulation
+ * traces, with no run-level pass/fail. Apply feed events by sequence number and
+ * refresh loaded simulation pages for fields the feed does not carry.
  */
 export default function RunDetailPage() {
   const { projectId, runId } = useParams<{
@@ -181,14 +174,8 @@ function RunDetailView({
   const [moreSimulationsRefused, setMoreSimulationsRefused] = useState<Refusal | null>(null);
 
   /**
-   * What the feed has changed since the run was read, by conversation, plus the
-   * run's own status.
-   *
-   * **Applied at most once each, by sequence number.** The feed is stateless and
-   * answering the same `after` twice answers the same page twice, so the client's
-   * half of the bargain is to remember what it has applied. That is what lets
-   * this tab be closed, reopened, or left through a dropped connection and still
-   * be right.
+   * Remember the last applied event sequence so replayed feed pages do not
+   * apply execution changes twice.
    */
   const [moved, setMoved] = useState<ReadonlyMap<string, Moved>>(new Map());
   const [runStatus, setRunStatus] = useState<string | null>(null);

--- a/apps/web/app/projects/[projectId]/runs/[runId]/simulations/[simulationId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/runs/[runId]/simulations/[simulationId]/loading.tsx
@@ -6,19 +6,7 @@ import { projectPath } from "../../../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../../../ui/shell.tsx";
 
-/**
- * What the router draws between the press and
- * `/projects/:projectId/runs/:runId/simulations/:simulationId` arriving.
- *
- * One simulation carries its transcript, its judgements and its evidence,
- * which is the heaviest read in the product and the longest a person waits
- * anywhere in it.
- *
- * Its header is the page's own down to its shape — the same eyebrow or the
- * same crumbs, never one standing in for the other — so nothing is redrawn a
- * second way when the page arrives. `agents/loading.tsx` carries the
- * reasoning every one of these shares.
- */
+/** Match the simulation evidence page's header while the route loads. */
 export default function SimulationLoading() {
   const { projectId, runId } = useParams<{ projectId: string; runId: string }>();
 

--- a/apps/web/app/projects/[projectId]/runs/[runId]/simulations/[simulationId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/runs/[runId]/simulations/[simulationId]/page.tsx
@@ -51,25 +51,10 @@ import {
 } from "../../../../../../../ui/shell.tsx";
 
 /**
- * One simulation's evidence: what happened, how it happened, and the grades
- * produced from it.
- *
- * **The page is reached from its run and is not in the navigation.** A
- * simulation is a thing inside a run, not a product area, and a sidebar entry
- * for it would invite somebody to go looking for a simulation without knowing
- * which run they wanted. The address is project-scoped and stable, so it can be
- * pasted into a ticket and open the same simulation next month.
- *
- * **One read supplies the whole page.** `GET /v1/simulations/{id}` answers the
- * pins, the identities, the frozen plan, the measures, the grades and the
- * transcript together, with the transcript's window worked out on the server
- * from the simulation's own stamps. The only second request this page ever
- * makes is the recording's, and only when there is one to hear — a signed link
- * is short-lived, so carrying one in the page answer would make the address
- * stale a quarter of an hour after it loaded.
- *
- * **The facts stay apart.** Simulation execution, grading progress, individual
- * grade results and the display-only combined score answer different questions.
+ * Open simulation evidence from its run using a project-scoped URL. The
+ * simulation read supplies pins, execution facts, grading, measures, and
+ * transcript; recording links are resolved separately because they expire.
+ * Keep execution, grading progress, individual grades, and combined score distinct.
  */
 export default function SimulationEvidencePage() {
   const { projectId, runId, simulationId } = useParams<{

--- a/apps/web/app/projects/[projectId]/runs/loading.tsx
+++ b/apps/web/app/projects/[projectId]/runs/loading.tsx
@@ -1,19 +1,7 @@
 import { Loading } from "../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../ui/shell.tsx";
 
-/**
- * What the router draws between the press and
- * `/projects/:projectId/runs` arriving.
- *
- * No eyebrow and no crumbs, because the page has neither: **Simulation
- * runs** is the whole label, and either would be a line the header gains and
- * then loses.
- *
- * Its header is the page's own down to its shape — the same eyebrow or the
- * same crumbs, never one standing in for the other — so nothing is redrawn a
- * second way when the page arrives. `agents/loading.tsx` carries the
- * reasoning every one of these shares.
- */
+/** Match the Simulation runs title without adding an eyebrow or breadcrumbs. */
 export default function RunsLoading() {
   return (
     <div data-slot="route-loading">

--- a/apps/web/app/projects/[projectId]/settings/keys/loading.tsx
+++ b/apps/web/app/projects/[projectId]/settings/keys/loading.tsx
@@ -1,17 +1,7 @@
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
-/**
- * What the router draws between the press and
- * `/projects/:projectId/settings/keys` arriving.
- *
- * Its own boundary, so moving between settings views stays instant.
- *
- * Its header is the page's own down to its shape — the title bar carries the
- * page's name and nothing else, and the settings rail beside the page is the
- * trail into it — so nothing is redrawn a second way when the page arrives.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
- */
+/** Match the API keys page title while the route loads. */
 export default function KeysSettingsLoading() {
   return (
     <div data-slot="route-loading">

--- a/apps/web/app/projects/[projectId]/settings/keys/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/keys/page.tsx
@@ -53,24 +53,10 @@ import {
 } from "../../../../../ui/shell.tsx";
 
 /**
- * The keys a terminal authenticates with.
- *
- * **A secret exists once.** It is in the answer to the request that minted it
- * and nowhere else — not in a row, not behind a reveal control, not in any
- * route. So the page shows it once, says so plainly, and what remains
- * afterwards is a prefix, four characters, and who minted it.
- *
- * **This is the one page where a viewer's controls stay live.** Every other
- * mutation in the product is an admin's or a member's and is shown disabled to
- * a viewer; here, creating and revoking *your own* key is something every role
- * does, because `egma login` mints one as its last step and a credential you
- * cannot list or revoke is a credential you cannot rotate. An admin
- * additionally sees and can revoke everybody else's, which is what responding
- * to a leak requires. Neither of those splits is enforced here — the server
- * filters the list and refuses the write.
- *
- * Keys belong to the organization even when they are scoped to one project, so
- * the note under the heading says so and every row states its scope.
+ * Display a newly minted API secret once; later reads expose only its hint
+ * and metadata. All roles can manage their own keys, while admins can also
+ * manage others' keys. The server filters reads and enforces revocation rights.
+ * Keys belong to the organization and may be scoped to one project.
  */
 export default function ApiKeysSettingsPage() {
   const { projectId } = useParams<{ projectId: string }>();
@@ -84,21 +70,8 @@ export default function ApiKeysSettingsPage() {
 const WHOLE_ORGANIZATION = "";
 
 /**
- * The lane a row's own controls stand in.
- *
- * The shared table draws the trailing cell as the boards do — a fixed 48px slot
- * with no side padding, so that every ⋮ in the product lines up in one column
- * down the table (`78X-0`). A cell holding a named button rather than a ⋮ is
- * wider than the slot and grows it, and with no padding of its own the button
- * then sits against the panel's own hairline. This puts the row's padding back
- * inside the cell, where the width is the caller's problem rather than the
- * table's. It is the row's padding by name rather than a bare `px-4`, so it
- * reads the same declaration the cells beside it do.
- *
- * **And it stops at the narrow layout, because there the row already pays
- * it.** A stacked row is a padded block — `stacked:px-(--row-padding-x)` on
- * the row, `stacked:p-0` on every cell — so a control cell keeping its own
- * would stand at 32px while every value above it sat at 16.
+ * Pad named row actions because the table's trailing slot is sized for a menu
+ * trigger. Remove that padding in stacked layout, where the row already supplies it.
  */
 const ROW_ACTIONS =
   "flex items-center justify-end gap-2 px-(--row-padding-x) stacked:px-0";
@@ -294,15 +267,7 @@ function ApiKeys({ projectId }: { readonly projectId: string }) {
         key: "actions",
         header: "Actions",
         /*
-         * A row control, said to the table rather than only drawn like one.
-         *
-         * The shared table keeps an `action` cell at the trailing edge and lets
-         * it out of the one-line ellipsis every other cell gets. That second
-         * half is why this is here: the ellipsis comes from `overflow: hidden`
-         * on the cell, and an outline is clipped by an ancestor's overflow, so a
-         * control in an unmarked cell had the Ember focus ring cut off on every
-         * side. Other row controls were already marked; these were the same
-         * concept drawn two ways.
+         * Mark the cell as an action so table overflow rules do not clip its focus ring.
          */
         action: true,
         cell: (key) => (

--- a/apps/web/app/projects/[projectId]/settings/loading.tsx
+++ b/apps/web/app/projects/[projectId]/settings/loading.tsx
@@ -1,20 +1,7 @@
 import { Loading } from "../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../ui/shell.tsx";
 
-/**
- * What the router draws between the press and
- * `/projects/:projectId/settings` arriving.
- *
- * Settings also draws a second navigation column of its own, which arrives
- * with the page rather than with this, so the card moves once on arrival.
- * Drawing that column here would mean giving a fallback the settings
- * navigation's own state for the sake of one shift.
- *
- * Its header is the page's own down to its shape — the title bar carries the
- * page's name and nothing else, the way every settings page's does — so
- * nothing is redrawn a second way when the page arrives. `agents/loading.tsx`
- * carries the reasoning every one of these shares.
- */
+/** Match the Project settings title while the route loads. */
 export default function SettingsLoading() {
   return (
     <div data-slot="route-loading">

--- a/apps/web/app/projects/[projectId]/settings/organization/loading.tsx
+++ b/apps/web/app/projects/[projectId]/settings/organization/loading.tsx
@@ -1,17 +1,7 @@
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
-/**
- * What the router draws between the press and
- * `/projects/:projectId/settings/organization` arriving.
- *
- * Its own boundary, so moving between settings views stays instant.
- *
- * Its header is the page's own down to its shape — the title bar carries the
- * page's name and nothing else, and the settings rail beside the page is the
- * trail into it — so nothing is redrawn a second way when the page arrives.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
- */
+/** Match the Organization settings title while the route loads. */
 export default function OrganizationSettingsLoading() {
   return (
     <div data-slot="route-loading">

--- a/apps/web/app/projects/[projectId]/settings/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/page.tsx
@@ -35,23 +35,9 @@ import {
 } from "../../../../ui/shell.tsx";
 
 /**
- * What this project is called and what it is for.
- *
- * **The three live fields of one project, and nothing about the organization.**
- * That separation is the whole shape of this Settings area: what is here
- * changes one product area, and what is under the Organization group changes
- * things every project shares. A page that mixed them would leave an admin
- * unsure which of the two they had just done.
- *
- * **Every save names the revision the form was opened at.** Two admins with
- * this page open in two tabs is ordinary, and the second save is refused rather
- * than silently overwriting the first — with what was typed still on screen, so
- * the fix is to read the project again rather than to retype anything.
- *
- * A viewer and a member see the same page with the same fields and the controls
- * that would change data genuinely disabled. The server refuses their write
- * either way, which is where the boundary actually is; this is a courtesy to a
- * reader, and never a lock.
+ * Edit project metadata with expectedRevision so concurrent saves cannot
+ * silently overwrite each other. Keep refused drafts for retry. Server-provided
+ * permission disables editing for users who cannot manage projects.
  */
 export default function ProjectSettingsPage() {
   const { projectId } = useParams<{ projectId: string }>();
@@ -74,19 +60,8 @@ function ProjectSettingsBody({ projectId }: { readonly projectId: string }) {
   const settled = answer?.status === "ready" ? answer.value : null;
 
   /**
-   * The server's own answer, not this page's reading of a role.
-   *
-   * `mayManageProjects` travels with the project because the API computed it
-   * from `permits(auth, "manage_projects", …)` — the same check that decides
-   * whether the write lands. Deriving it here from `role === "admin"` would
-   * make this page a second opinion about what `manage_projects` means, and the
-   * two would part company the moment the permission moved: either controls
-   * withheld from somebody the server would have allowed, or controls offered
-   * whose writes it refuses.
-   *
-   * False until the read answers, which is *not yet known* rather than *no* —
-   * the same rule the role above follows, and the reason the disabled controls
-   * carry no sentence until there is one to give.
+   * Use the server's mayManageProjects result instead of duplicating role policy.
+   * Do not state a permission-refusal reason before the read resolves.
    */
   const mayAdminister = settled?.mayManageProjects ?? false;
 
@@ -241,16 +216,7 @@ function ProjectSettingsBody({ projectId }: { readonly projectId: string }) {
       />
       <PageBody>
         <SettingsLayout projectId={projectId} current="project">
-          {/*
-            * No section heading over a page that holds one form.
-            *
-            * The title bar says "Project", the line under it says what the
-            * page is for, and the rail says which settings these are. A
-            * "Details" heading over the only thing on the screen was the
-            * largest type on it — larger than the page's own title — and said
-            * less than anything else. A page that grows a second group gets
-            * `Section` back, and then the heading is doing work.
-            */}
+          {/* One form needs no extra section heading beneath the page title. */}
           <div className="flex flex-col gap-4">
             {refused === null ? null : (
               <Refused

--- a/apps/web/app/projects/[projectId]/settings/people/loading.tsx
+++ b/apps/web/app/projects/[projectId]/settings/people/loading.tsx
@@ -1,20 +1,7 @@
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
-/**
- * What the router draws between the press and
- * `/projects/:projectId/settings/people` arriving.
- *
- * Its own boundary, so moving between settings views stays instant.
- *
- * People and invitations are two reads on one page; this names the first,
- * which is the one that decides whether the page can be drawn at all.
- *
- * Its header is the page's own down to its shape — the title bar carries the
- * page's name and nothing else, and the settings rail beside the page is the
- * trail into it — so nothing is redrawn a second way when the page arrives.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
- */
+/** Match the People settings title while membership and invitation reads load. */
 export default function PeopleSettingsLoading() {
   return (
     <div data-slot="route-loading">

--- a/apps/web/app/projects/[projectId]/settings/people/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/people/page.tsx
@@ -64,58 +64,18 @@ import {
 } from "../../../../../ui/shell.tsx";
 
 /**
- * Who is in this organization, and the four things an admin may do about it.
- *
- * **Membership is the organization's and not a project's.** The grouped local
- * navigation says that once; this page can focus on people and invitations.
- *
- * **Inviting never depends on email.** With a transport configured the message
- * is posted; with none, the link comes straight back here and whoever created
- * it passes it on. A self-hosted install is pleasant right up until the second
- * person, and requiring SMTP is where that stops.
- *
- * Everybody may read the list — a member who cannot see their colleagues cannot
- * work out who to ask for anything — and the controls that change it are
- * genuinely disabled for anybody but an admin rather than hidden. The server
- * refuses their write either way, which is where the boundary is.
+ * Membership and invitations apply to the organization. Without email
+ * transport, show the returned invitation link for manual sharing. Disable
+ * admin actions for other roles; the server still enforces permission.
  */
 
 type Tab = "people" | "invitations";
 
 /**
- * The lane a row's own controls stand in.
- *
- * The shared table draws the trailing cell as the boards do — a fixed 48px slot
- * with no side padding, so every ⋮ in the product lines up in one column down
- * the table (`78X-0`). This row keeps named buttons rather than a ⋮ (the
- * browser walk measures three controls in it), so the cell is wider than the
- * slot and needs the row's own padding back inside it, or the last button sits
- * against the panel's hairline.
- *
- * **It is a grid, and a browser is what said so.** `Button` writes `why` as a
- * `<span>` beside the control it explains, so a cell holding two of them holds
- * button, sentence, button — and wrapping that in a flex row put the sentence
- * between the two buttons. Letting the row wrap fixed the sentence and broke
- * the buttons instead: a wrapping flex box is only as wide as its widest child,
- * so the table shrank the column to one button and stacked the other under it.
- * Two `max-content` columns give the cell a minimum the table has to honour,
- * and the sentence is placed on a second row spanning both — so the buttons sit
- * side by side whether or not there is a reason under them. The reading order
- * does not move, which is what `aria-describedby` follows.
- *
- * `w-0 min-w-full` on the sentence is the second half of that, and the first
- * screenshot is what found it: an item spanning two `max-content` tracks hands
- * its own width to them, so a 600px sentence made two 300px buttons. A width of
- * zero is what the tracks are measured against; the minimum is a percentage,
- * which is indefinite while they are being measured and resolves to the whole
- * pair afterwards. The sentence also has to be told it may wrap: the shared
- * cell keeps every other fact on one line, and a row control's cell inherits
- * that.
- *
- * **The side padding stops at the narrow layout, because there the row already
- * pays it.** A stacked row is a padded block — `stacked:px-(--row-padding-x)`
- * on the row, `stacked:p-0` on every cell — so a control cell keeping its own
- * would stand at 32px while every value above it sat at 16.
+ * Use max-content grid tracks to keep named actions side by side, with any
+ * disabled-action reason spanning a second row. w-0 min-w-full lets the reason
+ * wrap without widening the button tracks. Remove cell padding in stacked
+ * layout because the row already supplies it.
  */
 const ROW_ACTIONS = [
   "grid grid-cols-[max-content_max-content] items-center gap-2",
@@ -385,17 +345,7 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
     {
       key: "actions",
       header: "Actions",
-      /*
-       * A row control, said to the table rather than only drawn like one.
-       *
-       * The shared table keeps an `action` cell at the trailing edge and lets
-       * it out of the one-line ellipsis every other cell gets. That second
-       * half is why this is here: the ellipsis comes from `overflow: hidden`
-       * on the cell, and an outline is clipped by an ancestor's overflow, so a
-       * control in an unmarked cell had the Ember focus ring cut off on every
-       * side. Other row controls were already marked; these were the same
-       * concept drawn two ways.
-       */
+      /* Mark the cell as an action so table overflow rules do not clip its focus ring. */
       action: true,
       cell: (member) => (
         <div className={ROW_ACTIONS}>
@@ -533,19 +483,8 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
 }
 
 /**
- * Asking somebody to join, and the link that comes back when there was nowhere
- * to post it.
- *
- * **The link is the whole promise of this page on a self-hosted install.** A
- * form that quietly dropped it would leave somebody with an invitation that
- * exists and cannot be delivered, which is worse than a refusal.
- *
- * **An invitation whose day has passed is drawn as its own thing.** The list
- * route answers with everything nobody has accepted, expired ones included, so
- * a single "waiting to be accepted" list says something untrue about half of
- * what is in it — and somebody reading it waits for a person who can no longer
- * accept. The standing is said in words on the row, and the only thing to do
- * about a dead invitation, sending another, is the only control it carries.
+ * Keep returned invitation links visible when email is unavailable. Distinguish
+ * expired invitations from pending ones and offer resend for expired links.
  */
 function Invitations({
   invitations,

--- a/apps/web/app/projects/[projectId]/tests/[testId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/tests/[testId]/loading.tsx
@@ -6,18 +6,7 @@ import { projectPath } from "../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
-/**
- * What the router draws between the press and
- * `/projects/:projectId/tests/:testId` arriving.
- *
- * Reached by pressing a row, where the press has to be answered at once or
- * it reads as a row that does not open.
- *
- * Its header is the page's own down to its shape — the same eyebrow or the
- * same crumbs, never one standing in for the other — so nothing is redrawn a
- * second way when the page arrives. `agents/loading.tsx` carries the
- * reasoning every one of these shares.
- */
+/** Match the test detail header and breadcrumbs while the route loads. */
 export default function TestLoading() {
   const { projectId } = useParams<{ projectId: string }>();
 

--- a/apps/web/app/projects/[projectId]/tests/[testId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/tests/[testId]/page.tsx
@@ -20,16 +20,8 @@ import {
 } from "../../../../../ui/shell.tsx";
 
 /**
- * The old test address, which is a deep link now and nothing else.
- *
- * **The test full page is retired.** A test is read and edited in its suite's
- * grid, beside every other test of that suite, so this address has one job
- * left: work out which suite the test belongs to and land there. That is a
- * navigation to a page rather than a panel opening, so a redirect is the honest
- * shape — the blanket "a panel never navigates" rule is about panels.
- *
- * The address survives because links to it were copied, pasted and bookmarked
- * while the page existed, and a link that used to answer must keep answering.
+ * Resolve a direct test link to its owning suite, where tests are read and
+ * edited in the grid.
  */
 export default function TestPage() {
   const { projectId, testId } = useParams<{ projectId: string; testId: string }>();

--- a/apps/web/app/projects/[projectId]/tests/loading.tsx
+++ b/apps/web/app/projects/[projectId]/tests/loading.tsx
@@ -1,18 +1,7 @@
 import { Loading } from "../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../ui/shell.tsx";
 
-/**
- * What the router draws between the press and
- * `/projects/:projectId/tests` arriving.
- *
- * A sidebar destination, so this is one of the seven boundaries a person
- * crosses all day. It is also the one a prefetch fills first.
- *
- * Its header is the page's own down to its shape — a bare title bar, with no
- * label above the toolbar the boards do not draw — so nothing is redrawn a
- * second way when the page arrives. `agents/loading.tsx` carries the
- * reasoning every one of these shares.
- */
+/** Match the Tests list title while the route loads. */
 export default function TestsLoading() {
   return (
     <div data-slot="route-loading">

--- a/apps/web/app/projects/[projectId]/tests/new/loading.tsx
+++ b/apps/web/app/projects/[projectId]/tests/new/loading.tsx
@@ -6,18 +6,7 @@ import { projectPath } from "../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
-/**
- * What the router draws between the press and
- * `/projects/:projectId/tests/new` arriving.
- *
- * Its own boundary rather than the list's, for the same reason the new agent
- * form has one: **Write a test** must not be answered with “Loading tests…”.
- *
- * **What arrives is the suite with the write-a-test panel over it**, so the
- * fallback wears the suite's shape rather than a page title of its own: the
- * same trail, the same bar, nothing redrawn a second way on arrival.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
- */
+/** Match the suite frame that contains the new-test entry row. */
 export default function NewTestLoading() {
   const { projectId } = useParams<{ projectId: string }>();
 

--- a/apps/web/app/projects/[projectId]/tests/new/page.tsx
+++ b/apps/web/app/projects/[projectId]/tests/new/page.tsx
@@ -14,16 +14,8 @@ import {
 import { SuiteScreen } from "../suite-screen.tsx";
 
 /**
- * Writing a test, which is the suite's grid with its entry row already open.
- *
- * **The write-a-test sheet is retired.** A test is written in the grid's entry
- * row now, so this address draws the suite the address names and opens that
- * row — the same screen the suite's own address draws, one row further on. It
- * stays a real address because links to it were copied while the sheet existed.
- *
- * With no suite in the address there is nothing to write into, and the answer
- * is the suites screen: every test belongs to one suite for its whole life, so
- * choosing the suite is the first thing that has to happen.
+ * Open the named suite with its new-test entry row active. Without a suite
+ * parameter, show the suites screen so the user can choose where to write.
  */
 export default function NewTestPage() {
   const { projectId } = useParams<{ projectId: string }>();

--- a/apps/web/app/projects/[projectId]/tests/parts.tsx
+++ b/apps/web/app/projects/[projectId]/tests/parts.tsx
@@ -10,15 +10,8 @@ import { Refused } from "../../../../ui/form.tsx";
 import { Menu } from "../../../../ui/menu.tsx";
 
 /**
- * The controls the Tests screens share: the ⋮ a page carries for itself, and
- * the confirmation that names what is about to go.
- *
- * They are here rather than in the shared set because two screens use them and
- * both are this route's — the promise this file made was that the pair moves to
- * `apps/web/ui/` as soon as a third area grows it. Runs and Running graders did,
- * so the row's own ⋮ and the two panel parts that go with it left on
- * 2026-08-23 and are now `ui/row-menu.tsx`. What is left is the toolbar's ⋮,
- * which no other area draws, and the confirmation these three screens share.
+ * Test-screen toolbar actions and deletion confirmation. Shared row menus
+ * live in ui/row-menu.tsx.
  */
 
 /**

--- a/apps/web/app/projects/[projectId]/tests/suite-screen.tsx
+++ b/apps/web/app/projects/[projectId]/tests/suite-screen.tsx
@@ -37,31 +37,9 @@ import { TestsGrid } from "./tests-grid.tsx";
 const SAVED_FOR = 1500;
 
 /**
- * The one word a finished save says, over the grid the save happened in.
- *
- * **This grid saves itself, so it has to say when it did** (founder,
- * 2026-09-04). Every other write surface in the product is a form with a Save
- * button that goes busy and then says `Saved.` beside itself; a cell that
- * commits on blur has no button to change, so a person who typed a scenario
- * and clicked away had nothing at all telling them egma had taken it.
- * `DESIGN.md`: "Save state is truthful: unchanged, saving, saved, or failed."
- *
- * **A word, muted, and no colour** — `DESIGN.md` gives every state a word and
- * makes the mark beside it optional supporting information, so the check is
- * `aria-hidden` and the sentence is the whole message. It is not a chip: a
- * chip is a standing fact about a record, and this is a thing that just
- * happened.
- *
- * **And no motion.** "Do not animate actions used many times each day" — a
- * cell commit is the most repeated action on this screen, and a word that
- * faded in and out under every one of them would be decoration on routine
- * work. It appears, it stands, it goes.
- *
- * A refused save says nothing here. The refusal is already written in the cell
- * or in the dialog it was refused in, which is where the person is looking.
- *
- * It lives in this file rather than `ui/` because one screen saves this way.
- * The moment a second one does, this is what moves.
+ * Show a brief Saved message after successful grid commits, since autosave
+ * has no button state to acknowledge completion. Keep routine saves unanimated;
+ * refusals remain in the cell or dialog where they occurred.
  */
 function SaveIndicator({ save }: { readonly save: number }) {
   const [showing, setShowing] = useState(false);
@@ -94,27 +72,9 @@ function SaveIndicator({ save }: { readonly save: number }) {
 }
 
 /**
- * One suite, and the tests inside it, as a spreadsheet grid.
- *
- * **Two addresses draw this screen.** `/tests/suites/:suiteId` is the suite
- * itself, and `/tests/new?suite=:suiteId` is the same suite with the entry row
- * already open — the old write-a-test address, kept as a deep link now that the
- * side sheet it used to open is retired.
- *
- * **Suite management is not here, but running is.** Rename and Delete suite
- * live on the suites list's row menu, where one screen owns them (founder's
- * ruling, 2026-08-24). Run suite came back to this screen on 2026-08-26 by
- * developer decision: running is what a suite is for rather than a way of
- * managing one, and it stands over the tests it runs. It goes to the run
- * builder with this suite in the address, which is where the suites list's own
- * Run suite goes.
- *
- * **Writing a test is the grid's own verb, and the toolbar holds no second
- * one.** The ghost row at the foot of the grid says "+ Write a test" where the
- * row it opens will stand, so a second button in the title bar said the same
- * word twice and pointed away from the place the caret lands. It went on
- * 2026-08-25. The two ways in are the ghost row and the `/tests/new?suite=`
- * address, which both open the entry row in place.
+ * Display one suite's editable test grid. /tests/new?suite= opens the entry
+ * row on this screen. Run suite opens the run builder; suite rename and delete
+ * remain on the suites list.
  */
 export function SuiteScreen({
   projectId,
@@ -153,17 +113,8 @@ export function SuiteScreen({
   const [removed, setRemoved] = useState<ReadonlySet<string>>(new Set());
   const [shownSuite, setShownSuite] = useState<TestSuite | null>(null);
   /**
-   * How many saves this screen has watched land, which is all the indicator
-   * needs to know.
-   *
-   * A count rather than a timestamp: two saves inside one millisecond are two
-   * saves, and `Date.now()` would call them one — the word would keep the
-   * first one's remaining time instead of starting again.
-   *
-   * **The seam is the two callbacks the grid already has.** `onSaved` is every
-   * landed cell commit and every landed dialog Save; `onCreated` is the entry
-   * row's. Both fire only on a ready answer, so there is nothing for the grid
-   * to tell this screen that it was not already telling it.
+   * Count successful saves to restart the indicator even when two occur within
+   * one millisecond. Cell/dialog saves and entry-row creation share this signal.
    */
   const [saves, setSaves] = useState(0);
   const [search, setSearch] = useState("");

--- a/apps/web/app/projects/[projectId]/tests/suite-sheets.tsx
+++ b/apps/web/app/projects/[projectId]/tests/suite-sheets.tsx
@@ -23,16 +23,7 @@ import type { TestSuite } from "../../../../lib/test-suites.ts";
 import { Field, Refused } from "../../../../ui/form.tsx";
 import { RelativeInstant, useMinuteClock } from "../../../../ui/relative-time.tsx";
 
-/**
- * Where a test suite is created and where it is renamed.
- *
- * **A suite is one short record, so it is written in the side sheet** rather
- * than on a page of its own: the list a person came from stays on screen behind
- * it, which is the arrangement `DESIGN.md` records for agents, connections,
- * personas and tests alike. Both boards (`94I-0`, `9FG-0`) draw the same panel
- * with the same one field; what differs is the title, the sentence under the
- * field, and whether there is anything to delete yet.
- */
+/** Create and rename suites in sheets over the list using the same name field. */
 
 /**
  * The hint under the field, which is the only place either sheet explains

--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -53,55 +53,14 @@ import { DestructiveItem, MenuReason, RowMenu } from "../../../../ui/row-menu.ts
 import { ConfirmDialog } from "./parts.tsx";
 
 /**
- * The suite's tests, as a spreadsheet.
+ * Existing tests save individual fields; new tests require an explicit complete
+ * entry-row submit. Name, scenario, expected behaviors, and personas are required.
  *
- * **The grid has one grammar, and the founder wrote it on 2026-08-24: editing
- * saves itself cell by cell; creating asks once and cannot fire early.** An
- * existing test is four cells that each commit alone, so changing a scenario is
- * one click, one blur and one request carrying one field. A new test is an
- * entry row with a commit bar, because there is no honest way to save a quarter
- * of a test — a test with no persona, or no behavior, is not a test that can
- * run, and a row that saved itself a field at a time would have to invent the
- * rest.
- *
- * All four fields are mandatory: name, scenario, at least one expected
- * behavior, at least one persona. The platform holds the same four; this screen
- * says so before the request rather than after it, and repeats the platform's
- * own sentence when a request is refused anyway.
- *
- * **The save grammar, whole.** Every rule below exists because a version
- * guard makes two saves of one test contend, and because a request is awaited
- * while a person keeps typing. Four rules, and together they close the family:
- *
- * 1. **Different tests save in parallel; one test saves in order.** Separate
- *    rows carry separate guards, so they cannot contend. Two cells of one test
- *    would carry the same version, so they queue, and a queued save reads its
- *    version or revision when it is sent — from the answer the save in front
- *    of it received, never from the render that started it.
- * 2. **A wake seeds from the newest intent.** The stored row, with any
- *    unfinished save of it laid over the top, because the row still shows what
- *    that save is replacing.
- * 3. **An answer closes only its own session, and only over what it sent.**
- *    Leaving a cell and returning is a new session, so a late answer from the
- *    old one neither closes it nor speaks into it; and pressing Enter and
- *    carrying on typing never leaves the session, so the draft itself is what
- *    says the answer has been overtaken.
- * 4. **A commit is dropped only when it is an identical resubmit** — the blur
- *    that follows an Enter. Anything a person actually changed queues.
- *
- * What that buys is one sentence: a version conflict can only be a write this
- * client did not make, so the refusal in the cell means another person moved
- * the test, and it is never about something the person in front of it did.
- *
- * The look is `LNC-0`, `LUT-0` and boards 10–14 of Paper page 04B: a Pure Paper
- * panel inside one hairline, hairlines between every cell, a woken cell inside
- * a 2px ink edge, add-affordances on the woken cell, and a ghost row at the
- * foot that opens the entry row.
- *
- * The two JSON cells are the exception to "only when woken", and the founder
- * made it on 2026-09-04: they are not cells anybody types in, so they never
- * wake, and an empty one that showed nothing was a control with no sign it was
- * one. They carry the same add-affordance at rest.
+ * Serialize saves per test and read the latest version/revision when sending.
+ * Different tests may save concurrently. Reopened cells start from pending
+ * intent, and late answers may affect only their original edit session and
+ * unchanged submitted draft. Drop identical Enter/blur resubmits.
+ * Mock tools and env open JSON dialogs instead of inline text editors.
  */
 
 /** A persona as a cell needs it: an id to send and a name to show. */
@@ -117,14 +76,8 @@ type Field =
   | "env";
 
 /**
- * The two fields written as raw JSON, in a dialog rather than in the cell.
- *
- * **They are cells that open something, not cells you type in.** A mock tool's
- * answer is arbitrary JSON and an env is two nested objects, and neither fits
- * on a table row that has to stay scannable beside a scenario. So the cell
- * carries one short summary — or, while it holds nothing, the line that offers
- * to write the first one — and the writing happens in the smallest dialog that
- * holds a monospace editor, a reason when there is one, and Save and Cancel.
+ * Edit mock tools and env as JSON in dialogs; cells show a summary or an
+ * action to add a value.
  */
 type JsonField = "mockTools" | "env";
 
@@ -133,19 +86,8 @@ function isJsonField(field: Field): field is JsonField {
 }
 
 /**
- * What each JSON dialog is called, what its empty cell offers, and what its
- * empty editor shows.
- *
- * **The example is written by the same call the editor is.** A stored value
- * opens as `JSON.stringify(value, null, 2)`, so a one-line example taught the
- * shape in a grammar this field never writes back: somebody copied it, saved,
- * reopened, and read a document that looked nothing like the one they had
- * pasted. Running a real value through the same call is what keeps the empty
- * editor and the full one the same shape — it cannot drift, because there is
- * no second copy of the formatting to drift from (founder, 2026-09-04).
- *
- * `add` is the empty cell's own line, and it is a verb rather than the column
- * heading again: the cell says what pressing it does.
+ * Format examples with the same JSON.stringify indentation as stored values.
+ * Empty-cell labels describe the action that opens the editor.
  */
 const JSON_FIELD: Readonly<
   Record<
@@ -187,14 +129,8 @@ const JSON_FIELD: Readonly<
 type Woken = { readonly testId: string; readonly field: Field };
 
 /**
- * One edit session: a cell, and *which time* it was woken.
- *
- * **The cell is not the identity a late answer needs.** Leaving a cell and
- * coming back to it is a new session over the same two coordinates, so a save
- * still in flight from the first one would match the second on `testId` and
- * `field` and clear a draft somebody is in the middle of typing. `at` is what
- * tells the two apart: a counter that moves on every wake, so a session is
- * only ever itself.
+ * Identify each cell edit session with a new counter value. Reopening the
+ * same cell must not let a previous save clear the new draft.
  */
 type Session = Woken & { readonly at: number };
 
@@ -204,22 +140,8 @@ function isContent(field: Field): boolean {
 }
 
 /**
- * The columns, at the proportions `LNC-0` draws them, rebalanced for two more.
- *
- * **Every column holds its own heading on one line at the grid's floor**, and
- * that is what set these numbers rather than taste. At the 900px floor the
- * headings want, inside `--row-padding-x` either side, about 100px for
- * `Mock tools` and about 90px for `Personas`; `Expected behaviors` is the
- * widest word in the row and wants about 150.
- *
- * **The two JSON lanes are 15% each, and the sentences in them are why**
- * (founder, 2026-09-04). Their cells no longer hold a bare count and a list of
- * key names: an empty one offers `+ Add mock tools` or `+ Add env variables`,
- * and a full Env says `View env variables`. That is about 130px of words in a
- * lane that was 8%, which is 72px at the floor — so Env was the one column in
- * the grid whose content could not be drawn inside it at any width. Scenario
- * and Expected behaviors gave up the five and four points, because they are
- * the two lanes with room to give and their own headings still fit.
+ * Allocate enough width for headings and JSON-cell actions at the grid's
+ * minimum width. Keep the mock tools and env columns wide enough for their labels.
  */
 const COLUMNS: readonly {
   readonly field: Field;
@@ -242,26 +164,8 @@ const COLUMNS: readonly {
 ];
 
 /**
- * The star over a column a test cannot be saved without.
- *
- * **It is the product's own label grammar, moved up to the heading.** The grid
- * has no field labels — a cell is the value and the column heading is its only
- * name — so the four mandatory fields had no way of saying so until the Save
- * button refused. `DESIGN.md` already sets the grammar: a mandatory field's
- * label ends in `*`.
- *
- * **The star wears the heading's own colour, not Ember** (founder,
- * 2026-09-04). A form draws its star in the brand colour, where it is one mark
- * on a quiet column of labels. A heading row is six labels side by side, and
- * four orange marks across it read as a state the table is in rather than a
- * fact about four fields. `ui/form.tsx` keeps the Ember star for forms.
- *
- * **And it is never only a picture**, which is the other half of the same
- * rule. A `<th>` takes no `aria-required`, so the heading says the word
- * instead, and it says it through the cell's own name rather than a hidden
- * span beside the star: the name a `<th>` computes from its contents runs the
- * text nodes together, so a hidden `(required)` was announced as
- * `Name(required)`. `columnHeading` below is the one place that name is built.
+ * Mark required columns with a heading-colored star and include required in
+ * the accessible column name. A th does not support aria-required.
  */
 function RequiredMark() {
   return (
@@ -278,35 +182,14 @@ function columnHeading(header: string, required: boolean): string | undefined {
 
 const CELL = "border-r border-b border-border p-0 align-top last:border-r-0";
 /*
- * **The row's own ⋮ lane, and it is not a fifth column.** The four columns are
- * the test's content; this is the house table's trailing slot, which every row
- * of every list in the product carries so the triggers line up in one lane.
- * The boards are silent on it, so the current screen's verb stays: a test is
- * deleted from its row.
- *
- * **It is the labelled width, because this grid says Actions over it.** The
- * unlabelled `--table-action-width` is sized for a ⋮ and nothing else, so the
- * word ran out through the table's own right hairline. Header and body cells
- * read the one token — and so does the `<col>` this table's fixed layout
- * actually measures — so the lane stays one straight edge from the heading to
- * the last row.
+ * Use the labeled action-width token for the Actions header, cells, and col.
+ * The narrower icon-only action token would clip the heading.
  */
 const ACTION =
   "w-(--table-action-labelled-width) border-b border-border p-0 text-center align-top";
 /**
- * The lane's padding, and it is the house table's rather than this grid's own.
- *
- * This is the one table in the product that is not drawn from
- * `components/ui/table.tsx`, and it had been reading from 10px where every
- * other list reads from `--row-padding-x`. Six pixels is enough to see: a
- * person who walks Agents, Runs, Personas and then a suite watches the first
- * column step left, and 10px is not on `DESIGN.md`'s spacing scale to begin
- * with. Header and cells both read this, so the column keeps one edge from the
- * heading to the last row — which is the same promise the shared table makes.
- *
- * The edge itself is imported rather than copied: this grid is the one table
- * that inherits nothing from `components/ui/table.tsx`, and two files naming
- * the same edge separately is how it drifted off it the first time.
+ * Reuse shared table padding and edge tokens because this grid does not
+ * render through the standard table component.
  */
 const PAD = `${LANE_X} py-(--row-padding-y)`;
 const TEXT = "text-sm leading-(--line-caption) text-foreground";
@@ -502,33 +385,9 @@ function Arriving({
 }
 
 /**
- * The persona picker, and this is its only home.
- *
- * It opens from the woken Personas cell — search, tick boxes, Done — because
- * the cell is where the answer is read.
- *
- * **It is the kit's popover now, and that is what deleted the grid's worst
- * trade.** The panel used to be an absolutely positioned box inside the cell,
- * which any scroll container clips, so the grid switched its own sideways
- * scrolling off for as long as a picker was open — and on a phone that switch
- * threw away the reader's place in the table. `PopoverContent` is drawn in a
- * portal, so nothing clips it and the grid scrolls at all times.
- *
- * **The click-outside rule is Radix's, and it is the same rule spelled once.**
- * The hand-written listener had to measure "elsewhere" against an owner id,
- * because a marker with no owner made *another* row's trigger count as inside
- * this panel: the picking moved to that row, Done never ran, and the personas
- * ticked here went with no save and no word said. A popover only knows itself,
- * so pressing another row's trigger dismisses this one first — which closes it
- * the way Done does, keeping the ticks — and the press then opens that row's.
- * The owner id is gone from this component because Radix is what holds the
- * rule now, and `tests-grid` keeps its own `picking` only to know which cell to
- * commit.
- *
- * The reading lives in `PersonaChoices`, inside the panel, because Radix mounts
- * the panel's children when it opens. A row that is never opened must not send
- * the project's whole persona list over the wire, and there is one of these per
- * row.
+ * Portal the persona picker so the grid can keep horizontal scrolling.
+ * Dismissal commits the selected personas. Mount PersonaChoices only while
+ * open to avoid fetching the persona list for every unopened row.
  */
 function PersonaPicker({
   projectId,
@@ -563,16 +422,8 @@ function PersonaPicker({
         className="w-[min(300px,calc(100vw-var(--space-8)))] p-0"
         aria-label="Choose personas"
         /*
-         * **Focus leaving does not shut this panel; a press elsewhere does.**
-         * A popover closes on both by default, and the first one is wrong here:
-         * the cell this hangs off keeps a caret of its own — the entry row puts
-         * one in Name as soon as it wakes — so focus lands back outside the
-         * panel a tick after it opens and Radix reads that as an exit. The
-         * panel shut itself before anybody could tick a name.
-         *
-         * A press outside still closes it, which is the rule that matters: that
-         * is the save, and it is what carries the ticks to the platform. Escape
-         * still closes it too.
+         * Prevent focus-out dismissal because the entry row may restore its own
+         * caret after opening. Pointer dismissal and Escape still close the picker.
          */
         onFocusOutside={(event) => event.preventDefault()}
       >
@@ -1066,33 +917,9 @@ type Offer =
   | "never";
 
 /**
- * What a JSON cell shows at rest: the summary, or the way to write the first one.
- *
- * Muted text rather than a chip (founder, 2026-09-03): a chip in a table lane
- * this narrow is decoration, and what a reader needs is one short fact they can
- * scan past.
- *
- * **An empty cell says how to fill it** (founder, 2026-09-04). It used to be
- * blank, so the only thing that said a mock tool or an env could be written
- * here was the pointer changing shape over it — which a person has to already
- * suspect the cell is a control to find.
- *
- * **But it says it only to the row being reached for** (founder, 2026-09-04,
- * on seeing it built). Two brand lines on every row of a full suite is a column
- * of orange down a table whose job is to be scanned: `ADD_LINE` is an
- * invitation, and an invitation repeated on forty rows stops being one. So a
- * written row rests on `None` — the truthful empty state, in the same faint ink
- * the summary beside it uses — and offers the line when a pointer is over the
- * cell or the keyboard is in it. The entry row keeps the line at all times,
- * because that row *is* the act of authoring.
- *
- * **The swap is CSS, not state.** Two spans and the button's own `group`, so a
- * pointer crossing a suite re-renders nothing; a `useState` per cell would run
- * React on every mouse move across the grid. The pointer half is gated to fine
- * pointers, which is `DESIGN.md`'s rule and the reason `pointer-hover` exists —
- * on a touch screen `:hover` sticks after a tap and would leave the line up on
- * the row somebody just pressed. The focus half is not gated, because a
- * keyboard is a keyboard on every device.
+ * Show empty saved cells as None, with an add action on fine-pointer hover
+ * or keyboard focus. The entry row always shows the action. Use CSS for the
+ * swap so pointer movement does not update React state.
  */
 function JsonSummary({
   field,
@@ -1131,16 +958,8 @@ function JsonSummary({
 }
 
 /**
- * The smallest dialog that fits one JSON field.
- *
- * The editor, the reason when there is one, Save and Cancel — and nothing
- * else. Centred, focus trapped, Escape closes, the opener restored: all of that
- * is `ui/dialog.tsx`'s, which is why none of it is written here.
- *
- * **The text is this component's, not the grid's.** A keystroke in here would
- * otherwise re-render every row of the table, and the value only matters when
- * Save is pressed. The reason and the busy state come from above, because the
- * platform is what says them.
+ * Keep editor text local so typing does not re-render the grid. Shared dialog
+ * primitives own focus and dismissal; the grid supplies save status and refusals.
  */
 function JsonDialog({
   field,
@@ -1259,16 +1078,8 @@ export function TestsGrid(props: GridProps) {
 
   const [active, setActive] = useState<Woken | null>(null);
   /**
-   * The woken cell as it is *now*, not as it was when a commit was created.
-   *
-   * **The state alone cannot answer this question.** A commit is awaited, and
-   * the function that resumes after the await still closes over the `active`
-   * of the render that started it — which, for a late answer, is the cell that
-   * has since been left. Comparing against that closure would let A's answer
-   * decide it is still A and clear the cell somebody is typing into, which is
-   * the exact bug the guard exists to stop. The ref is written in the same
-   * breath as the state, so it is true at every instant rather than at every
-   * render.
+   * Read the current edit session from a ref after awaits. A render closure
+   * may still refer to a cell the user has already left.
    */
   const wokenNow = useRef<Session | null>(null);
   /** Moves on every wake, so no two edit sessions can be mistaken for one. */
@@ -1284,33 +1095,13 @@ export function TestsGrid(props: GridProps) {
    */
   const draftNow = useRef<Draft | null>(null);
   /**
-   * What each cell's unfinished save is trying to make true.
-   *
-   * **A wake seeds from the newest intent, not from the row.** The row still
-   * shows the value a save is in the middle of replacing, so a cell woken while
-   * its own save is in flight used to start from the value the person had just
-   * typed over. Blurring it without touching anything then committed that older
-   * value back — against the version their own save had just minted, so it
-   * landed, and their edit was undone by a click that changed nothing.
-   *
-   * Seeded from here instead, that blur commits a value equal to what is
-   * stored, and the unchanged path absorbs it without a request.
+   * Seed reopened cells from pending save intent, not the older stored row.
+   * Otherwise an unchanged blur could write the previous value back.
    */
   const intent = useRef<Map<string, string | readonly string[]>>(new Map());
   /**
-   * The tail of each test's queue, so one test's saves happen in order.
-   *
-   * **Two cells of the same test cannot go at once, and the reason is the
-   * version guard.** A content edit carries the version it was read at, so two
-   * content cells committed together would carry the *same* one: the first
-   * mints a new version and the second is refused for holding the version it
-   * has just replaced. That refusal would be about nothing a person did, and if
-   * the caret had already moved it would have nowhere to be shown — an edit
-   * gone with no request left standing and no sentence, which is the one thing
-   * this grid promises never to do.
-   *
-   * Different tests keep no queue between them: their guards are separate rows,
-   * so they are independent by construction and run side by side.
+   * Queue saves per test so each receives the version/revision produced by
+   * the previous save. Different tests keep independent queues.
    */
   const queued = useRef<Map<string, Promise<void>>>(new Map());
   /**
@@ -1467,14 +1258,7 @@ export function TestsGrid(props: GridProps) {
   }
 
   /**
-   * Put the grid back to rest, but only if the cell that asked is still the
-   * woken one.
-   *
-   * **A save that lands late must not reach into a cell somebody has since
-   * clicked into.** A commit is awaited, and in that time the caret can be two
-   * cells away with a sentence half typed into it; un-waking that cell would
-   * throw away what was typed with no refusal and no record — the one thing
-   * this grid promises never to do.
+   * Close only the edit session that requested the save; preserve any newer active cell.
    */
   function rest(mine?: Session): void {
     if (mine !== undefined && wokenNow.current?.at !== mine.at) return;
@@ -1549,15 +1333,8 @@ export function TestsGrid(props: GridProps) {
     setCellRefused(null);
 
     /*
-     * One field, and the guard the platform asks that field for. A content edit
-     * carries the version it was read at, so a save cannot land on top of
-     * somebody else's; a name is identity and carries the revision instead.
-     *
-     * Both are read here rather than closed over, because this runs when the
-     * queue reaches it: the save in front may have minted a version since, and
-     * carrying the older one would be refused for no reason a person could act
-     * on. A genuine refusal now means what it says — somebody else moved this
-     * test — which is exactly what the sentence in the cell is for.
+     * Read guards when the queued save starts. Content uses expectedVersionId;
+     * name edits use expectedRevision. Earlier saves may have advanced either guard.
      */
     const send = async (): Promise<void> => {
       const guard = latest.current.get(test.id) ?? {
@@ -1624,25 +1401,9 @@ export function TestsGrid(props: GridProps) {
   }
 
   /**
-   * A press anywhere else is leaving the cell, and leaving a cell commits it.
-   *
-   * **Blur alone does not close a cell, because most of a page takes no
-   * focus.** The canvas beside the table, the table's own headings, the page
-   * title: pressing any of them moves focus nowhere, so no blur fires and the
-   * woken cell sat there wearing its ink edge over words nobody had saved
-   * (founder, 2026-09-04). A press is what a person means by "I am done with
-   * that cell", whether or not the browser had anywhere to put the caret.
-   *
-   * **It runs the same `commit` a blur runs**, so every rule that governs a
-   * save governs this one: the identical-resubmit guard that makes a press
-   * followed by a blur one request rather than two, the per-test queue, the
-   * version the queue hands it, and the refusal shown in place. Escape is
-   * untouched and still reverts.
-   *
-   * The handler is rebuilt every render and reached through a ref, because it
-   * has to run *this* render's `commit` over *this* render's draft — a
-   * listener captured once would save whatever was in the cell when it was
-   * woken.
+   * Outside pointer presses commit even when focus does not change. Use the
+   * same commit path as blur, including duplicate suppression; Escape reverts.
+   * Read the latest handler through a ref so it submits the current draft.
    */
   const outsidePress = useRef<((event: Event) => void) | null>(null);
   useEffect(() => {
@@ -1712,17 +1473,8 @@ export function TestsGrid(props: GridProps) {
   }
 
   /**
-   * One JSON field of one written test, saved against the version it was read
-   * at.
-   *
-   * **It queues behind whatever else that test is saving**, for the reason the
-   * cell commits do: two content edits carrying the same version would have the
-   * second refused for holding a version the first had just replaced. The guard
-   * is read when the queue reaches this, so the save in front hands this one
-   * the version it minted.
-   *
-   * A refusal stays in the dialog. Nothing is written and nothing is closed, so
-   * the JSON somebody wrote is still on screen to fix.
+   * Queue JSON saves with other edits to the same test and read the latest
+   * version when sending. Keep refused drafts open in the dialog.
    */
   async function saveJson(
     test: ListedTest,
@@ -1875,14 +1627,8 @@ export function TestsGrid(props: GridProps) {
   }
 
   /**
-   * A JSON cell: the summary, and the way into the dialog that writes it.
-   *
-   * It is a button rather than a woken cell because there is nothing to type
-   * here — the value is JSON and it is written in the dialog. A row a reader
-   * cannot author draws the same summary with nothing to press.
-   *
-   * Focus is the product's own two-pixel indicator, drawn on every button by
-   * the unlayered rule in `globals.css`. The cell adds none of its own.
+   * Editable JSON cells open a dialog with a real button. Read-only rows show
+   * the same summary without an interactive control.
    */
   function jsonCell(test: ListedTest, field: JsonField): ReactNode {
     const said = jsonSaid(field, test);
@@ -1945,16 +1691,8 @@ export function TestsGrid(props: GridProps) {
                   return;
                 }
                 /*
-                 * **A cell whose own picker is open has not been left.** The
-                 * panel is drawn in a portal now, so it is not a descendant of
-                 * this cell and the test above reads focus moving into it as
-                 * focus going away — which committed the cell and tore the
-                 * panel down under the person about to tick a name. Asking
-                 * whether this cell is the one picking is the same question
-                 * without depending on where focus landed, which a browser may
-                 * not say: `relatedTarget` is null on plenty of real blurs.
-                 *
-                 * Shutting the picker is what commits, and it commits there.
+                 * An open portaled persona picker still belongs to this cell. Do not commit
+                 * on blur into it; picker dismissal owns that commit.
                  */
                 if (picking === test.id) return;
                 void commit(test, field);
@@ -2161,22 +1899,9 @@ export function TestsGrid(props: GridProps) {
       }}
     >
       {/*
-        The grid scrolls sideways rather than squeezing, the way every other
-        table's `TablePanel` already does. Six percentage columns and a fixed
-        lane share whatever width there is, and this grid has no narrow layout
-        to fall back to, so under `--tests-grid-min-width` the columns stop
-        holding their own headings on one line. Mock tools and Env raised that
-        floor past a tablet, and the token says why.
-
-        **It scrolls at all times now, and it used not to.** The persona picker
-        was an absolutely positioned panel inside the cell it belongs to, and a
-        scroll container clips exactly that — so this wrapper switched between
-        `overflow-x: auto` and `overflow-visible` to keep an open picker whole,
-        and on a phone the switch threw away the reader's place in the table.
-        The picker is the kit's popover now and is drawn in a portal, the way
-        the shared table's ⋮ always was, so nothing here has to move out of its
-        way.
-      */}
+       * Keep horizontal scrolling below the grid minimum width. Portaled pickers
+       * do not require changing overflow or losing the current scroll position.
+       */}
       <div className="overflow-x-auto">
       <table className="w-full min-w-(--tests-grid-min-width) table-fixed border-collapse border border-border bg-surface text-sm">
         <caption className="sr-only">Tests in this suite</caption>
@@ -2221,18 +1946,9 @@ export function TestsGrid(props: GridProps) {
         </thead>
         <tbody>
           {/*
-            An empty suite draws no teaching row. The faint "One situation to
-            put the agent in…" row looked like a row to type in, so the first
-            thing a person did on an empty suite was click it and get nothing:
-            it was a picture of a test, and the way in was the line under it.
-            The way in is now the only thing there (developer decision,
-            2026-08-26).
-
-            The run-flow refinement answered the same complaint the other way,
-            by making that faint first cell open the entry row. The row is
-            gone instead, so there is nothing left to make clickable: a picture
-            of a test that opens a real one is still a picture of a test.
-          */}
+           * An empty suite shows only the actionable entry row, without a sample row
+           * that could be mistaken for an editor.
+           */}
           {tests.map((test) => (
             <Fragment key={test.id}>
               <tr>

--- a/apps/web/app/recording-player.tsx
+++ b/apps/web/app/recording-player.tsx
@@ -8,39 +8,12 @@ import { offersNothing } from "../lib/recording-refusals.ts";
 import { Notice } from "./ui.tsx";
 
 /**
- * The audio egma recorded of one voice conversation, wherever somebody is
- * reading about it.
+ * Shared recording playback for simulation results and transcript views.
+ * Resolve signed links on demand, retry playback once, and restore position.
+ * Call load() on replacement even if the URL is unchanged.
  *
- * **One component and not two, because the awkward parts are not the markup.**
- * Two surfaces want this: a run's results, where somebody found the conversation
- * whose transcript looks wrong, and one transcript, where somebody is already
- * looking at the turn they doubt. What they share is everything that took a bug
- * to learn — fetching a link rather than carrying one, retrying once when a link
- * has gone stale, saying `load()` out loud because a same-second retry mints a
- * byte-identical URL, and putting the listener back where they were. A second
- * copy of that would drift from the fixes, and the fixes are the file.
- *
- * **What the two surfaces do not share is words**, so words are handed in. A
- * run's results name the persona who called, because that page is about a run
- * and names the persona of every conversation on it. A transcript may be a
- * production exchange nobody simulated, so `persona` names nothing there and the
- * page speaks the transcript's own vocabulary — `human` and `agent` — which is
- * held against the banned list in one file. One sentence for two surfaces would
- * have to be wrong on one of them.
- *
- * Every string this can render comes from those words, with exactly one
- * exception: the line saying a link is being fetched, which is behind
- * `knownToExist` and therefore cannot reach a transcript at all. That is what
- * keeps the transcript surface's copy checkable in one file — any word that
- * could appear there belongs in `RecordingWords`, including the ones only a
- * broken deployment would ever show.
- *
- * A refusal egma writes is shown as its own sentence, which is a **wire**
- * sentence rather than page copy — the same way a run's results have shown one
- * since ticket 02, and the reason a client is given a stable code to branch on
- * and a sentence that improves. Which refusals reach a screen at all is decided
- * by `offersNothing`; the one that says `conversation` out loud is the chat
- * refusal, and a chat is an absence, so it is never one of them.
+ * Callers provide surface-specific labels and whether a recording is known
+ * to exist. The refusal policy distinguishes expected absence from failures.
  */
 
 export type RecordingWords = {
@@ -63,17 +36,8 @@ export type RecordingWords = {
 };
 
 /**
- * What a recording resolves to, or why it did not.
- *
- * There is no "idle": this component is only mounted once somebody could hear
- * something, which is the moment they asked.
- *
- * **The two failures are separate states because they are separate facts.**
- * `unresolved` is egma declining to hand over a link at all. `unplayable` is a
- * link that resolved and a store that then would not serve it twice running:
- * by then a player is on screen, somebody has pressed play, and a control that
- * silently vanished would be worse than the error it was hiding — so that one
- * is always said out loud, on both surfaces.
+ * Keep link-resolution failure separate from playback failure after resolution.
+ * The latter must stay visible once the user has a player to operate.
  */
 type Playable =
   | { readonly status: "resolving" }
@@ -94,51 +58,21 @@ export type RecordingPlayerProps = {
   readonly simulationId: string;
   readonly words: RecordingWords;
   /**
-   * Whether the surface already knows there is a recording to hear.
-   *
-   * A run's results do: the run's own answer says which conversations have one,
-   * so this is mounted only where there is, and a refusal there contradicts
-   * what the same page was just told — worth a sentence, whatever it says.
-   *
-   * A transcript does not. It holds a trace identifier, which says which
-   * simulation this is and nothing about whether that simulation recorded
-   * anything — a chat never can, and a voice conversation whose call never
-   * connected did not. So asking *is* how it finds out, an answer about this
-   * conversation is an answer rather than a fault, and the honest thing to show
-   * for one is nothing at all: not a disabled control, not an error, and not
-   * even the line saying a recording is being looked for, because each of those
-   * implies audio that does not exist.
-   *
-   * It buys silence for that one case and no other. A fault is still said, and
-   * so is a refusal of a link that had already worked — see `hidden` below.
+   * When true, a missing link contradicts the caller's recording metadata and
+   * should be shown. When false, initial lookup can silently confirm expected
+   * absence. Actual faults and failures after successful playback remain visible.
    */
   readonly knownToExist: boolean;
   /**
-   * The project this conversation is in, where the surface is inside one.
-   *
-   * **A run's evidence page names it and a transcript does not**, which is the
-   * same split `knownToExist` draws and for the same reason: one surface is a
-   * page inside a project and the other is the organization's. The recording
-   * route narrows by the acting project, and a session's acting project is the
-   * organization's *first* — so a run in any other project asked for its audio,
-   * was told there is no such conversation, and showed a page with a transcript
-   * on it and no player. The evidence page had loaded perfectly, because its
-   * own read does name the project.
+   * Project context for recording lookup. Both simulation evidence and transcript
+   * pages pass their project so a session default cannot select the wrong one.
    */
   readonly project?: string | undefined;
 };
 
 /**
- * **The page fetches its own link rather than carrying one**, and that is what
- * keeps both of these addresses shareable. A link to a recording is signed,
- * short-lived and bound to one object; baking one into a page's own answer
- * would put a credential in the address bar, make the page stale a quarter of an
- * hour after it loaded, and mean that a run of two hundred conversations minted
- * two hundred links to serve the one somebody wanted.
- *
- * The audio itself goes from the store straight to this element and never
- * through egma, which is what makes seeking cost nothing: dragging the scrubber
- * is a byte range the store serves.
+ * Resolve short-lived signed URLs when needed instead of storing them in
+ * shareable page URLs. The browser fetches audio and seek ranges from storage.
  */
 export function RecordingPlayer({
   simulationId,
@@ -218,18 +152,9 @@ export function RecordingPlayer({
   }, [simulationId, project, asked]);
 
   /**
-   * A replacement link is loaded because it is a replacement, not because it
-   * happens to read differently.
-   *
-   * A signature is stamped to the second, so a link asked for again inside the
-   * same second as the one it replaces comes back **byte for byte identical** —
-   * same instant, same expiry, same signature. React then sets `src` to the
-   * string it already holds, the DOM does not change, no request is made, and
-   * the recovery below quietly does nothing at all. Which is the whole failure
-   * it was written to fix, hiding behind a string comparison.
-   *
-   * So a retry says `load()` out loud. It is skipped on the first resolve,
-   * where the element loads on its own and calling this would fetch twice.
+   * Call load() on retries even if src is unchanged: signatures issued in the
+   * same second may produce identical URLs. Skip it on initial resolution to
+   * avoid a duplicate load.
    */
   useEffect(() => {
     if (playable.status !== "ready" || asked === 0) return;
@@ -276,22 +201,9 @@ export function RecordingPlayer({
         preload="metadata"
         src={playable.url}
         data-recording="true"
-        // A link lives a quarter of an hour and a page left open for an
-        // afternoon outlives it: the next seek comes back refused, and what a
-        // person sees is a scrubber that stopped for no stated reason.
-        //
-        // **One retry, asked for unconditionally, and only the second failure
-        // is believed.** The obvious version of this compares the link's expiry
-        // to `Date.now()` and refreshes only past it — and that is wrong,
-        // because `Date.now()` is the *reader's* clock: a browser a few minutes
-        // slow decides a dead link is still good and never asks again, which is
-        // exactly the failure this is here to fix, now reachable only by people
-        // whose laptops are wrong. A link is cheap and a second one settles it,
-        // so nothing here reasons about time at all.
-        //
-        // It cannot loop: the retry flag is set before asking and cleared only
-        // by a load that worked, so a store that is genuinely gone costs two
-        // requests and then says so.
+        // Retry once after a playback error without relying on the browser clock to
+        // diagnose expiry. Set the retry flag before requesting; reset it only after
+        // a successful load so repeated failures cannot loop.
         onError={() => {
           if (isASecondTry.current) {
             return setPlayable({ status: "unplayable" });
@@ -322,16 +234,8 @@ export function RecordingPlayer({
 }
 
 /**
- * A refusal, said where the player would have been.
- *
- * It keeps the standing-off room the player's own section has, because it
- * stands in the same place: what sits above it is a strip of facts, and a
- * sentence pressed against the edge of one reads as part of it. That spacing
- * used to be a sibling rule in the transcript stylesheet — the notice was
- * spaced by whatever happened to precede it — which meant the same refusal was
- * spaced differently depending on whether the exchange had been graded. The
- * shared notice still owns everything else: the edge, the tone, and telling
- * somebody who is not looking at the screen.
+ * Keep refusal spacing consistent with the player section, independent of
+ * which facts or grades precede it.
  */
 function Said({ children }: { readonly children: string }) {
   return (

--- a/apps/web/app/reset-password/page.tsx
+++ b/apps/web/app/reset-password/page.tsx
@@ -10,23 +10,9 @@ import { Field } from "../../ui/form.tsx";
 import { AuthForm, AuthShell, LinkLine, Notice, StatePage } from "../ui.tsx";
 
 /**
- * The page behind the link, and it asks for one thing.
- *
- * A new password, and nothing else. The link already names the account, so
- * there is no address to type and nothing to get wrong — the same reason the
- * invitation page shows the address rather than asking for it.
- *
- * **A link somebody already used says so**, because "you already did this, so
- * sign in" and "nothing happened at all, so ask for another" are opposite
- * instructions. The API decides which, and this page never guesses between them.
- *
- * **Once the hour is up the API can no longer tell which**, and that has a page
- * of its own for the same reason: a page that picked the likelier one would
- * tell half the people holding such a link to go on using a password that no
- * longer works. So it says both, and what to do either way.
- *
- * Setting the password does not sign anybody in. Two steps a person can see is
- * better than one they cannot, and using the password is what proves it works.
+ * Ask only for a new password; the link identifies the account. Display the
+ * API's used, expired, or invalid-link state without inferring it locally.
+ * Successful reset still requires sign-in.
  */
 
 type Refused = {

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -19,16 +19,8 @@ import { SessionLoading } from "../../ui/session-loading.tsx";
 import { AuthForm, AuthShell, LinkLine, Notice, StatePage } from "../ui.tsx";
 
 /**
- * Signing up: one page, one submit, and an organization and a project at the
- * end of it.
- *
- * Both names arrive filled in and both are editable. Nothing here asks a person
- * which project they mean before they have one, which is the form that would
- * spend the ten minutes the product is judged on.
- *
- * Every path on this page is relative, so the pages are served from whatever
- * origin the instance runs on and never from a domain egma runs. A self-hoster
- * depends on nothing they do not operate in order to log in.
+ * Submit signup with editable organization and project names. Use relative
+ * paths so the flow stays on this deployment's origin.
  */
 
 type Availability = { open: boolean; message?: string };

--- a/apps/web/app/ui.tsx
+++ b/apps/web/app/ui.tsx
@@ -7,29 +7,8 @@ import { cn } from "@/lib/utils";
 import { useTheme } from "../ui/theme.tsx";
 
 /**
- * The access pages' own shell, and nothing else.
- *
- * Signing in, signing up, accepting an invitation and authorizing a terminal
- * are not product pages: nobody has a project yet, there is nothing to navigate
- * between, and the page is the whole of what somebody is doing. They keep the
- * large type `DESIGN.md` reserves for auth, onboarding and public pages.
- *
- * **One column, centred, and nothing beside it.** The surface used to be a
- * split screen — a brand panel on the left with a canvas of drifting dots
- * behind it, the work on the right. The 2026-08-23 look is the opposite of
- * that: Neutral Paper, one Pure Paper panel inside a hairline with no corner
- * and no shadow, the wordmark and one quiet sentence above it, and a single
- * entrance. Nothing else on the page moves.
- *
- * **Everything a signed-in product page is drawn inside lives in `ui/`** — the
- * compact shell, the selector, the navigation, the page states, the lists and
- * the controls. This file re-exports the four pieces that pages already name so
- * that a page composes its own subject and never its own frame.
- *
- * **The controls here are the product's controls.** This surface once carried
- * its own `Button`, `TextInput` and `Field`; they are gone, and what is left is
- * composition — a shell, a panel, a notice and a line of links. There is one
- * control vocabulary in this product and it is the shadcn base.
+ * Compose access pages in a centered shell with shared product controls.
+ * Signed-in product navigation and page layouts live in ui/.
  */
 export {
   AppShell,
@@ -43,20 +22,8 @@ export {
 const STATEMENT = "Trust the voice agents you ship in production.";
 
 /**
- * The full Egma logo, which belongs here and in the signed-in sidebar.
- *
- * 32px tall, and only that: the width comes off the SVG's own viewBox, the way
- * the signed-in sidebar's copy of this mark takes it. A number in the class
- * list would be a second declaration of the logo's proportion, and a logo has
- * exactly one. It is left-aligned to the panel's edge and is deliberately
- * **not a link**: signed
- * out, `/` sends everybody straight back to `/sign-in`, so a link here would be
- * a control that reloads the page somebody is already on.
- *
- * The dark-theme treatment is an arbitrary variant rather than a `dark:` one
- * because this product has no `dark:` variant: every other surface changes with
- * the token values, and a two-colour SVG has no token to change. `data-theme`
- * is written on the document element, so the ancestor selector is the theme.
+ * Set logo height and let the SVG preserve its aspect ratio. Keep it unlinked
+ * on access pages. The document data-theme selector handles the two-color SVG.
  */
 export function Brand() {
   return (
@@ -120,17 +87,8 @@ export function ThemeToggle() {
 }
 
 /**
- * A quiet line of links under an access panel: the way to sign up, the way back
- * to signing in, the way to ask for another link.
- *
- * It is a component rather than a class list repeated eleven times because the
- * link inside it carries five decisions — the Ember underline, the offset, the
- * thickening on hover, the 44px target a coarse pointer needs, and the press
- * feedback — and a page that wrote four of them would look right.
- *
- * The two spacing rules are relationships rather than properties: the first
- * line after a form is separated from it by a rule, and a second line follows
- * the first more closely than it follows the form.
+ * Share access-page links, interaction targets, and spacing. Separate the
+ * first link row from the form and place subsequent rows closer together.
  */
 export function LinkLine({ children }: { readonly children: ReactNode }) {
   return (
@@ -164,23 +122,8 @@ export function LinkLine({ children }: { readonly children: ReactNode }) {
 }
 
 /**
- * The fields of an access page, in a column.
- *
- * **The shared `Form` draws a card, and this surface is already one.** The old
- * arrangement kept it and then reached into it from the access stylesheet —
- * `.authCard form { border: 0; background: transparent; … }` — to undo four of
- * its five declarations. That is a route styling the inside of a shared
- * component, which is the thing this migration exists to remove, and it stopped
- * working the moment the card became Tailwind.
- *
- * So the access surface composes its own form. What is left after the undoing
- * was a flex column and one gap, and that is what this is.
- *
- * **A notice inside it pays the gap once.** `Notice` carries its own bottom
- * margin, because on two access pages it stands over a fact list or a lone
- * button rather than over a form. Inside this column that margin lands on top
- * of the flex gap and opens 40px where the rhythm says 20, so the form — the
- * one element that can see it is a row among rows — takes it back.
+ * Use a plain form column inside the existing access card. Remove a notice's
+ * bottom margin here so it does not add to the form gap.
  */
 export function AuthForm({
   onSubmit,
@@ -203,19 +146,9 @@ export function AuthForm({
 }
 
 /**
- * The access composition: the wordmark, one sentence, and the panel that holds
- * the work — one centred column on Neutral Paper.
- *
- * **The whole column enters once and nothing else ever moves.** Opacity and 8px
- * of travel on the dialog's own duration, drawn by `@starting-style` rather
- * than by a script, so nothing decides at runtime whether this page is visible:
- * a browser without it draws the column already arrived, which is the only
- * failure a sign-in page is allowed to have. Reduced motion keeps the fade and
- * drops the travel.
- *
- * The panel is `--surface` inside a 1px hairline with **no corner and no
- * shadow**. `DESIGN.md` gives the shared shadow to menus, sheets and dialogs —
- * surfaces that sit *over* something. This one floats over nothing.
+ * Access shell with one entrance transition. @starting-style falls back to
+ * visible content; reduced motion removes travel. The panel uses a hairline
+ * without the shadow reserved for overlays.
  */
 export function AuthShell({
   eyebrow,
@@ -270,16 +203,7 @@ export function AuthShell({
             "max-[620px]:p-6",
           )}
         >
-          {/*
-           * The eyebrow, the title and the lead are one block with one rhythm,
-           * so a page with no eyebrow or no lead is spaced by what it has
-           * rather than by a margin written for the page that has both.
-           *
-           * The 32px under the block is a relationship rather than a property:
-           * it is paid only when there is something below to pay it to, which
-           * is what keeps a bare loading state from ending in a band of
-           * nothing.
-           */}
+          {/* Space the heading block from content only when content follows it. */}
           <div className="flex flex-col gap-3 [&:not(:last-child)]:mb-8">
             {eyebrow === undefined ? null : (
               <p className="m-0 text-sm tracking-(--tracking-label) text-faint uppercase">
@@ -321,17 +245,8 @@ export function StatePage({
 }
 
 /**
- * One thing worth saying above the form it is about.
- *
- * The tone decides the edge and the announcement, never the words: an error is
- * an `alert` because somebody has to hear it without looking, and a neutral
- * notice is neither, because a page that announces everything announces
- * nothing.
- *
- * `data-slot` is on it because the transcript pages space themselves against a
- * notice from their own stylesheet, and a class name they cannot see is not
- * something they can point at. `AuthForm` uses the same handle to take the
- * bottom margin back inside a gapped column.
+ * Errors use alert semantics; neutral notices do not. The data-slot allows
+ * composition-specific spacing, including removal of margin inside AuthForm.
  */
 export function Notice({
   tone = "neutral",

--- a/apps/web/components/ui/badge.tsx
+++ b/apps/web/components/ui/badge.tsx
@@ -5,20 +5,8 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * The chip, square like everything else.
- *
- * The variant names are the meanings rather than shadcn's `default`,
- * `secondary` and `destructive`. A chip in this product usually carries a
- * product result — success, warning, failure — and `DESIGN.md` is exact about that
- * being said in words with colour only supporting it. A name like `secondary`
- * would let a failed run be labelled with whatever colour happened to be
- * second, so those names are deliberately absent.
- *
- * There is no brand variant, for the same reason: "Brand orange does not mean
- * passed, failed, skipped, or errored."
- *
- * The chip carries the word; the caller supplies the icon or shape beside it
- * where the state needs one.
+ * Use semantic tones for status badges and let text carry the meaning.
+ * Brand color is not a result state; callers supply supporting icons when needed.
  */
 const badgeVariants = cva(
   [
@@ -35,15 +23,8 @@ const badgeVariants = cva(
         failure: "border-failure-border text-failure",
       },
       /*
-       * Two shapes, and the second one is a chip that holds a number.
-       *
-       * `verdict` is the chip this product has always drawn: a word in
-       * letter-spaced capitals, at the dense control height. `count` is the
-       * overflow chip the boards put at the end of a cell that ran out of room
-       * (`719-0`) — "+3", 22px tall on the quiet neutral surface, in ordinary
-       * sentence case because it is a number and capitals would say nothing.
-       * It is deliberately not a variant of the colour axis above: a count
-       * carries no verdict, and the colours there all do.
+       * Keep shape separate from tone: verdict uses a compact uppercase label,
+       * while count preserves ordinary text for numbers and identifiers.
        */
       shape: {
         verdict: "min-h-(--control-sm) px-3 tracking-(--tracking-label) uppercase",

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -5,33 +5,9 @@ import { useId, type ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * The three kinds of button `DESIGN.md` names, plus the destructive one.
- *
- * The variant names are shadcn's, so a component pasted from the registry
- * arrives already dressed. What each name *draws* is egma's: `default` is the
- * wash primary, `secondary` and `outline` are both the one outlined kind
- * `DESIGN.md` describes, and `ghost` and `link` are both the quiet action.
- * shadcn's own `secondary` — a filled grey button — is a look this product does
- * not have, so no name produces it.
- *
- * **`default` is the wash button, and it replaced a Deep Ember block.** The
- * boards draw the one action a page offers as Ember Wash behind Deep Ember
- * text on a neutral hairline (`71O-0` on the agents board, `7DC-0` in the side
- * sheet's footer), 36px tall with 16px of side padding. The developer ruled on
- * 2026-08-23 that this *is* the primary action and retired the filled one, so
- * no variant name produces a Deep Ember block any more. Hover and press move
- * both halves one step: the fill takes a little more Ember, the ink takes the
- * darker Ember steps `DESIGN.md` already named for a primary's feedback.
- *
- * **Sizes are 32 / 36 / 44, and 36 is the default.** The board's toolbar
- * control is 36px and its form control is 44px, so `default` is the toolbar's
- * and `lg` is the one a sheet or a dialog footer wears. A 36px button is under
- * the 44px `DESIGN.md` asks of a coarse pointer, so the base puts that back on
- * every touch screen — the same trade the sidebar row already makes.
- *
- * Every value here is a theme key, and every theme key reads one of egma's
- * own declarations in `tailwind-theme.css`. Nothing here holds a colour, a
- * size, a radius or a duration of its own.
+ * Map registry-compatible variants to Egma's primary, outlined, quiet, and
+ * destructive styles. Default size fits toolbars; lg fits forms. Coarse
+ * pointers retain the minimum tap target through shared theme values.
  */
 const buttonVariants = cva(
   [
@@ -72,15 +48,8 @@ const buttonVariants = cva(
           "active:bg-primary-wash-pressed active:text-primary-pressed",
         ],
         /*
-         * Secondary: transparent with a one-pixel Midnight Ink border.
-         *
-         * Hover raises the border to `--foreground` as well as the fill. In
-         * light theme that is invisible — `--border-strong` and `--foreground`
-         * are both Midnight Ink — which is exactly why it went missing: the
-         * CSS Modules button it replaces said it out loud, and dark theme is
-         * where the two part company (`#4a4a44` against `#f2f2ed`). Without
-         * it a quiet button in dark theme answered a hover with a fill change
-         * and a border that stayed put.
+         * Raise the secondary border on hover as well as its fill. Border and
+         * foreground tokens differ in dark mode.
          */
         secondary: [
           "border border-border-strong bg-transparent text-foreground",
@@ -128,17 +97,8 @@ const buttonVariants = cva(
 );
 
 /**
- * Why a control is not available, said where anybody can find it.
- *
- * **A disabled button cannot take focus, so a tooltip on one is a reason only
- * a mouse can reach.** The developer's decision was to *disable rather than
- * hide* precisely so a viewer is told why an action is not theirs — and a
- * reason half the people using egma cannot get to does not deliver that
- * decision, it only looks like it does.
- *
- * So the sentence is written on the page beside the control, and the control
- * points at it with `aria-describedby`. It stays a `title` as well, because a
- * pointer user hovering is a real way to ask.
+ * Show disabled-action reasons beside the control and associate them with
+ * aria-describedby. A title alone is not accessible to keyboard users.
  */
 function WhyNot({ id, why }: { readonly id: string; readonly why: string }) {
   return (
@@ -149,30 +109,9 @@ function WhyNot({ id, why }: { readonly id: string; readonly why: string }) {
 }
 
 /**
- * The button, and the two things this product's buttons have always carried
- * that the registry's does not.
- *
- * `busy` and `why` are **optional and default to what a stock shadcn button
- * does**, so every existing caller compiles and draws unchanged. They are here
- * rather than at each call site because both are product decisions written down
- * in `DESIGN.md` and in the permission model, and both are the kind of decision
- * that is quietly lost when it is copied to forty places:
- *
- * - **`busy`** is a write in flight. The control stays visible, named, and
- *   inert until it settles, and says so to assistive technology rather than
- *   only to the eye.
- * - **`why`** is why an action is not this person's. It disables the control
- *   *and* writes the sentence beside it, because a disabled button cannot take
- *   focus and a `title` alone is a reason only a pointer can reach.
- *
- * Neither is authorization. The server checks the same permission on every
- * request and refuses a viewer's write whether or not a browser was involved.
- *
- * **`type` is deliberately not defaulted**, which is the registry's behaviour
- * and not this product's old one. A `<button>` inside a `<form>` submits it
- * unless it says otherwise, so every caller says which it is. The CSS Modules
- * button defaulted to `type="button"`; a migration that leans on that default
- * instead of saying the word turns a Remove control into a form submission.
+ * busy keeps an in-flight action inert and announced; why disables it with
+ * a visible explanation. Neither replaces server authorization.
+ * No type default is set, so callers must specify button versus submit in forms.
  */
 function Button({
   className,

--- a/apps/web/components/ui/card.tsx
+++ b/apps/web/components/ui/card.tsx
@@ -3,16 +3,8 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * A Pure Paper group at the 12px card radius.
- *
- * No shadow: "Tables, sidebars, inputs, and ordinary cards do not float." The
- * structure comes from the border and the change of surface, which is what
- * keeps a page of cards readable when there are twenty of them.
- *
- * The `m-0` on the title and the description is not decoration. Tailwind's
- * reset removes every default margin and `globals.css` gives those defaults
- * back for the CSS Modules pages that still expect them, so a heading or a
- * paragraph inside a new component has to say it wants none.
+ * Bordered card using the shared shape and surface tokens.
+ * Reset title and description margins so base typography adds no spacing.
  */
 function Card({ className, ...props }: ComponentProps<"div">) {
   return (

--- a/apps/web/components/ui/checkbox.tsx
+++ b/apps/web/components/ui/checkbox.tsx
@@ -4,28 +4,9 @@ import { useFieldHint } from "@/ui/field-hint.ts";
 import { cn } from "@/lib/utils";
 
 /**
- * One binary choice: whether a grader can fail a run, whether a list includes
- * what has been archived.
- *
- * **It is the browser's own checkbox**, for the reasons written on `select.tsx`
- * and one more of its own: the registry's Radix checkbox is a `<button>` with
- * `role="checkbox"`, so it carries no `checked` property, submits nothing with
- * a native form, and is not the element a person's assistive technology has
- * been taught. `accent-color` is what dresses it, which keeps the platform's
- * own indeterminate and focus behaviour and costs nothing.
- *
- * **The box is 18px and the target is 44px, and they are deliberately not the
- * same number.** `DESIGN.md` asks for a 44px pointer target on a coarse
- * pointer; it does not ask for a 44px checkbox, and an 18px box is what this
- * control has always drawn. So the label wrapper — which is the target,
- * because a label activates the control it wraps — grows to the tap target on
- * a coarse pointer and stays at the box's size on a fine one. The box is
- * centred in it either way, so a mouse sees no change at all.
- *
- * This was carried over at 18px by the wave that wrote this file and flagged
- * for the developer, who approved the fix. Callers with visible copy still
- * keep that copy visible and point at the control with `htmlFor`, which makes
- * the whole label a target as well.
+ * Use a native checkbox for checked state, form behavior, and platform
+ * interaction. The wrapper supplies the coarse-pointer target while keeping
+ * the visible box compact; callers still associate visible labels.
  */
 function Checkbox({ className, ...props }: ComponentProps<"input">) {
   const hint = useFieldHint();

--- a/apps/web/components/ui/command.tsx
+++ b/apps/web/components/ui/command.tsx
@@ -6,31 +6,9 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * A list somebody types to narrow, and the rows it narrows to.
- *
- * **This is the kit's combobox, and what it buys is the keyboard.** The product
- * already had a search-and-tick panel — the tests grid's persona picker — built
- * by hand: a text field, a `.filter()`, and a column of checkboxes. It worked
- * with a mouse and it was a wall to anybody driving with a keyboard, because
- * every row was its own Tab stop and nothing linked the field to the list it
- * was narrowing. `cmdk` owns that relationship: the field keeps focus, the
- * arrow keys walk the filtered rows underneath it, and the active row is
- * published as `aria-activedescendant` so a screen reader is told which row the
- * typing is pointing at.
- *
- * **`role` here is `listbox`, not `menu`.** `ui/menu.tsx` says why in its own
- * words — a panel with something to type in is not a list of commands — and the
- * same rule decides this file. `cmdk` writes the listbox and option roles, and
- * the panel around it is a `dialog`, which is what `PopoverContent` is given.
- *
- * **Filtering stays with the caller.** `shouldFilter` is off, because the one
- * list this draws is narrowed against the server's own page-by-page read and a
- * second, hidden filter inside the widget would disagree with the count the
- * panel prints. The rows handed in are the rows drawn.
- *
- * No `CommandDialog` here. shadcn ships one for a page-wide palette; this
- * product has no such surface, and an export nothing renders is a component
- * that rots.
+ * Use cmdk for combobox/listbox relationships and keyboard selection. Disable
+ * its internal filter because callers supply server-filtered rows; filtering
+ * again could hide results without changing the displayed count.
  */
 function Command({
   className,
@@ -101,17 +79,8 @@ function CommandGroup({
 }
 
 /**
- * One row.
- *
- * The highlight is `data-[selected=true]`, which is `cmdk`'s word for "the row
- * the arrow keys are on" and not for "the row somebody ticked". A multi-select
- * has both states at once, so they are drawn by different things: the pointer
- * and keyboard highlight is this background, and whether a row is chosen is
- * said by `aria-checked`, which `role="option"` supports and which `cmdk` does
- * not touch. Reading the highlight as the answer is the mistake this comment
- * exists to stop, and the reason a caller ticking rows must set `aria-checked`
- * itself: a checkbox drawn inside the row is a picture, and the row is the
- * control a screen reader is on.
+ * cmdk selected state is the active keyboard/pointer row, not multi-selection.
+ * Callers must set aria-checked for chosen options independently of the highlight.
  */
 function CommandItem({
   className,

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -7,27 +7,9 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * The centered modal layer, drawn the way the confirm boards draw it.
- *
- * 480px wide, 24px of padding, a 20px column gap, the shared orange-brown
- * shadow over a neutral hairline and no corner at all — read off `BEM-0` and
- * `BMT-0` with `get_computed_styles` on 2026-08-23. The header is a title with
- * a close beside it over a hairline; the footer is the answer and the way out,
- * in that order, at the left. The boards put 28px of padding on the panel and
- * this is 24: 28px is off `DESIGN.md`'s 4px spacing list, and the ticket rounds
- * it to the step that is on it.
- *
- * Radix supplies what `DESIGN.md` requires of a dialog and a hand-written one
- * keeps getting wrong: focus is trapped, the page behind it is inert, Escape
- * closes it, and the exact opener is focused again afterwards.
- *
- * The entrance and the exit are not here. They are in `tailwind-theme.css`,
- * keyed on `data-slot` and `data-state`, so the motion is a property of the
- * theme rather than a class list each dialog has to remember — and so the exit
- * is a CSS animation, which is what Radix waits for before unmounting.
- *
- * A destructive dialog still has to name the agent, test, persona, grader, key,
- * invitation, run, or project it is about. No component can do that for it.
+ * Shared dialog primitives with theme-owned dimensions and motion. Radix
+ * manages modal behavior and exit presence; callers supply meaningful titles
+ * and name the affected record in destructive confirmations.
  */
 function Dialog(props: ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
@@ -117,17 +99,8 @@ function DialogContent({
 }
 
 /**
- * The head of a dialog, and the hairline the boards draw under it.
- *
- * `BK0-0` measures 16px of padding under the title and a 1px `--border` rule
- * across the panel's inner width — the same on `BEM-0`, `BMT-0` and `C8F-0`.
- * Nothing here drew it, and no caller could add it (`ui/dialog.tsx` takes no
- * class for its head), so one screen reached for a `Separator` as the panel's
- * first child instead. It belongs on the head, once.
- *
- * A column rather than the board's row: the close control is placed by
- * `DialogContent`, against the panel, so that a head with two lines in it does
- * not move the ✕ down the corner.
+ * Keep the title divider in the shared header. The close button is positioned
+ * by DialogContent so multiline titles do not move it.
  */
 function DialogHeader({ className, ...props }: ComponentProps<"div">) {
   return (

--- a/apps/web/components/ui/dropdown-menu.tsx
+++ b/apps/web/components/ui/dropdown-menu.tsx
@@ -7,24 +7,9 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * The menu, on Pure Paper with the shared orange-brown shadow.
- *
- * Two things here are `DESIGN.md` rather than shadcn. The highlighted item — the
- * one under the pointer or the arrow keys — uses the quiet neutral mix, because
- * that is a hover and not a selection. A *selected* item, the one that is
- * currently true, uses Ember Wash and a mark beside it, because "the active item
- * uses Ember Wash and a small Ember mark" and because state is never colour
- * alone. shadcn spends one colour on both and would have said "hovered" and
- * "chosen" the same way.
- *
- * Items are 36px, which is what the boards draw (`9AH-0`), and 44px wherever
- * the pointer is coarse — the same trade every dense control in this product
- * makes. The panel holds them on 4px of padding.
- *
- * The transitions name their properties. `transition-colors` would include
- * `outline-color`, and an item reached with the arrow keys would then fade its
- * focus ring in rather than showing it — motion on keyboard navigation, which
- * `DESIGN.md` forbids.
+ * Distinguish highlighted items from selected items: selection adds a mark.
+ * Keep coarse-pointer targets large enough and transition only background and
+ * text colors so keyboard focus outlines appear immediately.
  */
 function DropdownMenu(
   props: ComponentProps<typeof DropdownMenuPrimitive.Root>,

--- a/apps/web/components/ui/input.tsx
+++ b/apps/web/components/ui/input.tsx
@@ -4,20 +4,9 @@ import { useFieldHint } from "@/ui/field-hint.ts";
 import { cn } from "@/lib/utils";
 
 /**
- * A text field at the 8px input radius.
- *
- * No focus style of its own: `globals.css` decides focus for every control in
- * the product from outside every cascade layer, so no class here can turn it
- * off. **A text field's focus is quiet** — its hairline darkens to ink, in
- * place, and it draws no ring (`DESIGN.md`, developer decision 2026-08-24).
- * The two-pixel Ember indicator is still what every other control wears.
- *
- * **A field inside a `Field` describes itself with that field's hint.** The id
- * arrives through context rather than through a prop, because a caller wiring
- * `aria-describedby` by hand forgets exactly the fields nobody checks — the
- * page still looks right without it. An `aria-describedby` passed in wins,
- * because a field being refused has something more urgent to say than what to
- * write in it.
+ * Use shared text-field focus styling and inherit the enclosing Field hint.
+ * An explicit aria-describedby overrides the inherited hint, for example to
+ * name a validation error.
  */
 function Input({ className, type, ...props }: ComponentProps<"input">) {
   const hint = useFieldHint();

--- a/apps/web/components/ui/label.tsx
+++ b/apps/web/components/ui/label.tsx
@@ -6,21 +6,8 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * The visible name of a control.
- *
- * `DESIGN.md`: "Keep labels visible. Placeholder text is not a label." So this
- * is drawn rather than hidden, at the 14px step and at weight 500 — the weight
- * the type rules reserve for compact labels, and the highest weight this
- * product has.
- *
- * Radix rather than a plain `<label>` for one behaviour a plain one gets
- * wrong: a double click on a label selects the words around it, which is what
- * a person sees when they meant to select the value in the field. Radix
- * suppresses that and leaves the click-to-focus a label is for.
- *
- * No focus ring here. `globals.css` draws the two-pixel Ember indicator on
- * every focusable element from outside every cascade layer, so no component in
- * this directory carries one of its own.
+ * Keep control labels visible. Radix preserves click-to-focus while suppressing
+ * accidental text selection on repeated label clicks.
  */
 function Label({
   className,

--- a/apps/web/components/ui/popover.tsx
+++ b/apps/web/components/ui/popover.tsx
@@ -6,42 +6,9 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * A small anchored surface on Pure Paper.
- *
- * It grows from the control that opened it. Radix measures that origin and
- * publishes it as `--radix-popover-content-transform-origin`;
- * `tailwind-theme.css` reads it, so "menus and popovers scale from the trigger
- * origin" is true here without any popover being told about it.
- *
- * **The panel is bounded here rather than by each caller, because Radix
- * publishes the room it has and never uses it.** Radix measures
- * `--radix-popover-content-available-height` on every placement and writes it
- * to the element, and then reads it back nowhere: the string `maxHeight` does
- * not occur in `@radix-ui/react-popper` at all. So a panel is exactly as tall
- * as its content unless somebody says otherwise. `ui/menu.tsx` said so; this
- * file did not, and the agents list found the gap. An agent with enough
- * connections opened a `+N` panel taller than the window, over an
- * `overflow: visible` that gave it no way to scroll, so the rows past the edge
- * could not be reached at all. That is the select picker's fault again, and
- * worse — the picker at least scrolled.
- *
- * So the cap belongs to the primitive. A caller that forgets is the normal
- * case, and forgetting should cost nothing. The value is `ui/menu.tsx`'s own —
- * the room Radix measured, less the theme's smallest step, so the panel keeps
- * a gap off the edge it was pushed against instead of sitting flush on it.
- *
- * `overflow-x` is pinned to `hidden` rather than left alone: a single axis set
- * to `auto` computes the other from `visible` to `auto` as well, which hangs a
- * horizontal scrollbar under a menu that never needed one.
- *
- * **`collisionPadding` is the same gap, on the other axis.** Radix shifts a
- * panel back inside the window when it would overflow, and it shifts it to
- * exactly the edge: the default padding is zero. A 300px panel opened from a
- * column near the right of a 640px screen therefore landed flush, with its last
- * column of text and the underline of its Done touching the window — the same
- * cut-off look the select picker shipped, one axis over. Eight pixels, matching
- * the picker's own margins, so a panel pushed against an edge still reads as a
- * panel.
+ * Use Radix's measured transform origin and available height. Cap the panel
+ * and enable vertical scrolling so long lists remain reachable; hide horizontal
+ * overflow and reserve collision padding from viewport edges.
  */
 function Popover(props: ComponentProps<typeof PopoverPrimitive.Root>) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />;

--- a/apps/web/components/ui/progress.tsx
+++ b/apps/web/components/ui/progress.tsx
@@ -6,34 +6,9 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * The bar that explains completion.
- *
- * `DESIGN.md` gives this component one line — "Progress: explain completion —
- * transform-based fill, linear while active" — and the registry's version keeps
- * only the first half of it. What arrives from shadcn fills on `transition-all`
- * with the default easing, which is `all` (forbidden outright) decelerating
- * (which lies about the rate of the work). Both are fixed here.
- *
- * **It is dressed to meet `RunProgress`, not to copy it today.**
- * `ui/run-status.tsx` already draws this product's progress bar, and every
- * decision it made that `DESIGN.md` backs is taken here too: a neutral track,
- * an ink fill, the chip radius, 200ms linear, and no movement under reduced
- * motion.
- *
- * **One measurement differs on purpose.** `RunProgress` is `h-1.5`, which is
- * 6px and not on the 4px grid `DESIGN.md` sets; a general primitive has no
- * business starting off the grid, so this is `h-2`. The two are therefore 2px
- * apart until `RunProgress` moves onto this primitive, and adopting the 8px is
- * the change that migration should make rather than an override it should
- * carry. `run-status.tsx` is outside this ticket's fence, so it is named here
- * instead of edited.
- *
- * The fill is `--foreground` rather than the brand orange, which is the choice
- * `RunProgress` already made and worth keeping deliberately: `DESIGN.md` spends
- * Ember on "focus, icons, marks, and narrow active edges" and Deep Ember on
- * "primary filled actions with white text". A bar that is neither reads as ink,
- * and ink is also the highest contrast available in both themes for a shape
- * that carries no text of its own.
+ * Theme-styled progress with an ink fill, transform-based updates, and linear
+ * easing while active. Reduced motion removes movement. This primitive has
+ * its own height; RunProgress is a separate composition.
  */
 function Progress({
   className,
@@ -42,15 +17,8 @@ function Progress({
   ...props
 }: ComponentProps<typeof ProgressPrimitive.Root>) {
   /*
-   * `max` honoured, which the registry's version drops.
-   *
-   * Radix reads `max` — it puts it on `aria-valuemax` and decides `data-state`
-   * with it — but the indicator shadcn ships computes `100 - value`, so it only
-   * ever agrees with the label when `max` happens to be 100. A caller counting
-   * three onboarding stages says `value={1} max={3}`, is announced as "1, out of
-   * 3", and is drawn at one percent. The eye and the screen reader must not be
-   * given two different answers, so the share is computed the same way Radix
-   * computes the one it announces.
+   * Compute the fill using max as well as value so its visual fraction agrees
+   * with the accessible progress value.
    */
   const ceiling = typeof max === "number" && max > 0 ? max : 100;
   const filled =
@@ -68,17 +36,7 @@ function Progress({
     <ProgressPrimitive.Root
       data-slot="progress"
       className={cn(
-        /*
-         * "Quiet hover, read-only, progress, and supporting surfaces use a
-         * neutral Graphite-and-Paper mix." That mix is `--surface-soft`.
-         *
-         * The track is square, like every other component: the 2026-08-23
-         * ruling collapsed the radius table to one line and a progress bar is
-         * a component rather than a shape. The paragraph below about a round
-         * cap is kept because the mechanism it argues for is still the right
-         * one — a `translateX` inside a clipping track survives a cap of any
-         * radius, including none.
-         */
+        /* Use a neutral track and let it clip the moving indicator. */
         "relative h-2 w-full overflow-hidden rounded-chip bg-surface-soft",
         className,
       )}
@@ -87,35 +45,16 @@ function Progress({
       {...props}
     >
       {/*
-       * Transform-based, and the transform is a `translateX` inside a clipping
-       * track rather than the `scaleX` `RunProgress` uses.
-       *
-       * Both are "transform-based fill". This one is the registry's, so a
-       * component pasted from shadcn lands on it unedited, and it is also the
-       * better of the two here: `scaleX` on a pill squashes the leading cap
-       * horizontally, while a full-width indicator slid left keeps its cap
-       * round and lets the track clip the other end.
+       * Translate a full-width indicator inside the clipping track to represent
+       * the completed share without changing its geometry.
        */}
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
         className={cn(
           "size-full rounded-chip bg-foreground",
           /*
-           * "Linear while active."
-           *
-           * Linear is the whole point: a fill that decelerates says the work is
-           * slowing down, and a bar that is still moving has no business
-           * claiming that. The easing turns over to `--ease-out` only on
-           * `data-state="complete"`, where a value settling into its final
-           * place is exactly what an ease-out describes.
-           *
-           * 200ms is written here rather than read from the theme, and it is
-           * the same non-token duration, for the same reason, as the one
-           * already written in `ui/run-status.tsx`: the motion tokens name
-           * interface motion — a press, a popover, a dialog — and this is a
-           * value catching up to a new value, which `DESIGN.md` gives a
-           * behaviour for and no token. It is under the 300ms ceiling. Called
-           * out in the pull request for the developer to overrule.
+           * Use a short linear transition while active, then ease into completion.
+           * This smooths reported values and does not estimate the rate of work.
            */
           "transition-transform duration-200 ease-linear",
           "data-[state=complete]:ease-out",

--- a/apps/web/components/ui/radio-group.tsx
+++ b/apps/web/components/ui/radio-group.tsx
@@ -7,21 +7,8 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * Exactly one of a small closed set.
- *
- * Radix supplies the whole radio-group contract, which is the part a
- * hand-written group loses quietly: the group is one Tab stop, the arrow keys
- * move inside it and come back round, Home and End reach the ends, selection
- * follows focus, and every option reports `role="radio"` with `aria-checked`.
- * None of that shows in a screenshot, so none of it fails visibly when it is
- * dropped in a refactor.
- *
- * Radix moves focus in a task after the key, rather than during it, so React
- * has committed the new selection before anything is focused. A caller sees
- * `onChange` and then the focus move, in that order.
- *
- * No focus ring here: `globals.css` draws the two-pixel Ember indicator on
- * every focusable element from outside every cascade layer.
+ * Use Radix for single-choice state, roving focus, and keyboard handling.
+ * Focus appearance comes from the shared stylesheet.
  */
 function RadioGroup({
   className,
@@ -37,18 +24,8 @@ function RadioGroup({
 }
 
 /**
- * The two shapes one option is drawn in.
- *
- * The names are egma's, and they follow `button.tsx`: one primitive, more than
- * one thing it may look like, chosen by a named prop rather than by a class
- * list each caller reassembles. `dot` is the registry's radio — a small round
- * box beside its own label. `segment` is the joined strip a filter is drawn
- * as, where the option carries its own words.
- *
- * **`segment` is not a tab and not a toggle group.** Both would draw this, and
- * both would say something else about it: tabs name panels a page switches
- * between, and this switches which rows a table is asked for. What the radio
- * group says is what a person's assistive technology is told.
+ * Named visual variants retain radio semantics: dot for labeled options,
+ * segment for compact filters, and card for larger choices.
  */
 const radioItemVariants = cva(
   [
@@ -105,19 +82,8 @@ const radioItemVariants = cva(
           "data-[state=checked]:shadow-[inset_0_2px_0_var(--accent)]",
         ],
         /*
-         * **One option, drawn as the whole card.** The chosen one carries the
-         * narrow Ember edge this file already asks Ember for — on the leading
-         * edge, which is the edge a person reads first and the same edge the
-         * sidebar's active row marks itself with. It is drawn as an inset
-         * shadow rather than a border so the card never changes size between
-         * states: a border that thickened on selection would shift every word
-         * beside it by a pixel.
-         *
-         * The wash arrives with it, and the two together mean the state is
-         * never colour alone — the indicator's own filled ring says it a third
-         * time. `DESIGN.md` keeps one radius and it is 0, so this is square,
-         * and the only motion is the press scale the base already carries plus
-         * a quiet colour fade.
+         * Draw the selected edge as an inset shadow so selection does not change
+         * card dimensions. Keep the radio indicator as an additional state cue.
          */
         card: [
           "relative flex min-h-(--tap-target) w-full items-start gap-3 p-4 text-left",

--- a/apps/web/components/ui/select.tsx
+++ b/apps/web/components/ui/select.tsx
@@ -7,48 +7,9 @@ import { useFieldHint } from "@/ui/field-hint.ts";
 import { cn } from "@/lib/utils";
 
 /**
- * A choice among things egma already knows about — a voice provider, a
- * replacement persona, which measure a grader holds to a bound.
- *
- * **It is the browser's own select, and that is a decision rather than a
- * shortcut.** shadcn's registry select is built on Radix: a button that opens a
- * listbox drawn in a portal. It looks the same in every browser, and what it
- * costs is everything the native control already does for free — the platform
- * picker on a phone, the wheel on iOS, type-ahead, the operating system's own
- * assistive behaviour, and a `<select>` element that a form, a test and a
- * person driving with a keyboard all recognise. This product's selects have
- * always been native, every one of them is inside a form somebody has to be
- * able to fill in on a phone, and `DESIGN.md` asks for one semantic tree rather
- * than for a particular listbox. So the registry's *shape* is kept — one file
- * under `components/ui`, `data-slot`, `cn` over the caller's classes, every
- * value a theme key — and its Radix dependency is not.
- *
- * The chevron is shared in both themes. `globals.css` restyles the open picker
- * where a browser supports `appearance: base-select`, which is where that
- * belongs: one rule for every select in the product rather than a drawn arrow
- * on each one.
- *
- * The options always come from the server. A hand-written copy of a list the
- * server owns is a list that is wrong the day the server grows an entry, and
- * silently: the form would keep offering yesterday's choices and refusing
- * today's.
- *
- * **The three sizes are `Button`'s, and `default` is not the default here.** A
- * select is mostly a form field, so `lg` (44px, the form control) is what a
- * caller gets for saying nothing and every form is unchanged. But a select is
- * also a filter above a list and a control inside a row, and those are 36px —
- * so the height became a prop instead of something each caller wrote for
- * itself. The roster row had a 44px select standing a head above the two 36px
- * buttons beside it, which made every row of that table 60px tall.
- *
- * Two other screens keep a class list of their own for their toolbar filters,
- * and that one stays: it is shared with `Input`, and a text input cannot take
- * a `size` prop — `size` is already a native attribute there.
- *
- * The coarse-pointer minimum is not traded away for the smaller steps:
- * `pointer-coarse` puts the 44px target straight back, which is the trade
- * `Button` and the sidebar row already make — and which the copied class lists
- * were not making at all.
+ * Use native select behavior for forms, keyboard input, and platform pickers.
+ * Shared CSS styles the trigger and supported custom pickers. Callers supply
+ * options. Default to the larger form size; compact sizes retain coarse-pointer targets.
  */
 const selectVariants = cva(
   [

--- a/apps/web/components/ui/separator.tsx
+++ b/apps/web/components/ui/separator.tsx
@@ -6,26 +6,9 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * The neutral hairline that puts two groups of content apart.
- *
- * `DESIGN.md`: "Most structure comes from contrast and borders." A rule drawn
- * with this rather than with a `border-b` on whichever element happens to be
- * next to it says the line is a thing *between* two groups, so neither group
- * carries the other's boundary.
- *
- * **It defaults to decorative, and that default is the honest one.** A rule is
- * usually drawn because two groups look better apart, not because a reader who
- * cannot see it is missing a fact — and Radix publishes a decorative separator
- * as `role="none"`, so a screen reader is not told about a line that means
- * nothing. A separator that *does* carry meaning says `decorative={false}` and
- * becomes a real `role="separator"`.
- *
- * **Reach for a border instead when the rule changes edge with the viewport.**
- * Orientation here is a DOM attribute, so a rule that is horizontal in a column
- * and vertical once the same two groups sit side by side cannot be one element
- * — it would need a class to beat `data-[orientation=…]` at a width, and that
- * is a specificity race rather than a layout. `settings-nav.tsx` has exactly
- * that rule and keeps it as a border for this reason.
+ * Default visual separators to decorative. Use decorative=false for a
+ * semantic separator. Prefer responsive borders when the dividing edge changes
+ * with layout instead of changing this component's orientation.
  */
 function Separator({
   className,

--- a/apps/web/components/ui/sheet.tsx
+++ b/apps/web/components/ui/sheet.tsx
@@ -13,55 +13,12 @@ import {
 import { cn } from "@/lib/utils";
 
 /**
- * The panel that comes in from the right to create, read or edit one thing.
+ * Modal form sheet anchored to the right with shared dialog behavior and
+ * theme-owned motion. Use ui/dialog's nonmodal sheet for adjacent reading views.
  *
- * **This is the surface the boards choose over a page.** `77F-0` opens a
- * connection in it, `7E0-0` creates an agent in it, and the personas and tests
- * boards do the same with their own records — so a person stays on the list
- * they were reading while they work on one row of it. `DESIGN.md` records that
- * choice for agents, connections, personas and tests.
- *
- * Read off `7CD-0` with `get_computed_styles` on 2026-08-23: anchored to the
- * right edge, 440px wide, full height, Pure Paper behind a neutral hairline on
- * its left edge, the shared orange-brown shadow, a 20px column gap, and no
- * corner. The boards put 28px of padding on it; that is off `DESIGN.md`'s 4px
- * spacing list, so this is the 24px step that is on it — the same rounding the
- * confirm dialog makes.
- *
- * **It is the same Radix dialog the centred one is, and that is the point.**
- * Focus is trapped, the page behind is inert, Escape closes it and the exact
- * control that opened it is focused again afterwards. A hand-rolled drawer
- * loses every one of those quietly. What differs from `dialog.tsx` is where the
- * panel sits and how it arrives, and nothing else.
- *
- * **The motion is not here.** `tailwind-theme.css` keys the entrance, the exit
- * and the reduced-motion form of both on `data-slot` and Radix's `data-state`,
- * exactly as it does for the dialog, the popover and the drawer. The sheet
- * travels from its own edge on the drawer's tokens — 280ms in, 220ms out —
- * because that is the movement `DESIGN.md` gives an edge-attached surface, and
- * under reduced motion it stays put and fades.
- *
- * **`ui/dialog.tsx` also has a `sheet` kind, and the two are not the same
- * thing.** That one is a wide reading surface that deliberately leaves the page
- * behind it usable — the transcript beside its grader results. This one is a
- * modal form. Both are kept, and a caller choosing between them is choosing
- * whether the page behind stays reachable.
- *
- * **The panel is portaled inside `<main>`, not to `<body>`, and that is a
- * decision with a test behind it.** The browser walk reads whole screens as
- * `page.innerText("main")`, and the create, edit and read flows for agents,
- * connections, personas and tests are all moving into this panel. A panel
- * portaled to `body` is outside `main`, so every one of those reads would come
- * back without the thing the person is actually looking at — and the
- * expectation would be quietly false rather than loudly broken.
- *
- * `SheetHost` is what makes that possible: `ui/shell.tsx` renders one at the
- * end of every product page, and this file's portal aims at it. The panel is
- * still `position: fixed`, so the scrim covers the whole viewport including
- * the sidebar, which is outside `main` — the DOM position changes what a text
- * read finds, not where anything is drawn. With no host in the tree (a
- * component test rendering a sheet on its own) Radix falls back to `body`,
- * which is the behaviour that was there before.
+ * Portal to the product page's SheetHost inside main, with body as the fallback.
+ * This keeps form content within the page landmark while fixed positioning
+ * lets the overlay cover the viewport.
  */
 
 /**
@@ -104,19 +61,8 @@ function SheetClose(props: ComponentProps<typeof DialogPrimitive.Close>) {
 }
 
 /**
- * The portal, aimed at the page's own host — **and at `<body>` when there is
- * none.**
- *
- * The fallback is not a nicety. A component test renders one screen with no
- * shell around it, so no `SheetHost` is mounted and no container exists; a
- * portal that insisted on one would mount nothing at all, and every page test
- * that opens a sheet would fail to find a single control inside it. Radix's own
- * default for `container` is `document.body`, and `undefined` is how you ask
- * for it, so the fallback is the library's rather than a second code path
- * written here.
- *
- * A caller may still pass its own `container`; the spread is after this, so it
- * wins.
+ * Use the nearest page sheet host, falling back to Radix's body portal when
+ * none exists. An explicit caller container takes precedence.
  */
 function SheetPortal(props: ComponentProps<typeof DialogPrimitive.Portal>) {
   const root = useContext(SheetRootContext);
@@ -186,17 +132,8 @@ function SheetContent({
 }
 
 /**
- * The title, and the way out beside it.
- *
- * The close is drawn here rather than positioned over the panel's corner,
- * because that is what the board draws — one row, the title at the left and the
- * ✕ at the right, over the hairline that separates the head from the fields. An
- * absolutely placed close would have to be told the panel's padding, and would
- * be wrong the day the padding moves.
- *
- * It is a 44px target on every pointer. A close is the control somebody reaches
- * for when they have decided they are finished, and it is the one control in
- * the panel that has nothing beside it to catch a near miss.
+ * Place title and close control in one header row so padding changes keep
+ * them aligned. Preserve the close control's full tap target.
  */
 function SheetHeader({
   className,
@@ -306,15 +243,8 @@ function SheetBody({ className, ...props }: ComponentProps<"div">) {
 }
 
 /**
- * The bottom of the sheet: what this panel is for, the way out of it, and —
- * at the far end — the one destructive thing it offers.
- *
- * The split is the board's (`7DA-0`): submit and cancel together at the left,
- * Delete alone at the right in the failure colour. Putting the destructive
- * action at the other end of the row is what stops it being pressed by
- * somebody aiming for Cancel, and `DESIGN.md` asks for it to be kept apart from
- * the normal save. It is a text action rather than a filled one, because the
- * confirmation it opens is where the filled destructive button lives.
+ * Keep submit and cancel together, with destructive actions separated at
+ * the opposite edge. Destructive confirmation is handled by the caller.
  */
 function SheetFooter({
   className,

--- a/apps/web/components/ui/sidebar.tsx
+++ b/apps/web/components/ui/sidebar.tsx
@@ -14,24 +14,8 @@ import {
 import { cn } from "@/lib/utils";
 
 /**
- * The signed-in navigation bar, as parts.
- *
- * These are shadcn's Sidebar primitives with egma's theme on them and the parts
- * this product has no use for left out. What is missing is missing on purpose:
- *
- * - **No collapsible rail, no icon mode, no persisted open state.** egma's bar
- *   is always open on a wide screen and always a drawer on a narrow one, and
- *   the shell already owns that switch at its one layout breakpoint. A second
- *   opinion about when a sidebar is open would be a second navigation model.
- * - **No `Sidebar` root.** The `<aside>` is the shell's own frame — it is a
- *   column of the shell's grid and it is what the breakpoint hides — so it
- *   stays where the shell keeps it. These primitives own everything inside it.
- * - **No mobile `Sheet`.** The drawer is the product's existing one, and the
- *   same three groups are drawn inside it rather than a second copy of them.
- *
- * Every value here is a theme key and every theme key reads one of egma's own
- * declarations in `tailwind-theme.css`, so nothing in this file holds a colour,
- * a size or a duration of its own.
+ * Sidebar content primitives; the shell owns its aside, wide/narrow breakpoint,
+ * and mobile drawer. Do not introduce separate persisted or collapsible state here.
  */
 
 type SidebarContextValue = {
@@ -72,15 +56,8 @@ function SidebarProvider({
 }
 
 /**
- * The organization bar at the very top of the signed-in sidebar.
- *
- * The approved Paper refinement puts the Egma mark, organization name, plan
- * and arrows in this row. The project is a separate control below it.
- *
- * 56px tall over a hairline, which is exactly the topbar beside it (`73A-0`
- * and `71V-0` are both 56). The two bars line up across the whole application
- * because they read the same two theme values, not because somebody matched
- * them once.
+ * Organization header sharing height and divider tokens with the adjacent
+ * top bar. Project selection is rendered separately below it.
  */
 function SidebarBrand({ className, ...props }: ComponentProps<"div">) {
   return (
@@ -113,14 +90,8 @@ function SidebarHeader({ className, ...props }: ComponentProps<"div">) {
 }
 
 /**
- * The groups, and the one thing in the bar that scrolls.
- *
- * `min-h-0` is what lets it scroll rather than push the footer off a short
- * screen: a flex child will not shrink below its content without it, and the
- * account control would be the part that left.
- *
- * `asChild` is here because this is the product's navigation landmark. The
- * caller supplies the `<nav>` and its label; this supplies the layout.
+ * Let navigation scroll without pushing the account footer offscreen.
+ * Callers may supply the labeled nav landmark through asChild.
  */
 function SidebarContent({
   className,
@@ -153,22 +124,8 @@ function SidebarFooter({ className, ...props }: ComponentProps<"div">) {
 }
 
 /**
- * A set of rows, labelled or not.
- *
- * The label is tied to the group rather than left floating above it, so a
- * screen reader says which group it has entered instead of reading six links
- * with nothing between them. The id is made here and taken by the label,
- * because a group knows it has one and a caller should not have to invent a
- * unique string for every bar it draws.
- *
- * **`labelled={false}` is for the group that is drawn without a heading**, and
- * it takes the region away with the heading rather than only hiding the word.
- * A `role="group"` still pointing `aria-labelledby` at a heading that is not
- * rendered is a named region with a dangling name — a screen reader announces a
- * group and then has nothing to call it. So an unlabelled group is a plain
- * wrapper: the rows inside it are still links in the same `<nav>`, and they are
- * reached exactly as they were. It defaults to `true`, so every group that had
- * a heading before this prop existed keeps the heading and the region it had.
+ * Associate labeled groups with generated heading IDs. An unlabeled group
+ * must omit both group semantics and aria-labelledby to avoid a dangling name.
  */
 const SidebarGroupLabelId = createContext<string | null>(null);
 
@@ -192,28 +149,8 @@ function SidebarGroup({
 }
 
 /**
- * The word over a group.
- *
- * **It is a heading, because a sectioned navigation is walked by heading.** The
- * `aria-labelledby` wiring above already gives the group its accessible name;
- * this is the other half, and they answer different questions. The name is what
- * a person hears once they are *inside* a group. A heading is how they get to
- * one at all — the heading list is Simulations and Monitoring, and jumping
- * between them is one keystroke rather than six arrow presses. The top group
- * is not in that list, because it is drawn with no heading at all: it is the
- * two rows a person lands on, reached before any jump is needed.
- *
- * `h2` because the bar has no heading above it and the page's own title is the
- * `h1` beside it. It carries no size of its own — `DESIGN.md` removed those —
- * so `text-sm` is the size, and `globals.css` holds every heading at weight
- * 400. `mt-0` is not decoration: `globals.css` gives headings the browser's own
- * margins back for the legacy pages, and a heading here must not inherit them.
- *
- * Weight 400 and the compact label treatment, which is what the bar already
- * used for the one group label it had. It is quiet on purpose: the label says
- * where a row belongs, and the row is the thing being read. `px-2` is the row's
- * own padding, so the label starts exactly where the row's icon starts — on the
- * bar's 16px gutter, in line with the project block above it.
+ * Use h2 for navigation group headings so users can jump between sections.
+ * Keep compact type and align labels with navigation icons.
  */
 function SidebarGroupLabel({ className, ...props }: ComponentProps<"h2">) {
   const labelId = useContext(SidebarGroupLabelId);
@@ -260,47 +197,9 @@ function SidebarMenuItem({ className, ...props }: ComponentProps<"li">) {
 }
 
 /**
- * One row of the bar.
- *
- * **The active row wears Ember Wash and a small Ember mark**, which is what
- * `DESIGN.md` asks of a current item, and it says `aria-current="page"` as
- * well — state is never colour alone. The mark is drawn on every row and
- * coloured on the active one, so the row's text sits in the same place whether
- * or not it is the one you are on.
- *
- * **The motion is colour and nothing else.** A sidebar row is the most-pressed
- * control in the product and `DESIGN.md` is exact about that: do not animate
- * actions used many times each day, and give routine navigation colour
- * feedback. So there is no press scale here — the row answers on press rather
- * than after a movement — and the 140ms hover is the theme's hover token,
- * dropped entirely under reduced motion the way the rest of the bar's
- * ancestors already drop theirs.
- *
- * **The two properties are named rather than reached for as `transition-colors`,
- * and a keyboard pass is what found the difference.** Tailwind's `colors` group
- * sweeps in `outline-color`, and this product's focus indicator is an outline —
- * so every Tab step through the bar faded its ring up from the row's text
- * colour over 140ms. That is animating keyboard navigation, which `DESIGN.md`
- * names first among the things not to animate, and it is a focus indicator
- * arriving late, which is worse. Hover changes the background and the text and
- * nothing else, so those two are what move.
- *
- * **The row is 36px where the pointer is fine and 44px where it is coarse.** A
- * bar of six rows is read as a block rather than pressed one row at a time, and
- * at 44px each the block was loose enough to read as six boxes stacked instead
- * of two or three clusters. 36px is `--control-md`, the height this product
- * already gives a compact control. The 44px tap target is not traded away for
- * that: `pointer-coarse` puts it straight back on every touch screen, which is
- * the same rule the segmented choice control already uses.
- *
- * **The row's 8px padding is what puts its icon on the bar's 16px gutter.** The
- * column around it is inset 8, so 8 and 8 land the icon exactly where the Egma
- * mark, the word `Project`, the project name and the group labels already
- * start: one left edge down the whole sidebar. It was 12 against a column inset
- * of 16, which put every icon and every group label 12px right of the project
- * block above them. The Ember mark is unaffected either way — it is absolutely
- * placed on the row's own leading edge and pushes nothing, so a lit row's icon
- * stands on the same line as a quiet one's.
+ * Mark the current page visually and with aria-current without shifting text.
+ * Use color-only navigation feedback and explicit transition properties so
+ * focus outlines do not animate. Preserve coarse-pointer target sizes.
  */
 function SidebarMenuButton({
   className,

--- a/apps/web/components/ui/skeleton.tsx
+++ b/apps/web/components/ui/skeleton.tsx
@@ -3,40 +3,9 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * A quiet stand-in for content that has not arrived.
- *
- * `DESIGN.md` asks a loading state to "show progress" with a "fast, quiet
- * indicator", and this is the mark it does that with. It claims no shape of
- * its own — the caller gives it the height and the width of whatever is coming
- * — so it never pretends to be a table it has not seen.
- *
- * **Two things about the stock shadcn skeleton change here, and both are rules
- * in `DESIGN.md` rather than preferences.**
- *
- * 1. **The bar reads `--border`.** shadcn draws it on the quiet accent
- *    surface, which this theme maps to `--surface-soft` — 6% Graphite on
- *    paper. The application canvas is 3% Graphite on paper, so a skeleton on
- *    the canvas was three percent of one colour away from the page it was
- *    drawn on: present in the DOM, invisible to a person. `--border` is 18%,
- *    still "a neutral Graphite-and-Paper mix" and still quiet, and it is
- *    legible on the canvas, on Pure Paper and in dark theme alike.
- * 2. **The radius is named for a component.** shadcn's generic medium step and
- *    `rounded-input` are the same 8px today; only one of them says which of
- *    egma's four radii it means, and only one of them moves if that step ever
- *    does.
- *
- * **The breath is not here.** shadcn hands a skeleton Tailwind's own pulse
- * utility, which arrives welded to a two-second duration and an easing curve
- * of Tailwind's own, and "do not put a colour, a radius, a size, or a duration
- * in a component" leaves no room for either number. `tailwind-theme.css` owns
- * it instead, keyed on this element's `data-slot`, beside the run state mark's
- * turn and under the same rule in `DESIGN.md` — including the phase offset
- * that makes a column of these read as one wave, and the reduced-motion form
- * that stops it.
- *
- * Nothing in this file, prose included, may name a utility it does not use.
- * Tailwind finds class names by reading these files as text, so a class named
- * only to explain it is still a rule minted into the stylesheet.
+ * Placeholder sized by the caller, with enough neutral contrast to remain
+ * visible. Theme selectors own pulse and reduced-motion behavior.
+ * Avoid naming unused utilities in comments: Tailwind scans source text too.
  */
 function Skeleton({ className, ...props }: ComponentProps<"div">) {
   return (

--- a/apps/web/components/ui/sonner.tsx
+++ b/apps/web/components/ui/sonner.tsx
@@ -13,27 +13,9 @@ import { Toaster as Sonner, type ToasterProps } from "sonner";
 import { useTheme } from "@/ui/theme.tsx";
 
 /**
- * The registry's notification region, dressed in egma's values.
- *
- * It reads the product's own `useTheme` rather than `next-themes`, because
- * this application already has one place that decides light or dark and two
- * controls that write to it. A second theme source would be a second answer.
- *
- * **The product's own notification is not built on this, and that is
- * deliberate.** `ui/feedback.tsx` exports a `Toast` a page controls with an
- * `open` prop, and `DESIGN.md` asks that toast for a short translate plus
- * opacity on an *interruptible transition*. Sonner is a queue a caller pushes
- * into, and it leaves on a CSS animation and a fixed unmount timer — so a
- * dismissal cannot be answered at once, which is what keyboard dismissal has
- * to be. The two would also disagree about who owns the region. This file is
- * here, house-correct, for the day a queue is what a surface needs; until
- * then the shared `Toast` is what pages use, and the icons below are the ones
- * it draws, so the two would read as one product.
- *
- * Every value here is a theme key. Sonner reads its own custom properties, so
- * they are set to egma's rather than overridden later in a class list, and the
- * neutral surface with a state-coloured edge is the same shape a status chip
- * and the shared `Toast` already use.
+ * Queued notifications using the product's shared theme and status icons.
+ * The controlled Toast in ui/feedback.tsx has a separate owner-driven lifecycle;
+ * choose based on whether the caller needs a queue or explicit open state.
  */
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme } = useTheme();

--- a/apps/web/components/ui/table.tsx
+++ b/apps/web/components/ui/table.tsx
@@ -3,51 +3,13 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * The table, as the parts the boards draw it from.
- *
- * Read off `6ZM-0`, `71F-0` and `710-0` with `get_computed_styles` on
- * 2026-08-23: a Pure Paper panel inside one neutral hairline with the corners
- * clipped and no corner radius; a 40px header row of quiet 14px labels over a
- * hairline; body rows at least 52px tall with 8px of vertical padding, 16px of
- * side padding and a hairline between them; and a 48px slot at the trailing
- * edge that every row carries whether or not it holds a menu.
- *
- * **`TablePanel` is separate from `Table`, which is where this leaves the
- * registry.** shadcn's `Table` renders its own scrolling wrapper around the
- * `<table>`. This product's table is a *panel* — the border and the surface
- * belong to the frame, not to the element — and the same frame has to carry the
- * container query that makes a narrow table stack. Welding the two together
- * would mean `ui/data-table.tsx` reaching inside a primitive to add a class to
- * a `<div>` it cannot name.
- *
- * Nothing here holds a colour, a size or a radius of its own. The last column's
- * width is `--table-action-width`, declared in `tailwind-theme.css` beside the
- * row heights it lines up with.
+ * Separate TablePanel from Table so the frame owns surface, scrolling, and
+ * container queries. Shared tokens define row sizing, padding, and action width.
  */
 
 /**
- * The edge every column reads from, written once.
- *
- * **A header and the cells under it are one column, so they share one
- * declaration.** Two copies of the same padding are two things that can be
- * changed apart, and a header that drifts off its own figures is the defect
- * this names away. The rule is the wide layout's column alignment: one left
- * edge per lane, header and value on it, in every table.
- *
- * It is exported because one table in the product is not built from these
- * parts — the inline-editing suite grid in `tests/tests-grid.tsx` — and an
- * edge two files declare apart is an edge that drifts. What is still written
- * out by hand is the side padding the two settings tables put back inside
- * their own control cells, where the class list is a caller's rather than
- * this file's, and the stacked row's own copy in `ui/data-table.tsx`, which
- * pads a different layout and cannot drift this one.
- *
- * Two things align some other way, and both are deliberate:
- *
- * - The row's own control lane, centred in a slot of fixed width.
- * - Every non-primary value in the **stacked** layout, which `ui/data-table`
- *   right-aligns against its label. A narrow row is a label-and-value list
- *   rather than a set of columns, so it has no shared edge to keep.
+ * Share the header/body column edge with the test grid. Action columns and
+ * stacked label/value rows use their own alignment rules.
  */
 export const LANE_X = "px-(--row-padding-x)";
 

--- a/apps/web/components/ui/tabs.tsx
+++ b/apps/web/components/ui/tabs.tsx
@@ -7,21 +7,8 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * Switching between peer views of one page.
- *
- * **Radix is here for the keyboard, not for the look.** The tabs pattern is a
- * roving tab stop — one Tab step into the group, then Left, Right, Home and
- * End inside it — and a hand-written version of that is a listener per strip
- * that each has to get `dir`, looping, and the disabled tab right on its own.
- * Radix publishes it once, and it publishes `data-state` and `data-orientation`
- * alongside, which is what every rule below reads.
- *
- * `DESIGN.md` calls a tab strip navigation: "Navigation row — support routine
- * navigation — colour feedback only." So nothing here moves. The current tab
- * uses a fixed 2px Ember edge and medium label weight. A segmented control
- * keeps the approved top edge. A page or panel rail meets the content below it,
- * so its edge sits at the bottom. The weight is reserved in the compact strip
- * and changes no box dimensions.
+ * Use Radix for tab focus, selection, and orientation. Keep routine navigation
+ * free of spatial motion; mark the active tab with an edge and label treatment.
  */
 function Tabs({
   className,
@@ -43,18 +30,8 @@ function Tabs({
 }
 
 /**
- * The two shapes a strip of tabs takes in this product.
- *
- * - `default` is the segmented control: a quiet track holding the choices, and
- *   the current one on the plain product surface. It is for a small closed
- *   set that belongs inside a row of other controls.
- * - `line` is the rail: the choices sit on a hairline and the current one is
- *   marked on it — the mark alone, with no fill behind the label. It is for the
- *   top of a page or a panel, where the strip is what a whole region is
- *   switched by.
- *
- * The track and choices use the product's square geometry. Four pixels of
- * padding keep the segmented control readable as one unit.
+ * default is a segmented control; line is a rail at a page or panel edge.
+ * Both retain the same tab behavior with theme-defined geometry.
  */
 const tabsListVariants = cva(
   [
@@ -92,17 +69,8 @@ function TabsList({
 }
 
 /**
- * One choice in the strip.
- *
- * The current one always carries a mark that survives a greyscale screenshot:
- * a 2px rule at the content-facing edge. `DESIGN.md`: "State is not
- * communicated by colour alone." The active fill stays plain so the mark and
- * label do the work.
- *
- * There is no `focus-visible` rule here on purpose. `globals.css` draws the
- * product's Ember focus ring for everything a keyboard reaches, `[role="tab"]`
- * named among them, from an unlayered rule that no utility can undo. A ring
- * written here would be a second answer to a question already settled.
+ * Use a persistent edge mark as well as color for active state. Shared focus
+ * styles provide the keyboard indicator.
  */
 function TabsTrigger({
   className,
@@ -170,44 +138,15 @@ function TabsTrigger({
            */
           "group-data-[variant=line]/tabs-list:border-0",
           /*
-           * **The first label starts on the column's own left edge.** A rail
-           * strip leads a page, so its first word is read against the headings
-           * under it — and the shared `px-3` that gives every tab its plate had
-           * pushed that word 12px right of every `Section` title beside it.
-           * `DESIGN.md` asks for exact alignment.
-           *
-           * Padding rather than a negative margin on the list, which is the
-           * other way to do this: the Settings column is `overflow-y-auto`, so
-           * its `overflow-x` computes to `auto` as well, and anything pulled
-           * left of the content box is clipped with no scroll that can reach
-           * it. Dropping the first tab's own left padding moves the label and
-           * its plate together, and neither leaves the column.
-           *
-           * Horizontal only. Down a vertical rail the first tab is the top
-           * one, and taking its left padding away would step it out of line
-           * with every tab below it.
+           * Remove first-tab leading padding on horizontal rails to align with content.
+           * A negative list margin could be clipped by the settings scroll container.
+           * Keep vertical-rail labels aligned with each other.
            */
           "group-data-[orientation=horizontal]/tabs:group-data-[variant=line]/tabs-list:first:pl-0",
           /*
-           * The mark, drawn for the current tab and colourless for the rest.
-           *
-           * **The colour is the switch, and `content` cannot be.** Tailwind 4
-           * writes `content: var(--tw-content)` into *every* `after:` utility
-           * and declares `--tw-content` with an initial value of `""`, so the
-           * pseudo-element already exists the moment any `after:` class is on
-           * the element. Gating `content-['']` on the active state therefore
-           * turns nothing on or off — it was written that way first, and every
-           * tab in the strip drew a rule. The sidebar's active mark in
-           * `shell.tsx` had already settled this the other way round.
-           *
-           * The bar appears rather than fades: a transition on the trigger
-           * does not reach its own pseudo-element, and none is declared here.
-           * That is what `DESIGN.md` wants of a strip crossed by arrow key many
-           * times a day.
-           *
-           * One pixel of overhang keeps the 2px mark crisp against the edge.
-           * A segmented choice keeps the approved top mark. A rail tab marks
-           * the bottom edge where it meets the panel it switches.
+           * Keep the pseudo-element present and switch its color by active state.
+           * Tailwind pseudo-element utilities may create it even without an active-only
+           * content rule. The marker changes immediately during keyboard navigation.
            */
           "after:absolute after:rounded-chip after:bg-transparent",
           "data-[state=active]:after:bg-brand",
@@ -225,35 +164,10 @@ function TabsTrigger({
       onClick={(event) => {
         onClick?.(event);
         /*
-         * **A tab answers a press, so a click with no press behind it has to
-         * be given one.**
-         *
-         * Radix selects on `mousedown` rather than on `click`, which is right
-         * — `DESIGN.md`: "A control answers on press, not after an animation."
-         * A pointer press reaches it through `mousedown` and a keyboard Enter
-         * through `keydown`, so both are already answered.
-         *
-         * What reaches neither is a click that was *dispatched* rather than
-         * performed — a script, an automation harness, or this repository's
-         * own component tests, where `fireEvent.click` sends the click alone
-         * and no press ever happens. Eight Settings tests failed on exactly
-         * that. So the press is re-issued rather than the selection being
-         * re-implemented here, and Radix stays the one thing that decides what
-         * activating a tab means.
-         *
-         * **`isTrusted` is what keeps this off the keyboard path.** A browser
-         * fires a click with `detail === 0` after Enter or Space as well, so
-         * `detail` alone cannot tell a dispatched click from a keyboard one —
-         * and re-issuing there hands the consumer a second `onValueChange` for
-         * one press. Harmless against a page that commits the change straight
-         * away, and a trap for one that does not. Only a browser can set
-         * `isTrusted`, so a dispatched click is the one case left.
-         *
-         * **The re-issued press bubbles**, because React listens at the root
-         * and would not see it otherwise. It can therefore also reach an
-         * ancestor's `onMouseDown` or an outside-press handler. Nothing wraps a
-         * tab strip that way today; a component that does needs to know this is
-         * here.
+         * Synthetic clicks may omit the mousedown that Radix uses for selection.
+         * Forward only untrusted clicks through a bubbling mousedown; real pointer
+         * and keyboard activation already have their own paths. The forwarded event
+         * can also reach ancestor handlers.
          */
         if (event.defaultPrevented || event.detail > 0) return;
         if (event.nativeEvent.isTrusted) return;

--- a/apps/web/components/ui/textarea.tsx
+++ b/apps/web/components/ui/textarea.tsx
@@ -4,20 +4,8 @@ import { useFieldHint } from "@/ui/field-hint.ts";
 import { cn } from "@/lib/utils";
 
 /**
- * Somewhere to write more than a line, at the 8px input radius.
- *
- * A persona's personality can be several sentences, and a single-line field
- * for that text scrolls sideways while somebody is still deciding what to say.
- * It grows with a `rows` count rather than auto-sizing, so the page's layout is
- * decided by the page — and a caller that wants it to follow its content says
- * so with a class, which is how the Tests area's one-line behaviour rows ask
- * for it.
- *
- * `resize-y` is deliberate: sideways resizing pulls a field out of the column
- * it was laid out in, and every form in this product is a column.
- *
- * No focus ring of its own, for the reason `input.tsx` gives, and it describes
- * itself with the enclosing `Field`'s hint for the reason written there too.
+ * Multiline input with caller-controlled rows and vertical resizing. Use shared
+ * text-field focus styling and the enclosing Field hint.
  */
 function Textarea({ className, ...props }: ComponentProps<"textarea">) {
   const hint = useFieldHint();

--- a/apps/web/components/ui/tooltip.tsx
+++ b/apps/web/components/ui/tooltip.tsx
@@ -6,17 +6,8 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * A short explanation attached to one control.
- *
- * Radix supplies what a hand-written tooltip keeps getting wrong: the delay
- * before the first one, the grouping that opens the next one at once, Escape,
- * dismissal when a press lands elsewhere, the `aria-describedby` wiring, and a
- * position that answers the edge of the window instead of running off it.
- *
- * `disableHoverableContent` is on by default because of a rule rather than a
- * preference: `DESIGN.md` says a tooltip never holds an action, so there is
- * nothing in one to move a pointer into, and the grace area that protects that
- * journey only makes the tooltip outstay its welcome.
+ * Configure Radix tooltip timing and accessible descriptions. Disable hoverable
+ * content by default because these explanations contain no interactive controls.
  */
 function TooltipProvider({
   delayDuration = 500,
@@ -36,17 +27,9 @@ function TooltipProvider({
 }
 
 /**
- * One tooltip, which carries its own provider so a lone one works.
- *
- * **The inner provider is also what stops the delay grouping from working
- * across tooltips.** Radix keeps "one has just been shown, so open the next at
- * once" on the provider, and a provider per tooltip means each one only ever
- * groups with itself: the same trigger re-hovered is instant, its neighbour
- * still waits the full delay. A `TooltipProvider` mounted higher up does not
- * change that, because the nearest provider is the one a tooltip reads and the
- * nearest is always this one. Restoring the shared window means removing this
- * wrapper *and* mounting one provider above the product, which is two files at
- * once and is recorded with the coordinator rather than done here.
+ * Provide defaults for a standalone tooltip. This per-tooltip provider limits
+ * the skip-delay window to that trigger; a higher provider cannot share it
+ * across neighbors while this wrapper remains.
  */
 function Tooltip(props: ComponentProps<typeof TooltipPrimitive.Root>) {
   return (
@@ -61,30 +44,9 @@ function TooltipTrigger(props: ComponentProps<typeof TooltipPrimitive.Trigger>) 
 }
 
 /**
- * The panel itself.
- *
- * **No motion here.** `tailwind-theme.css` writes it, keyed on `data-slot` and
- * Radix's `data-state`, exactly as it does for the popover, the dropdown menu
- * and the dialog. Two things need that placement rather than a class list: the
- * reduced-motion form has to be a real `@media` block that comes later, where
- * a `motion-reduce:` utility of equal specificity leaves the winner to
- * Tailwind's variant sort order — a reduced-motion failure that fails silently
- * — and the development proof's reduced-motion frame keys off an ancestor,
- * which no class on this element can express.
- *
- * **No portal, and that is the deliberate part.** The registry portals this to
- * `body`, and a panel under `body` is out of reach of every descendant
- * selector in the theme, including the one the proof page's reduced-motion
- * frame is drawn with. Radix positions the panel `position: fixed` either way,
- * so staying in place keeps the collision handling and the escape from
- * ordinary `overflow` scrolling; what it gives up is an ancestor that is
- * itself a containing block for fixed children — a `transform`, `filter` or
- * `contain` — and the hand-written tooltip this replaces was
- * `position: absolute` inside its trigger, so it lost that case too.
- *
- * **No arrow.** This product's tooltip has never drawn one, and Radix measures
- * an arrow with a `ResizeObserver`, which the component tests have no
- * implementation of. Adding one is a change to two things, not one.
+ * Keep content in place so ancestor theme and preview selectors apply.
+ * Fixed positioning handles ordinary overflow, but transformed or contained
+ * ancestors can still constrain it. The theme owns motion; no arrow is rendered.
  */
 function TooltipContent({
   className,

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -1,32 +1,11 @@
 /**
- * Product analytics for the pages, off unless the build said `on` and gave a
- * key.
+ * Enable browser analytics only when the build enables Egma telemetry and
+ * supplies a PostHog key. Public environment values are fixed at build time.
  *
- * Next loads this file once in every browser session, before the app's own
- * code. `NEXT_PUBLIC_*` is resolved at build time — the hosted deployment
- * sets the flag and both variables where it builds (Vercel), and a
- * self-hoster who sets nothing builds pages that contain empty strings here,
- * initialize nothing, and send nothing anywhere. The flag is the same
- * `EGMA_TELEMETRY` every other process reads, mapped through next.config at
- * build — one flag is the whole decision, so a key left set in a build
- * environment cannot turn reporting on by itself. The key is a PostHog
- * project token, which is write-only by design: it can submit events and
- * read none back, which is what makes it publishable inside a page at all.
- *
- * What a key turns on: pageviews, session replay, web vitals, and the errors
- * pages throw.
- *
- * **Replay reads the page, and that is the point.** It used to mask every word
- * on every page and the recordings were grey blocks that answered nothing. It
- * records the pages now; `lib/replay-privacy.ts` marks the one thing it must
- * not read, which is a secret on screen. Inputs stay masked whatever the page
- * says, so every password and credential field is covered without a mark, and
- * a URL keeps only its path wherever one is recorded — a presigned recording
- * link is a credential and it is on the page as an `src`.
- *
- * Off for the whole product either way: request and response headers and
- * bodies, the console, cross-origin frames, canvases, and the query and
- * fragment of any URL that reaches an event.
+ * Mask input values and explicitly marked credential text. Strip query strings,
+ * fragments, and URL userinfo from recognized event URL properties, request
+ * names, and DOM href/src attributes. This does not sanitize arbitrary strings.
+ * Disable captured headers, bodies, console logs, cross-origin frames, and canvas.
  */
 
 import posthog, {
@@ -39,15 +18,8 @@ import { REPLAY_PRIVATE_SELECTOR } from "./lib/replay-privacy.ts";
 const RECORDED_URL_PROPERTY = /(?:url|href|referrer)$/i;
 
 /**
- * **A URL in the page can be the credential itself.** The recording player
- * hands an `<audio>` a presigned S3 GET, and the whole of its signature is the
- * query string — so an unstripped `src` in a snapshot is a working link to a
- * customer's call for as long as it lives.
- *
- * So the rule the events and the network capture already follow is the rule
- * for the DOM too: the path, never the query or the fragment. It costs nothing
- * to read: the only other `src` in the product is a static brand asset, and a
- * page's own address is already recorded without its query.
+ * Strip secrets from recorded href/src attributes, including signed recording
+ * URLs. Apply the same URL sanitizer used for events and captured requests.
  */
 const RECORDED_URL_ATTRIBUTE = /^(?:href|src)$/i;
 

--- a/apps/web/lib/agent-setup-flow.ts
+++ b/apps/web/lib/agent-setup-flow.ts
@@ -311,14 +311,8 @@ export function stepAfterRetellAgent(
 }
 
 /**
- * Where the answer to the one question leads, or `null` when the flow can save
- * now.
- *
- * **The phone-number chooser appears only when Phone call is picked**, because
- * a voice agent can answer several routed numbers and the flow has to be told
- * which one to dial. A developer who picked Text is never asked for a phone
- * number: the fast lane has no needless steps, and there is nothing honest to
- * ask about a number nothing will dial.
+ * Choose the next setup step, or null when ready to save. Only the phone
+ * connection flow asks which number to dial.
  */
 export function stepAfterRetellLanes(lane: RetellLane): AgentSetupStep | null {
   return lane === "phone" ? "retell-phone" : null;

--- a/apps/web/lib/agents.ts
+++ b/apps/web/lib/agents.ts
@@ -6,39 +6,15 @@ import type {
 import { agentPlatformLabel } from "./transcripts.ts";
 
 /**
- * The agents of one project, and every way egma can reach one, as the API
- * answers them.
- *
- * An **agent** is the customer's voice agent — the thing egma is trying to
- * establish trust in. It belongs to a project, which is why these reads are
- * never made without one. A **connection** is how egma reaches an agent, and an
- * agent has many: the same logical agent might be a process on a laptop today,
- * a hosted assistant in staging, and a phone number in production.
- *
- * The shapes are the API's own, field names included. Renaming its fields on
- * the way in would put a second vocabulary between the contract and the page,
- * and the two would drift the first time the API grew a field.
- *
- * **What is not here is as deliberate as what is.** No provider prompt, no
- * model, no tools: those live where the customer configures them, and a copy
- * in this application would be stale from the moment it was taken. And no
- * credential — a read answers whether one is present and a hint of which one it
- * is, and never the secret.
+ * API response types for a project's agents under test and their connections.
+ * Provider configuration stays on the agent platform; reads expose credential
+ * status and hints, not secrets.
  */
 
 export type ListedAgentWithConnections = ListAgentsResponse["agents"][number];
 export type ListedAgent = Omit<ListedAgentWithConnections, "connections">;
 
-/**
- * One page of them. Keyset, newest first: `nextCursor` is where this page
- * stopped, and asking for more means handing it back. It is `null` rather than
- * absent when there is no next page, so "there is no more" and "this answer is
- * an older shape" are different answers.
- *
- * The items are the widened shape below: the list read carries every listed
- * agent's connections, so a page of agents is a page of *reachability* rather
- * than a page of names each hiding a second request.
- */
+/** A page of agents with their active connections and the API pagination token. */
 export type AgentPage = ListAgentsResponse;
 
 export type ListedConnection = ListedAgentWithConnections["connections"][number];
@@ -55,38 +31,15 @@ export function connectionLabel(
   return `${connection.name} · ${modalityLabel(connection.modality)}`;
 }
 
-/**
- * One agent as a *list* of them answers it: the identity above, and every
- * living way egma can reach it.
- *
- * The connections are the same shape the agent's own read answers, because the
- * API describes them with one function. So a row and a page never disagree
- * about what a connection is, and code that reads one reads the other.
- *
- * Archived connections are not among them. "How egma reaches this agent" and
- * "how it used to" are two questions, and the second is asked of the agent's
- * own read.
- */
+/** Agent detail using the generated response shape, including connections. */
 export type AgentDetail = GetAgentResponse;
 
 /** Which half of the project a list is asking for. */
 export type ArchiveFilter = "active" | "archived";
 
 /**
- * Which platforms an agent is on, in the words a person reads, as this
- * application can honestly answer it.
- *
- * Every agent declares its platform when it is registered. Connections can
- * still name another platform when their connection type pins one, so the
- * list says every platform represented by a live connection and falls back to
- * the agent's declared platform when it has no live connection.
- *
- * **An agent can be reached on two platforms at once**, so every platform its
- * live connections name is said, and not the first of them. One Retell
- * connection and one LiveKit connection on one agent is an ordinary state, and
- * naming only the first made the answer depend on which connection was made
- * first: the same agent read `Retell` today and `LiveKit` the day that
- * connection was archived, with nothing about the agent having changed.
+ * List distinct platforms from active connections in display order. Fall back
+ * to the agent's declared platform when it has no active connections.
  */
 export function agentPlatformText(
   agent: ListedAgentWithConnections,

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,20 +1,6 @@
 /**
- * One raw account or bootstrap read, and the four things a page can be told.
- *
- * Every product page in this application asks the same question — *give me
- * this, in this project* — and has to answer the same four situations for
- * somebody looking at it: it is here, it is not here, egma refused, and you
- * are not signed in. Writing that fold once is what lets a page's own code be
- * about its own subject, and what stops one page quietly deciding that a 404
- * is a failure while its neighbour decides it is an empty list.
- *
- * **A missing thing and a project that is not yours are the same answer**, and
- * deliberately so: the API answers both as an absence so that following a
- * stranger's link never reveals whether the thing on the other end exists.
- *
- * The refusal's own sentence is always kept and never paraphrased. It is
- * written to be shown, it names the next move, and a second copy of it in a
- * page would be a second thing to keep in step.
+ * Map reads to ready, missing, refused, or signed-out states. Preserve the
+ * API refusal message so callers can display it without a second copy.
  */
 
 /** The shape every refusal from this API has: a stable code, and a sentence. */
@@ -86,14 +72,8 @@ export function unreachable<T>(): Answer<T> {
 }
 
 /**
- * One read, with the project named in it where the caller named one.
- *
- * **The signal is optional and nothing here decides one.** A read that has to
- * be bounded says so at the call, because how long a wait is worth depends on
- * what is waiting on it — a deadline written here would be one that every
- * request in the product silently inherited. An abort lands in the same catch
- * as a refused connection, and means the same thing to a page: egma did not
- * answer.
+ * Forward the caller's optional abort signal. This helper sets no deadline;
+ * an abort is returned as a failed read.
  */
 export async function readJson<T>(
   path: string,

--- a/apps/web/lib/connection-options.ts
+++ b/apps/web/lib/connection-options.ts
@@ -75,16 +75,7 @@ export type DiscoveredAgents = DiscoverAgentsResponse;
 export type DiscoveredAgent = DiscoveredAgents["agents"][number];
 export type ConnectionCandidate = DiscoveredAgent["connectionCandidates"][number];
 
-/**
- * Agents on the account that can be reached the way the form is set to.
- *
- * **The candidates decide, and they are not otherwise shown.** Discovery
- * answers each account agent with the connections it actually offers, so an
- * account holding chat agents and voice agents narrows to the half the chosen
- * modality can reach — and the person picks a name rather than choosing a
- * route. A candidate list of its own was drawn here until 2026-08-24; the
- * boards replaced it with the name and a typed phone number.
- */
+/** Filter discovered agents to those offering a connection for the chosen modality. */
 export function agentsForOption(
   agents: readonly DiscoveredAgent[] | null,
   option: ConnectionOption | undefined,

--- a/apps/web/lib/graders.ts
+++ b/apps/web/lib/graders.ts
@@ -45,18 +45,7 @@ export function graderOwnerLabel(owner: GraderOwner): string {
   return owner === "egma" ? "Egma" : "Project";
 }
 
-/**
- * There is no `graderTypeLabel`, and that is a decision rather than an
- * omission.
- *
- * "LLM judge" and "Code" were product words for `llm_as_judge` and `code`, and
- * the two never agreed: the API's word is what a person reads in a request, in
- * a webhook and in the library's own contract. **The type now reads as the
- * identifier it is** — the raw value, in the monospace stack, in a chip
- * (developer decision, 2026-08-25). A screen that wants it only has to draw
- * `grader.type`, so a helper that renamed it would be a second name to keep in
- * step with nothing.
- */
+
 
 /** One modality, as the word a person reads on a chip. */
 export function graderModalityLabel(modality: GraderModality): string {

--- a/apps/web/lib/instants.ts
+++ b/apps/web/lib/instants.ts
@@ -104,25 +104,8 @@ export function formatViewerInstant(
 }
 
 /**
- * The one absolute form a list column carries: `Aug 16, 2026`.
- *
- * **A list's date column is an absolute short date, and never a relative age.**
- * The boards print `Aug 16, 2026` in every list column that holds a time
- * (`6ZJ-0`, `8TQ-0`, `8P4-0`), and the product printed two other things: an ISO
- * day on the agents list and a changing age on personas, suites, tests, runs,
- * transcripts, keys and invitations. A column of ages is a column that cannot
- * be scanned — every row says "a moment ago" until it says "2 days ago" — and
- * two rows a minute apart are indistinguishable by the time anybody reads them.
- * Relative time stays where it is a fact inside a sentence: "started just now",
- * "last received 2 min ago".
- *
- * `precision` is here because one column names a *moment* rather than a day:
- * the transcript list's leading column is the exchange's own identity and has
- * always been to the second. It keeps that precision and takes this shape, so
- * there is still one absolute form in the product rather than two.
- *
- * The exact instant is not lost. `ListInstant` keeps the RFC 3339 value on the
- * element and the viewer-local moment with its zone in the title.
+ * Format absolute dates for list columns, with optional time precision.
+ * ListInstant separately preserves the exact timestamp and local time zone.
  */
 export function asListInstant(
   instant: string,

--- a/apps/web/lib/me.ts
+++ b/apps/web/lib/me.ts
@@ -2,28 +2,8 @@ import { readJson, type Answer } from "./api.ts";
 import { roleFrom, type Role } from "./roles.ts";
 
 /**
- * Where the person holding this session is, and what the pages should offer
- * them a choice between. What `/api/me` answers, as the pages read it.
- *
- * **There are two levels and they are called `organization` and `project`**,
- * which is what they are and what the rest of the codebase calls them. No third
- * word sits above the pair naming it: a container word invented for the top of
- * a hierarchy is how `project` comes to mean the tenancy container in one place
- * and something inside it in another, and a word that means two things is one
- * nobody can read a permission with.
- *
- * **This read names no chosen project, and never will.** Which project a tab is
- * working in lives in that tab's address; a mutable browser-wide "current
- * project" would make two tabs on two projects impossible and would make a
- * pasted link mean something different to whoever opened it. So this answers
- * the *choices* — every project the membership reaches, in stable creation
- * order — and the address answers the choice.
- *
- * **The organization and project control stays on screen even with one
- * project.** An earlier rule hid any level whose cardinality was one, on the
- * grounds that a level you are not using is clutter. It is not: it is where you
- * are, and somebody who cannot see where they are working cannot tell that a
- * page is empty because the project is empty.
+ * Session identity and available organizations and projects from /api/me.
+ * The selected project belongs in each tab's URL, not shared browser state.
  */
 
 /** The customer, and the role you hold in it. */
@@ -71,32 +51,14 @@ export function firstProjectOf(me: Me): Project | undefined {
 }
 
 /**
- * How long the session read may take before egma calls it a failure.
- *
- * **It is the one read in this product with a deadline, and what is standing on
- * it is the reason.** Every other request fails into a page that is already
- * drawn: a list says it could not load, and the application stays usable around
- * it. This one holds a cover over the whole document with everything behind it
- * inert — which is right while the answer is on its way, and a frozen page if
- * it never comes.
- *
- * A connection refused, dropped or reset rejects, and that path always worked.
- * What this closes is a server that accepts the connection and then says
- * nothing: no error, no response, and a browser limit of its own measured in
- * minutes. Twelve seconds is long enough that no real answer is thrown away and
- * short enough that nobody waits in front of a page they cannot touch.
+ * Bound the session read so an unresponsive server cannot leave the document
+ * behind its loading cover indefinitely.
  */
 export const SESSION_READ_TIMEOUT_MS = 12_000;
 
 /**
- * Who is signed in, bounded.
- *
- * Both readers of `/api/me` — the shell's session and the entrance — come
- * through here, so the deadline is one value rather than two that could drift,
- * and neither of them can be the one that forgets it. A read that runs out
- * arrives as an ordinary failure, which lands the pages on the states they
- * already have for one: `Session unavailable` in the shell, and the entrance's
- * own sentence with a way to try again.
+ * Share the session deadline between the shell and entrance. Timeout returns
+ * a failed read so each surface can show its retry state.
  */
 export async function readSession(
   timeoutMs: number = SESSION_READ_TIMEOUT_MS,

--- a/apps/web/lib/navigation.ts
+++ b/apps/web/lib/navigation.ts
@@ -70,16 +70,8 @@ export const NAVIGATION_GROUPS: readonly NavigationGroup[] = [
     ],
   },
   /*
-   * **The group says OBSERVABILITY and its one row says Traces** (developer
-   * decision, 2026-08-25). Only the words moved: the section id stays
-   * `monitoring` and the address stays `/monitoring/transcripts`, because a
-   * rename that moved an address would break every saved link for a change
-   * nobody asked for.
-   *
-   * `trace` is a real word in this domain rather than a borrowed one — it is
-   * what a person's own agent emits and what the SDK reports — so the screen
-   * is named for what lands on it. The **transcript** stays the name of the
-   * artifact a person opens and reads.
+   * Keep existing monitoring/transcripts URLs for saved links. The navigation
+   * label is Traces; the readable artifact is a transcript.
    */
   {
     id: "monitoring",

--- a/apps/web/lib/personas.ts
+++ b/apps/web/lib/personas.ts
@@ -6,27 +6,9 @@ import type {
 } from "@egma/platform-api/client";
 
 /**
- * The personas of one project, as `/v1/personas` answers them.
- *
- * A **persona** is the synthetic person who speaks with the agent. Egma
- * supplies a Predefined persona to every project, and a project can author a
- * Custom persona or fork the shared one.
- *
- * **A persona carries two names, and they are two different things.** `name` is
- * the team's word for them — shown in lists, pickers and the sheet's head,
- * rewritten in place, never spoken. `identityName` is the human name they give
- * the agent, versioned exactly like their personality, so the same test hears
- * the same person on every run.
- *
- * **Nothing in a persona says what that persona wants.** That is the test's
- * scenario. The whole worth of a persona is that one of them is used in forty
- * different situations, and a trait that said "asks to reschedule" would turn
- * a reusable person into a second copy of one test. The editor says so where
- * somebody is typing, and this file says so where somebody is reading.
- *
- * The shape is the API's own, field names included. Renaming its fields on the
- * way in would put a second vocabulary between the contract and the page, and
- * the two would drift the first time the API grew a field.
+ * Persona response types from the API. Projects can use Egma-provided or
+ * Custom personas. name is editable metadata; identityName is versioned
+ * behavior. The test scenario specifies what the persona wants to achieve.
  */
 
 export type Persona = GetPersonaResponse;
@@ -142,16 +124,8 @@ export function sameModelsDraft(
 }
 
 /**
- * One engine choice, as one control.
- *
- * **A provider and a model are one decision, and the boards draw one control
- * for it.** The server's catalog is a list of pairs its adapters can actually
- * execute, so a single choice over those pairs cannot produce a combination
- * that does not exist — where two controls, one for the provider and one for
- * the model, have to be kept in step by hand and can disagree in between.
- *
- * The value is the pair, joined by a separator no provider or model id
- * contains, because an `<option>` carries one string.
+ * Encode a catalog provider/model pair as one select value. Both IDs must
+ * exclude the separator for decoding to recover the pair.
  */
 export const MODEL_PAIR_SEPARATOR = "::";
 
@@ -174,14 +148,8 @@ export function modelPairFrom(
 }
 
 /**
- * What a person calls a provider, as against what a persona stores.
- *
- * A persona stores `openai`; the server's catalog is where `OpenAI` is
- * written, and the boards read the sheet's models back with the catalog's own
- * label. The provider is the fallback rather than an error: the catalog is a
- * second read that may not have answered yet, and a persona can name a
- * provider the deployment has since stopped offering. Neither is a reason to
- * show nothing.
+ * Use the catalog's provider label, falling back to its ID when the catalog
+ * is unavailable or no longer offers that provider.
  */
 export function modelSaid(
   catalog: readonly PersonaModelCatalogEntry[] | undefined,

--- a/apps/web/lib/project-context.ts
+++ b/apps/web/lib/project-context.ts
@@ -1,18 +1,8 @@
 /**
- * Which project a tab is looking at, and how it says so.
- *
- * **The address is the whole of the product-navigation answer.** There is no
- * mutable chosen project in a cookie or local storage — a person with Outbound
- * open in one tab and Support in another is an ordinary person, and neither tab
- * can be right if one mutable value decides for both. The API session does
- * carry its initial project for projectless requests, but every project page
- * names its project in both its URL and its requests. Reload, Back, Forward and
- * a pasted link therefore restore the same product context.
- *
- * Every product page therefore lives under `/projects/{projectId}/…` and every
- * product request it makes carries the same identifier. The identifier is the
- * project's stable id rather than its slug, because a slug is an admin's to
- * rename and a link somebody sent last month must still open the same project.
+ * Project pages carry the stable project ID in the URL and API requests.
+ * This lets separate tabs use separate projects and keeps links valid after
+ * a rename. Account routes need no project; API sessions also have an initial
+ * project fallback for requests that omit one.
  */
 
 export const PROJECT_SEGMENT = "projects";
@@ -60,24 +50,8 @@ export function sectionIn(pathname: string): string | null {
 }
 
 /**
- * The same page, in another project.
- *
- * **The area survives the change and the resource does not.** Somebody
- * switching project from a list wants that list in the other project; somebody
- * switching from one agent's page cannot want *that* agent, because it is not
- * in the project they just picked and the link would land on a refusal. So the
- * section is kept and everything under it is dropped.
- *
- * An address with no project in it at all becomes the new project's landing
- * page, because there is no area to carry across. `/new-project` carries no
- * project and can reach this function, because the only
- * caller is the selector's click handler and `AppShell` draws the selector on
- * every page it wraps, unconditionally, whatever the address says:
- *
- * - `/new-project`, which an organization holding none has to be able to reach.
- *
- * It lands on the new project's landing page because there is no area on the
- * address to carry into the project just picked.
+ * Keep the section when switching projects, but drop record IDs that belong
+ * to the old project. Addresses without a project use the new project's landing page.
  */
 export function inProject(pathname: string, projectId: string): string {
   const address = addressIn(pathname);

--- a/apps/web/lib/recording-refusals.ts
+++ b/apps/web/lib/recording-refusals.ts
@@ -1,48 +1,13 @@
 /**
- * Whether a refusal of a recording is worth saying out loud.
- *
- * It is the whole of what the player decides for itself, so it is here rather
- * than inside the component: a rule carried only by a render branch is a rule
- * nothing can test, and this one has been got wrong twice already.
- *
- * The shape of the problem. Two surfaces ask egma to turn a conversation's
- * recording into a link, and they are not asking the same question. A run's
- * results **already know** there is one — the run's own answer said so — so any
- * refusal there contradicts what the page was just told. One transcript knows
- * only which simulation it is; asking *is* how it discovers whether there is
- * anything to hear, and a chat and a call that never connected are ordinary
- * answers rather than faults. Those get nothing at all: not a disabled control,
- * not an error, nothing — because a control that does nothing reads as a broken
- * feature, and a sentence beside every chat is that control wearing words.
- *
- * **Silence is bought for that one case and no other**, and the two ways of
- * over-buying it are the two bugs this has had. A store nobody configured, a
- * fault, an egma that cannot be reached, a row carrying a corrupt reference —
- * every one of those is about *egma* rather than about the conversation, and a
- * broken deployment that looks exactly like a product working correctly is the
- * failure the whole recordings effort exists to end. And a refusal arriving
- * **after** a link had already worked is never quiet either: by then somebody
- * has a player on screen, and one that vanishes without a word is worse than
- * the error it hides.
+ * Hide expected recording absence only while availability is unknown. Once
+ * a recording is known to exist or a player has worked, show failures instead
+ * of silently removing it. Configuration and transport failures remain visible.
  */
 
 /**
- * The codes this route answers with when there is nothing to hear and there
- * never was: `not_found` is *no simulation of yours has that id* and *this one
- * recorded nothing*; `unprocessable` is *a chat has no audio and never will*.
- *
- * **Codes, and never the status alone.** Fastify's own not-found reply carries
- * a `message` and a 404 — so does an API gateway's, and so does a proxy that
- * has stopped forwarding this path — and every one of those is a broken
- * deployment rather than a conversation without audio. That misconfiguration
- * has happened once already on this exact route. A code is the API's promise
- * (`apps/api/src/http/refusals.ts`: *the codes are contract and never change;
- * the sentences improve deliberately*), so a code is what this reads.
- *
- * A refusal egma answers with any other code — including a reference it will
- * not sign, which is a defect and has `unsignable_reference` of its own — is
- * shown. Anything unrecognised is shown too, which is the safe direction: a new
- * refusal is heard until somebody decides it is an absence.
+ * Treat only the API codes not_found and unprocessable as expected absence.
+ * HTTP status alone could come from a broken proxy route. Show unknown codes
+ * and unsignable references as failures.
  */
 export const NOTHING_TO_HEAR: ReadonlySet<string> = new Set([
   "not_found",

--- a/apps/web/lib/replay-privacy.ts
+++ b/apps/web/lib/replay-privacy.ts
@@ -1,16 +1,6 @@
 /**
- * The one thing session replay is not allowed to read: a secret drawn where a
- * person can read it.
- *
- * Replay used to mask every word on every page, and the recordings were grey
- * blocks that answered nothing. It records the pages now, so this mark is what
- * is left of the old policy — it goes on the element holding a live credential,
- * and `instrumentation-client.ts` hands the selector to PostHog as the only
- * text it masks. rrweb inherits masking down the tree, so the mark covers
- * whatever is inside the element.
- *
- * A password field needs no mark. Every input in the product stays masked by
- * PostHog's own `maskAllInputs`, so the mark is for text on the page.
+ * Mark displayed credentials for replay text masking, including descendants.
+ * PostHog maskAllInputs separately covers input values.
  */
 export const REPLAY_PRIVATE_ATTRIBUTE = "data-replay-private";
 

--- a/apps/web/lib/return-to.ts
+++ b/apps/web/lib/return-to.ts
@@ -18,18 +18,9 @@
 const HERE = "https://egma.invalid";
 
 /**
- * A return path that cannot leave this origin, or nothing.
- *
- * **The candidate is resolved, and it has to land back where it started.**
- * `//elsewhere.example/x` is a URL a browser reads as another host, and
- * `https://elsewhere.example` obviously is — but listing the shapes that leave
- * is a list somebody finds the next entry in. `/<TAB>/elsewhere.example` was
- * one: a URL parser strips tab, carriage return and newline *before* it parses,
- * so a browser reads that as `//elsewhere.example` and goes there. Asking the
- * parser instead of guessing at it cannot be enumerated around.
- *
- * The API applies the same rule before it writes a path into a reset link, and
- * the suite holds the two copies to the same answers.
+ * Resolve a root-relative candidate with the URL parser and reject a changed
+ * origin. Parsing catches host changes hidden by control characters. Keep
+ * this rule in step with the API's reset-link validation.
  */
 export function safeReturnPath(raw: string | null | undefined): string | null {
   if (raw === null || raw === undefined) return null;

--- a/apps/web/lib/roles.ts
+++ b/apps/web/lib/roles.ts
@@ -1,16 +1,7 @@
 /**
- * What the role somebody holds in their organization lets them do, as the
- * pages read it.
- *
- * **Hiding a control is not authorization.** Every one of these answers is
- * about what is worth showing somebody; the server checks the same permission
- * again on every request and is the only thing standing between a viewer and a
- * write. That is why an unrecognized role reads as `viewer` here: the worst a
- * wrong guess can do is show too little, and showing too much is the failure
- * that would matter.
- *
- * A membership is held in the organization and applies to every project in it,
- * so none of these takes a project. Selecting a project never grants access.
+ * Organization roles control which actions the UI offers across projects.
+ * Unknown roles use viewer permissions. These helpers do not authorize
+ * requests; the server enforces access.
  */
 
 export const ROLES = ["admin", "member", "viewer"] as const;

--- a/apps/web/lib/settings.ts
+++ b/apps/web/lib/settings.ts
@@ -10,16 +10,8 @@ import type {
 } from "@egma/platform-api/client";
 
 /**
- * What the Settings pages read: the organization, the projects in it, the
- * people, and the keys.
- *
- * **The shapes are the API's, spelled once.** Four pages read these and a fifth
- * will; a page that re-declared `{ id, name, slug }` for itself would be a page
- * that keeps working after the API stops sending one of them.
- *
- * Nothing here can hold a secret. An API key's row carries what it looks like
- * and never what it is: the plaintext exists once, in the answer to the request
- * that minted it, and is never readable again from any route.
+ * Settings types from the generated API contract. Listed API keys contain
+ * metadata; only the creation response includes the new secret.
  */
 
 export type ProjectSettings = CreateProjectResponse &
@@ -38,20 +30,8 @@ export type Invitation = ListInvitationsResponse["invitations"][number];
 export type InvitationList = ListInvitationsResponse;
 
 /**
- * Whether an invitation can still be accepted.
- *
- * **Two states and not one.** The list route answers with every invitation
- * nobody has accepted, and the ones whose day has passed are in it: they read
- * as waiting when nothing is coming. Somebody who cannot tell them apart waits
- * for a person who was never going to be able to accept.
- *
- * `accepted` is the third state a link can be in and is deliberately not here —
- * an accepted invitation is a member, and the roster is where it shows up.
- *
- * The comparison is the one `stateOf` makes on the server, on the same field.
- * A date egma did not send, or sent unreadably, leaves this `pending`: a
- * standing this could not work out is not grounds for calling an invitation
- * dead.
+ * Unaccepted invitations are pending or expired. Invalid dates remain pending;
+ * accepted invitations are omitted by the list route.
  */
 export type InvitationStanding = "pending" | "expired";
 
@@ -89,15 +69,8 @@ export const NEW_PROJECT_PATH = "/new-project";
 export const ASSIGNABLE_ROLES = ["admin", "member", "viewer"] as const;
 
 /**
- * The rows an answer actually carried, and none at all when it carried
- * something these pages cannot read.
- *
- * A read whose shape is not the expected one is a deployment mid-upgrade, a
- * proxy answering for something else, or a write's own reply arriving where a
- * list was asked for. The cost of trusting it is not a wrong list — it is
- * `undefined.map`, which takes the whole settings page down and with it the
- * thing somebody came to change. An empty list renders an honest state; a crash
- * renders nothing at all.
+ * Fall back to an empty array for an absent or malformed list value. This
+ * prevents a render error but does not distinguish invalid data from no rows.
  */
 export function rowsIn<T>(rows: readonly T[] | undefined): readonly T[] {
   return Array.isArray(rows) ? rows : [];

--- a/apps/web/lib/signup-defaults.ts
+++ b/apps/web/lib/signup-defaults.ts
@@ -1,14 +1,6 @@
 /**
- * What the signup form says before anybody types in it.
- *
- * A person signing up should be able to accept both names and move on. The
- * organization comes from their email domain and the project is called
- * `Default`, and both are ordinary editable fields — nothing here decides
- * anything, it only saves typing.
- *
- * The API knows the same two rules, because an identity can be created without
- * ever seeing this page and still has to land somewhere sensible. A test holds
- * the two copies to the same answers.
+ * Default organization and project names for signup. Keep these rules in
+ * step with the API so previews match the names created.
  */
 
 export const DEFAULT_PROJECT_NAME = "Default";

--- a/apps/web/lib/test-suites.ts
+++ b/apps/web/lib/test-suites.ts
@@ -50,16 +50,7 @@ export function runSuitePath(projectId: string, suiteId: string): string {
   return `/projects/${encodeURIComponent(projectId)}/runs/new?suite=${encodeURIComponent(suiteId)}`;
 }
 
-/**
- * Whether a row survives what somebody typed in the search box.
- *
- * **The filter runs in the browser, and that is a gap rather than a design.**
- * Neither `listTestSuites` nor `listTests` takes a search, so this narrows the
- * page that is already on screen. It stays honest because the empty result says
- * which emptiness it is — "No test suites match …" is a different sentence from
- * "No test suites yet" — and it is why neither list pages through everything to
- * answer a search.
- */
+/** Filter names in the rows already fetched; this is not a server-wide search. */
 export function matchesSearch(name: string, search: string): boolean {
   const wanted = search.trim().toLocaleLowerCase();
   return wanted === "" || name.toLocaleLowerCase().includes(wanted);

--- a/apps/web/lib/tests.ts
+++ b/apps/web/lib/tests.ts
@@ -3,17 +3,7 @@ import type {
   ListTestsResponse,
 } from "@egma/platform-api/client";
 
-/**
- * Test wire shapes, as the generated platform contract returns them.
- *
- * **What is left is what still has a reader.** The test full page and the
- * write-a-test sheet retired on 2026-08-24, and everything this file held for
- * them went with them: the address of a test's own page, the persona-overflow
- * cell, the live/versioned field lists that told a two-save form which half it
- * was saving, and the behavior checks that form ran before its Save. The grid
- * asks those questions of its own cells, and the version shapes have no reader
- * at all while versioning stays hidden from the interface.
- */
+/** Test response types from the generated platform contract. */
 export type ListedTest = CreateTestResponse;
 export type TestPage = ListTestsResponse;
 
@@ -29,27 +19,10 @@ export type Read<T> =
   | { readonly ok: false; readonly why: string };
 
 /**
- * The two JSON fields, read the way the platform reads them.
- *
- * **These say the platform's own sentences, deliberately.** The grid's dialog
- * runs this before it sends anything, so a person who wrote `answer` twice sees
- * why without a round trip — and the sentence they see is the one they would
- * have got back, rather than a second, quieter opinion this screen invented.
- * The checks that need the exact serialized bytes stay on the server, because
- * only the server knows what it is about to write; a refusal from there is
- * shown in the same place.
- *
- * `packages/db/src/access/tests.ts` is where the same rules are kept for the
- * write itself, and it is the authority. What is here is a copy of the cheap
- * half of it, and it must say the same words.
- *
- * **The envelope has its own authority**, and it is
- * `apps/api/src/routes/tests.ts`: the door owns the shape of what arrives — a
- * list, of objects, with no key the shape has no place for — and the access
- * layer owns everything inside it. So the two sentences about the envelope are
- * copied from the door and the rest from the access layer, and a person who
- * writes the same mistake into the dialog and into a request reads one
- * sentence either way.
+ * Validate parsed JSON before submission, using the API's error messages.
+ * Envelope rules come from apps/api/src/routes/tests.ts; content rules come
+ * from packages/db/src/access/tests.ts. The server remains authoritative
+ * and also checks serialized size. JSON.parse cannot detect duplicate object keys.
  */
 
 /** The two keys an env may carry, and nothing else. */
@@ -259,19 +232,7 @@ export function mockToolsSummary(mockTools: readonly TestMockTool[]): string {
     : `${String(mockTools.length)} mock tools`;
 }
 
-/**
- * What an Env cell says at rest, and nothing when it holds none.
- *
- * **It names the way in rather than the keys.** The cell used to list the
- * platforms' own key names — `retell_dynamic_variables, job_dispatch_metadata`
- * is 47 characters of identifier — in the narrowest lane of the grid, where it
- * ran out through the column and told a reader nothing they could act on. The
- * cell is a button that opens the editor, so it says what pressing it does and
- * the keys are read where they can be read whole (founder, 2026-09-04).
- *
- * An env of empty objects still says nothing: `readEnv` never stores one, and
- * a cell that announced a value nobody wrote would be a lie about the row.
- */
+/** Show an editor action for nonempty env values. Empty objects produce no summary. */
 export function envSummary(env: TestEnv | null): string {
   if (env === null) return "";
   return ENV_KEYS.some((key) => env[key] !== undefined) ? "View env variables" : "";

--- a/apps/web/lib/transcript-copy.ts
+++ b/apps/web/lib/transcript-copy.ts
@@ -1,44 +1,12 @@
 /**
- * Every word these two pages say out loud, in one file.
- *
- * The store underneath them files a *trace* made of *spans*, and both of those
- * are storage words that never reach a person — `product-docs` puts them on the
- * reserved list precisely so that the row in ClickHouse and the thing somebody
- * reads never end up sharing a name. What a person reads is a **transcript**:
- * the record of the exchange, turns labelled `human:` and `agent:`, each with
- * what happened inside it.
- *
- * Collecting the copy here rather than scattering it through the markup is not
- * tidiness. It is what makes the vocabulary **checkable**: one test reads every
- * value below and holds it against the banned list, so a word that should never
- * have been typed fails the build rather than shipping in a heading. Any string
- * a page renders belongs in here.
- *
- * The URLs are deliberately not copy. The v1 endpoint's own path is a machine
- * surface — matching it is how somebody reading the network tab finds the
- * request — and no page ever prints it as a word. What a person navigates is
- * **Traces**, under **OBSERVABILITY**, and what they open there is a
- * **transcript**.
+ * Shared copy for the production evidence list and transcript detail.
+ * Keep spoken turns and tool calls named consistently; API paths remain
+ * machine identifiers rather than display copy.
  */
 
 /** The list page. */
 export const LIST = {
-  /**
-   * The heading, and deliberately not the navigation label: the sidebar reads
-   * its words from `lib/navigation.ts`, which is where a navigation item is
-   * decided. Two copies of the word that could disagree would be one too many,
-   * and this is the one the page renders.
-   *
-   * **It says Traces** (developer decision, 2026-08-25). It used to say
-   * Transcripts, under a sidebar group that used to say Monitoring; the group
-   * says OBSERVABILITY now and this screen is named for what lands on it.
-   *
-   * The rename is a *surface* rename and nothing else. The address did not
-   * move, and neither did the artifact's name: what a person opens from this
-   * list is still a **transcript**, and every row, fact and label below still
-   * says so. `trace` is honest here because it is the word a person's own SDK
-   * uses for what it reports — it is not the storage row leaking upward.
-   */
+  /** Page heading. Navigation labels are defined in lib/navigation.ts. */
   title: "Traces",
   /** What the table is called where somebody hears it rather than sees it. */
   tableLabel: "Production transcripts in this project",
@@ -66,17 +34,7 @@ export const LIST = {
   nothing: "—",
 } as const;
 
-/**
- * What each column of the list is called. The **order** they are shown in is
- * the page's, decided beside the cell that fills each one so that a heading and
- * the values under it can never drift apart.
- *
- * **There is no source column, and there is no name here for one.** Every row on
- * this surface is production by definition — a simulation is read under the run
- * that produced it — so a column repeating that on every line would be furniture
- * around a constant. The word is still a fact about one exchange and it is still
- * shown on the transcript, under `FACTS` below.
- */
+/** Trace-list column labels; the page owns their order. */
 export const COLUMNS = {
   started: "Started",
   duration: "Duration",
@@ -146,31 +104,9 @@ export const TRACE_SHEET = {
 } as const;
 
 /**
- * What a quiet Monitoring page says, in four states that never overlap.
- *
- * A page with nothing on it is where a developer decides whether egma works.
- * Each of these answers a different question, and the wrong one costs an
- * afternoon:
- *
- * 1. **Nothing in this window.** The list is empty because of the window rather
- *    than because of the project — a week of traffic read at the last hour. One
- *    line and the way out, and none of the teaching below: greeting a working
- *    export with a setup tutorial tells somebody their export is broken. It is
- *    also what a page says when it could not find out which of the two it was
- *    looking at, because this line is true either way.
- * 2. **Nothing has arrived, at any window.** The whole export setup, in the
- *    shortest form there is: the address this deployment listens on, the two
- *    variables that point an agent at it, where to mint the key they carry, and
- *    the caution about the key scope. Whichever window is
- *    selected — a developer on their first day lands on the default one, and
- *    this is the page written for them.
- * 3. **Nothing has arrived, and a key that names the whole organization is
- *    visible.** Customer OTLP rejects that scope because no project would own
- *    the evidence. Pointing somebody back to generic export setup would miss
- *    the specific key change they need, so this replaces the teaching.
- * 4. **Traffic is arriving and no project grader grades production.** The
- *    Expected behaviors grader grades simulations only, so an absence of grades
- *    here is the ordinary first state rather than a fault.
+ * Guidance for an empty window, empty recent history, a visible organization
+ * key, or traffic with no production grader. The history probe covers only
+ * the widest offered window; it does not establish all-time absence.
  */
 export const QUIET = {
   narrowWindow: {
@@ -318,22 +254,9 @@ export const FACTS = {
 } as const;
 
 /**
- * What this exchange measured — the metrics display, in words.
- *
- * A metric records an observed fact. A grader assigns a normalized score. The
- * two are shown apart for exactly that reason: the numbers below say what
- * happened, while the grades above say how a grader scored the trace. Nothing
- * here is green or red because a duration is not good or bad by itself.
- *
- * The numbers come off egma's one shared measure module — the same module the
- * response-latency grader reads through — and the page leads with the p90
- * turn, because the slow tail is what a caller hangs up on. The samples a
- * grade was computed over are the same list this figure was reduced from, so
- * the page can never be the reason somebody distrusts the score.
- *
- * A measure the spans do not carry is **absent** rather than shown as nothing:
- * an empty row would read as a measurement of zero, and a chat exchange has no
- * audio to have measured.
+ * Metric display text. Metrics describe observations; grades contain scores.
+ * Use API reductions and catalog units, and omit absent metrics instead of
+ * showing zero. metricLine displays p90; other surfaces can choose another reduction.
  */
 export const MEASURES = {
   label: "What was measured",
@@ -342,31 +265,13 @@ export const MEASURES = {
     "Nothing was measured here. Egma's own simulations time their turns; an " +
     "exchange your agent had carries whatever its telemetry emitted, which " +
     "for most frameworks is no timings at all.",
-  /**
-   * Where the numbers came from, said once and only when it applies.
-   *
-   * **A metric's provenance must never be a surprise.** Some of these figures
-   * were not timed by anybody: Egma worked them out from the timings your
-   * agent's own framework already records. A developer whose latency check
-   * suddenly starts failing is owed that sentence on the same screen as the
-   * number, not in a document they would have to go and find.
-   *
-   * Shown only when at least one figure on this page was worked out that way.
-   * A page whose every number was timed outright says nothing here, because a
-   * caveat about something that did not happen is noise.
-   */
+  /** Show when at least one displayed metric was derived from framework timings. */
   derived:
     "Some figures here were worked out from your framework's own timings " +
     "rather than timed by Egma. Each says which.",
   /**
-   * The mark beside one worked-out figure, so a reader need not guess which.
-   *
-   * **It belongs to that one origin and no other.** A figure an agent platform
-   * measured and handed over was not worked out from any framework's timings,
-   * so this wording is false about it — and a caveat that is itself untrue is
-   * worse than none, because it is the sentence a developer decides how much to
-   * believe a grade based on. A platform-reported figure therefore takes no mark and
-   * no caveat at all; where it came from stays on the record, not on the page.
+   * Mark framework-derived metrics only. Agent-platform reported values have
+   * a different origin and must not receive this label.
    */
   derivedOne: "from your framework's timings",
   /** One measurement is the number; several are read at the p90 — the figure
@@ -387,24 +292,9 @@ export const MEASURES = {
 } as const;
 
 /**
- * The audio **egma** recorded, and the words that keep it apart from the audio
- * a step carries.
- *
- * Two different things share one word on this page, and the confusion is not
- * hypothetical: a step can carry an `audioUrl` the agent's own telemetry
- * attached to it — somebody else's file, at somebody else's address, of
- * whatever that framework decided to keep. What is below is egma's own: both
- * sides of a voice conversation egma drove, the human on one channel and the
- * agent on the other, so either can be heard alone when a turn reads wrong.
- *
- * Neither is ever named just "audio". Each says whose it is, everywhere it
- * appears, so a reader never has to hold two labels side by side to work out
- * which one they are hearing.
- *
- * `persona` is the word for the human side in a **run's** results, and it is
- * deliberately not used here: a transcript may be a production exchange that
- * nobody simulated, where there is no persona to name. `human` and `agent` are
- * the two speakers a transcript labels, and they are what this says.
+ * Distinguish Egma's simulation recording from external audio URLs on spans.
+ * Transcript speaker labels use human and agent because the same surface
+ * also reads production traces, which have no persona.
  */
 export const RECORDING = {
   label: "What Egma heard",
@@ -436,32 +326,7 @@ export const RECORDING = {
     `Egma answered ${String(status)} for the audio it recorded here.`,
 } as const;
 
-/**
- * What each stored `kind` is called where a person can read it.
- *
- * The keys are the store's vocabulary and the values are the product's, and the
- * mapping is deliberate rather than a prettified passthrough:
- *
- * - `model` → **Model** — the language model answering.
- * - `tts` → **Speech** — turning the answer into audio. Not "TTS": an acronym
- *   is a word only to whoever already knows it.
- * - `stt` → **Speech recognition** — turning what was heard into words. No
- *   provider egma has met emits it: LiveKit puts what was heard on the turn
- *   itself rather than on a step of its own. It is here because the ticket
- *   names the step, and a framework that does emit one should meet a word for
- *   it rather than **Other**.
- * - `tool` → **Tool** — the agent reaching for something outside itself.
- * - `end-of-turn` → **Turn detection** — deciding the speaker had finished.
- * - `speaking` → **Speaking** — how long somebody's audio ran.
- * - `root` → **Overview** — the one step everything else happened inside. It is
- *   never part of the exchange, and it is reachable rather than displayed.
- * - `other` → **Other** — a provider egma has no vocabulary for yet. It renders
- *   rather than disappearing, because a step nobody named still took time.
- *
- * An unknown kind falls through to **Other** for the same reason: coverage is
- * not uniform across providers, and a page that hid what it could not classify
- * would quietly under-report the very frameworks egma has not met yet.
- */
+/** Display labels for stored span kinds. Unknown kinds remain visible as Other. */
 export const STEP_LABELS: Readonly<Record<string, string>> = {
   root: "Overview",
   "turn:human": "Human turn",

--- a/apps/web/lib/transcripts.ts
+++ b/apps/web/lib/transcripts.ts
@@ -13,21 +13,10 @@ import {
 } from "./transcript-copy.ts";
 
 /**
- * What the two v1 read endpoints answer with, and the handful of pure decisions
- * the pages make about it.
- *
- * The types use the contract's own lower-camel field names and storage words.
- * Durations stay as decimal strings because this is the wire; renaming it here
- * would mean two vocabularies to keep in step instead of one. Everything a
- * person reads is decided in `transcript-copy.ts`; nothing below returns a
- * sentence.
- *
- * The window functions are the load-bearing part. **Both endpoints require one
- * and neither defaults**, deliberately: the store is filed by time, so a read
- * that named no window would be a read of everything. That refusal is the
- * server's, and these are the pages' answer to it — a default of the last day
- * for the list, and, for one transcript, the window it was already known to
- * have happened in.
+ * Trace response types, display formatting, and bounded query windows.
+ * Preserve wire field names and decimal-string durations. Both read endpoints
+ * require a time window: the list uses the last day, and detail uses the
+ * record's known window.
  */
 
 /** Trace-level facts, as both endpoints report them. */
@@ -38,69 +27,23 @@ export type Step = TraceSpan;
 export type Grade = GetTraceResponse["grades"][number];
 
 /**
- * One measure this exchange produced, as the read hands it over.
- *
- * **Computed by the platform, never here — the reduction included.** The
- * samples arrive already worked out by egma's one shared measure module, and
- * so do the reductions — `mean`, `p50` and `p90`, each computed once in that
- * module. All of it is the platform's arithmetic, so this application renders
- * figures rather than deriving any.
- *
- * The reduction is the part that matters. Averaging the samples here would look
- * harmless and would be a second implementation of the exact number the page
- * leads with — correct until the day the rounding or the samples change under
- * one of them. A developer who found this page and the platform disagreeing
- * would be right to stop believing both, so the page is not allowed to be
- * capable of it.
- *
- * The unit rides each measure because the measure catalog owns it: a page that
- * assumed milliseconds would be wrong the moment somebody bounds a measure
- * counted in something else.
+ * Metric samples, reductions, and units supplied by the API. Render these
+ * values instead of recomputing the reductions in the browser.
  */
 export type Measured = GetTraceResponse["metrics"][number];
 
 /**
- * Whether Egma worked this figure out from the framework's own timings — the
- * one origin the pages say anything about.
- *
- * **`derived` alone does not answer it.** A figure an agent platform reported
- * arrives derived as well, because Egma did not time it either; `reportedBy`
- * beside it is what tells the two apart. Without that second half a page would
- * tell a developer their platform's number was "worked out from your
- * framework's own timings", which is a claim about an observation Egma never
- * made. A platform-reported figure takes no mark and no caveat; the rest of
- * its provenance stays on the record.
+ * Framework-derived metrics have derived=true and no reportedBy.
+ * Agent-platform reported values also set derived, so check both fields.
  */
 export function workedOutMetric(one: Measured): boolean {
   return one.derived === true && one.reportedBy === undefined;
 }
 
 /**
- * One metric as a person reads it, the same words on every surface that shows
- * one: the p90 the platform reduced to, its unit, and — where there was more
- * than one measurement — how many the figure stands over.
- *
- * **The p90 leads because the tail is what a caller feels.** The wire also
- * carries the median and the mean, computed by the same module; which of the
- * three a surface shows is a display decision, and today's is the p90. One
- * measurement is simply the number — every reduction of one sample is that
- * sample, so naming a statistic over it would be dressing.
- *
- * **Nothing is worked out here.** `p90` arrives on the answer, nearest-rank
- * from the shared measure module; this reads it. The series is used for one
- * thing only, which is saying how many measurements there were. A prefix says
- * so instead of the count, because the p90 of the part Egma holds is not the
- * p90 of the call.
- *
- * **The figure is printed to the whole unit.** A derived sample carries
- * nanosecond truth ("1994.917806"), and a person reads none of it: the page
- * says 1995, and the exact sample stays on the wire beside it for anything
- * that needs the last digits. Rounded here, in the one formatter, so no two
- * surfaces can differ in the last digit.
- *
- * Written once and imported by the transcript page and the simulation
- * evidence, so the two surfaces that show one conversation's metrics cannot
- * come to word the same figure two ways.
+ * Format the API's p90 rounded to a whole unit. For complete series, include
+ * the sample count when greater than one; for partial series, label the limited
+ * coverage instead. Add provenance only for framework-derived metrics.
  */
 export function metricLine(one: Measured): string {
   const shown = `${String(Math.round(one.p90))} ${one.unit}`;
@@ -168,14 +111,8 @@ const HOUR = 60 * 60 * 1000;
 const CLOCK_SKEW = 60 * 1000;
 
 /**
- * What the list's window is called in the address.
- *
- * The chosen window rides there rather than living only in this page's state,
- * so that a reload, a bookmark and a link somebody was sent all stay on the
- * window they were looking at. It is deliberately the choice — `7d` — and not
- * the two instants it computes to: those are a moment's arithmetic and would
- * freeze the list at whenever the link was made, which is the opposite of what
- * "the last seven days" means.
+ * Store the relative window choice in the URL so saved links remain relative
+ * to the time they are opened, rather than freezing exact timestamps.
  */
 export const WINDOW_PARAMETER = "window";
 
@@ -200,16 +137,8 @@ function hoursIn(choice: WindowChoice): number {
 }
 
 /**
- * Whether this is the widest window the control offers.
- *
- * It is what separates *nothing here* from *nothing in this hour*. A project
- * with a week of traffic read at the last hour is an empty list and a healthy
- * project, and the widest choice is as close to "everything" as this page can
- * ask for — the store caps a read at thirty-one days, so nothing wider exists
- * to offer.
- *
- * Derived from the offered windows rather than written down, so adding a wider
- * one moves this with it.
+ * The widest offered window, derived from the choices. It is bounded recent
+ * history, not an all-time query.
  */
 export const WIDEST_WINDOW: WindowChoice = WINDOWS.reduce((one, other) =>
   other.hours > one.hours ? other : one,
@@ -229,18 +158,8 @@ export function recentWindow(choice: WindowChoice, now: Date): Window {
 }
 
 /**
- * A second either side of when something happened.
- *
- * This is what lets one transcript be a link. The detail endpoint requires a
- * window too — a name is not a prefix of the store's filing order, so a lookup
- * naming only a name would have nothing to prune with — and the list already
- * knows when the exchange happened, so the row carries the answer into the URL
- * and the page deep-links from then on.
- *
- * Padded rather than exact because the end of a window is **open**: a `to` at
- * the closing instant excludes the very step that ended there. A second is far
- * more than the microsecond that would strictly be needed, and it costs a query
- * bounded by the same minute either way.
+ * Pad detail-query bounds by one second to cover timestamp rounding and the
+ * exclusive upper bound. Trace links carry this bounded lookup window.
  */
 const PADDING = 1000;
 
@@ -292,65 +211,18 @@ export function transcriptPath(projectId: string, facts: Facts): string {
   return `${transcriptsPath(projectId)}/${encodeURIComponent(facts.traceId)}?${query.toString()}`;
 }
 
-/**
- * What the store calls the two kinds of traffic, and the one this surface asks
- * for.
- *
- * **Monitoring is production and nothing else.** A simulation has a richer page
- * of its own inside the run that produced it — the frozen test, the persona, the
- * graders, the mock tools — so drawing it a second time and poorer, in a mixed
- * list, is a wrong door. The filter is the server's, in the address of the
- * request: narrowing what came back would answer differently depending on what
- * had already been fetched, and would quietly break paging.
- */
+
 /* ------------------------------------------------------------------ *
  * What to say when the page is quiet.
  * ------------------------------------------------------------------ */
 
 /**
- * Which guidance a quiet Monitoring page owes its reader — one of four, and
- * never two at once.
- *
- * Each answers a different question, and showing the wrong one sends somebody
- * the wrong way for an afternoon:
- *
- * - `nothing-in-this-window` — the list is empty because of the **window**, not
- *   because of the project: something *is* recorded further back. A week of
- *   traffic read at the last hour is an empty page and a healthy project, and
- *   greeting it with a setup tutorial tells somebody their working export is
- *   broken. One line and the way out; nothing else, because nothing else is
- *   known to be wrong.
- * - `set-up-capture` — nothing has arrived **anywhere**, at any window this page
- *   can ask about. The reader has an agent and no export, so what they need is
- *   the address, the two variables and a project key. It does not matter which
- *   window is selected: a developer whose first
- *   ever page is empty is the person this teaching exists for, and the default
- *   window is where they land.
- * - `key-names-the-organization` — the same emptiness, with a key that names no
- *   project actually **visible** to this reader. Customer OTLP rejects that
- *   scope because no project would own the evidence. This state points to the
- *   specific key change instead of repeating generic export setup.
- * - `nothing-watches-production` — traffic is arriving and no project grader is
- *   scoped to it, so grades stay absent. The Expected behaviors grader is fixed
- *   to simulations, so this is an ordinary first state.
- *
- * Nothing at all is the fifth answer, and it is the one a healthy project gets:
- * traffic arriving, with at least one project grader that grades production.
- *
- * The order is the point. With no traffic, telling somebody that no grader
- * watches production is noise about a problem they do not have yet.
- *
- * **A count nobody answered is `null`, and it is never read as a zero.** A
- * failed grader read folded into "no grader watches production" would put a
- * claim on screen that egma has no answer for — the same collapse
- * `ui/page-state.tsx` forbids between failed and empty — so a supporting read
- * that did not land means one less thing this page says, and never one more.
- *
- * `everRecorded` is that rule at its sharpest, because both of the sentences it
- * decides between are confident ones. Unanswered, the page falls back to the
- * window line: *nothing here, try a wider window* is true whatever the answer
- * would have been, while the teaching would be telling somebody with a working
- * export to go and build one.
+ * Choose one guidance state from available reads. An empty current window
+ * uses wider recent history to choose between widening the window and setup.
+ * A visible organization key takes precedence over general setup guidance.
+ * With traffic present, suggest grading only when the production grader count
+ * is known to be zero. null means unanswered, never zero. Despite its name,
+ * everRecorded covers only the widest offered window.
  */
 export type Quiet =
   | "nothing-in-this-window"
@@ -362,11 +234,8 @@ export function quietState(seen: {
   /** How many production conversations this window holds. */
   readonly listed: number;
   /**
-   * How many this project holds at the widest window there is — the answer to
-   * *has anything ever arrived* — or `null` where nothing answered.
-   *
-   * Only read when the window on screen is empty, which is the only time the
-   * question is asked.
+   * Count from the widest offered recent window, or null if the read failed.
+   * Read only when the current window is empty; this is not an all-time count.
    */
   readonly everRecorded: number | null;
   /** Visible keys that name no project, or `null` where nothing answered. */

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -2,17 +2,8 @@ import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 /**
- * Join class names, and let the last one win.
- *
- * Every shadcn component takes a `className` and merges it over its own
- * classes with this. `clsx` flattens the conditional forms; `tailwind-merge`
- * then drops earlier classes that set the same property, so a caller passing
- * `rounded-card` to a component that already says `rounded-button` gets one
- * radius rather than two declarations racing on source order.
- *
- * It is `lib/utils.ts` because that is where `components.json` points the
- * shadcn CLI. A component added by the CLI imports `@/lib/utils` and needs no
- * edit to compile here.
+ * Flatten conditional classes with clsx, then resolve conflicts recognized
+ * by tailwind-merge. Keep this import path in step with components.json.
  */
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,41 +1,15 @@
 import type { NextConfig } from "next";
 
 /**
- * The API is reached through this process, not around it.
- *
- * The pages and the API answer on one origin in every deployment, so the
- * session cookie is valid for both and there is no cross-origin cookie handling
- * anywhere. The browser only ever talks to the instance it loaded the page
- * from, which is also what makes a self-hoster's login depend on nothing they
- * do not run.
- *
- * **Not only the browser.** A mocked run points a customer's agent at
- * `/mock-tools/…` on this same origin, so the agent's own platform calls this
- * process too. A path this process does not forward is answered by its
- * not-found page, and a page is not an answer a caller's agent can use.
- *
- * `EGMA_API_ORIGIN` is read when the site is built rather than when it starts,
- * because Next resolves rewrites into the build. In Compose that is the API
- * service; running the two processes by hand it is localhost. Neither is a
- * value a self-hoster has to choose.
+ * Proxy API paths through the web origin for browser sessions and agent-platform
+ * mock-tool requests. Next resolves EGMA_API_ORIGIN when building rewrites;
+ * the default is the local API port.
  */
 const api = process.env.EGMA_API_ORIGIN ?? "http://127.0.0.1:3100";
 
 /**
- * Whether this build has to produce a server somebody else will start.
- *
- * `standalone` writes `.next/standalone`: the server plus the one copy of
- * `node_modules` it actually reached for. That directory is the self-hosted
- * product — `apps/web/Dockerfile` copies it into the runtime image and Compose
- * runs `node apps/web/server.js` out of it — and it is the only place the
- * directory is ever read.
- *
- * Vercel is the other place this builds, and it is not that place. It takes
- * `.next` and makes its own functions from it; it has never opened
- * `standalone`. So asking for the directory there only ever bought a slower
- * build and a copy nobody consumed, and from Next 16 it stopped being free:
- * the deployment that follows a clean build now fails. `VERCEL` is set in
- * every Vercel build, so the ask goes where the answer is used.
+ * Produce standalone output for self-hosted runtime images. Vercel builds
+ * use its deployment output instead.
  */
 const forSelfHosting = !process.env.VERCEL;
 
@@ -98,16 +72,8 @@ const config: NextConfig = {
           source: "/api/password-reset/:path*",
           destination: `${api}/api/password-reset/:path*`,
         },
-        // Where a mocked run's tool calls arrive. They come from the agent's
-        // own platform rather than from a browser, and the URLs Egma mints for
-        // them point at this origin — one origin is the design, and Retell
-        // refuses localhost and private addresses for a tool URL, so the mock
-        // endpoint has to answer where the pages answer.
-        //
-        // Without this rule they were answered by this process's not-found
-        // page: every mocked tool call on a live agent got Egma's own HTML 404,
-        // and the agent apologized to the caller for a broken backend on every
-        // call. The endpoint itself is the API's.
+        // Forward mock-tool URLs to the API. Agent platforms call these URLs directly
+        // and must receive the tool response, not Next's HTML not-found page.
         {
           source: "/mock-tools/:path*",
           destination: `${api}/mock-tools/:path*`,

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -21,15 +21,9 @@ import {
 } from "./platform-request.ts";
 
 /**
- * The Agents and Connections pages, rendered and driven.
- *
- * They are here in the fast lane rather than in the one real-browser journey
- * because none of what they prove needs a browser: a form drawn from what the
- * server said the connection options are, a control a viewer may not use being
- * genuinely disabled, a stale save keeping the typing it was refused for, and a
- * page that says `unknown` where nothing has been measured. Each drives the real
- * component the way somebody with a keyboard would and reads what the DOM then
- * says; nothing here asserts that a source file contains a string.
+ * Drive agent and connection components in jsdom: catalog-based fields, viewer
+ * restrictions, retained drafts after refused saves, and unknown measurements.
+ * These tests do not prove browser layout or server authorization.
  */
 
 const routed = vi.hoisted(() => ({
@@ -571,17 +565,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-/**
- * The agent editors use the same layout primitive as every other product form.
- *
- * It asks the elements what they are rather than what they are painted with.
- * A class name used to be the fingerprint of a shared component, because a CSS
- * Module hashes one and nothing else can produce it. On the Tailwind base a
- * class list is copyable, so a hand-rolled `<div className="flex gap-3">` would
- * pass a class check — and the migration itself failed one, which is the other
- * half of the same problem. `data-slot` is what `Form` and `FormActions` put on
- * the elements they draw, and a page that stopped using them fails this.
- */
+/** Check the shared form slots rather than copied utility classes. */
 function expectSheetLayout(action: HTMLElement): void {
   const form = action.closest("form");
   expect(form).not.toBeNull();

--- a/apps/web/test/brand-assets.test.ts
+++ b/apps/web/test/brand-assets.test.ts
@@ -1,24 +1,8 @@
 /**
- * Every file under `public/` that the application names, held against what is
- * actually there.
- *
- * **The one class of fault nothing else in this suite can see.** A component
- * test renders in jsdom, which fetches no images; the real-browser walk reads
- * a link by its accessible name rather than by whether the picture behind it
- * arrived; and Next's `<Image>` asks for a file at request time, so a missing
- * one is a 404 in the network panel and a blank rectangle on the page. Every
- * test stays green and every page in the product is wrong.
- *
- * A brand-asset migration exposed this gap: source could keep naming a deleted
- * image while component tests stayed green. This file is the guard that would
- * have reported the missing file. The public authentication Brand gives the
- * scan a real asset to hold; the signed-in shell also uses the compact mark.
- *
- * It reads the source rather than a list, so an asset added tomorrow is
- * covered the day it is written, and it deliberately says nothing about which
- * files `public/` holds: an unused file is not a fault, and demanding that
- * every asset be referenced would fail on a favicon a browser asks for by
- * convention.
+ * Check literal public-asset references found by the source scan. jsdom does
+ * not fetch images, so component tests can miss broken paths. This covers
+ * the configured source directories and reference pattern, not dynamic URLs.
+ * Unused public files are allowed, including convention-based browser assets.
  */
 
 import { readdirSync, readFileSync, statSync } from "node:fs";

--- a/apps/web/test/components.test.tsx
+++ b/apps/web/test/components.test.tsx
@@ -40,19 +40,8 @@ import {
 import { observeRequest, type FetchInput } from "./platform-request.ts";
 
 /**
- * The shared components, rendered.
- *
- * **This is the fast lane's half of the visual system, and it exists so that
- * the browser journey does not have to grow.** Ten tickets follow this one into
- * this shell; if the only way to prove a menu closes on Escape is to start
- * Postgres, ClickHouse, the API, Next and a real Chrome, then every one of them
- * will add to that file and the narrow ordered journey the spec asks for will
- * not survive. What genuinely needs a browser — two independent tabs on two
- * projects — stays there. Everything a component decides for itself is here.
- *
- * Nothing in this file asserts that a component exists or that a source file
- * contains a string. Every test drives a rendered component the way somebody
- * with a keyboard would, and reads what the DOM then says.
+ * Drive shared component behavior in jsdom. Browser layout and independent
+ * tabs require separate browser tests.
  */
 
 /**
@@ -467,16 +456,7 @@ describe("nested page navigation", () => {
     expect(page.className).toContain("font-normal");
   });
 
-  /**
-   * One page, one name — the invariant the first cut of this line broke.
-   *
-   * A header that appended its title whenever the trail's last step said
-   * something else drew two steps with no address, and this file draws every
-   * addressless step as an `<h1 aria-current="page">`. Three real pages ended
-   * up with two headings and two current steps, the settled simulation among
-   * them. The trail's type now allows one current step, and this holds the
-   * render to it: a deep trail, a short one, and a page with no trail at all.
-   */
+  /** Require one current heading with deep, short, or absent breadcrumb trails. */
   it("names itself once, whatever shape of page it is", () => {
     /* `steps` is 1 for a page inside a trail and 0 for a page with none. */
     function namesItselfOnce(page: ReactElement, steps: 0 | 1): void {
@@ -514,20 +494,7 @@ describe("nested page navigation", () => {
     namesItselfOnce(<PageHeader title="Tests" />, 0);
   });
 
-  /**
-   * The other half of the rule above, and it needs its own case.
-   *
-   * A page with no trail still says which section it is in, and on one screen
-   * that label is a *fact* rather than a repetition: the transcript page puts
-   * the trace's source and environment in it — "production / default" — and
-   * states it nowhere else. Sixty-four call sites pass this prop, so a version
-   * of `PageHeader` that accepted it and quietly drew nothing would take a
-   * line off every one of them and break no test at all. This is that test.
-   *
-   * It is not in the title bar. The bar holds the page title alone, which is
-   * what `71V-0` draws; the label and the purpose statement are the quiet
-   * block under it.
-   */
+  /** Keep the section label and purpose below the title even without breadcrumbs. */
   it("draws the eyebrow when a page offers no trail, outside the title bar", () => {
     render(
       <PageHeader
@@ -622,18 +589,8 @@ describe("a binary choice", () => {
   });
 
   /**
-   * A 44px target around an 18px box.
-   *
-   * `DESIGN.md` asks for a 44px pointer target on a coarse pointer; it does not
-   * ask for a 44px checkbox. The label is the target, because a label activates
-   * the control it wraps, so it is what grows — and only on a coarse pointer,
-   * so a mouse sees no change at all.
-   *
-   * A class assertion for the reason `design-system.test.tsx` writes down: jsdom
-   * loads no stylesheet, so what is guarded is the mapping. `pointer-coarse` is
-   * an egma variant, not a Tailwind one, and it is the whole of this fix — a
-   * later tidy that drops it takes the target back to 18px and nothing else on
-   * the page would look any different.
+   * Check the class mapping for a coarse-pointer target around the compact
+   * checkbox. jsdom cannot verify its computed size.
    */
   it("gives the checkbox a coarse-pointer target without growing its box", () => {
     render(<Checkbox id="weekly-summary" checked onChange={() => undefined} />);
@@ -673,26 +630,8 @@ describe("a binary choice", () => {
 /* ------------------------------------------------------------------------ */
 
 /**
- * The two-list choice, driven the way somebody without a pointer drives it.
- *
- * **This test moved here rather than being deleted, and where it came from is
- * the point.** It lived on the Personas list, because that page was one of the
- * two that drew this control — and the 2026-08-20 annotation batch took the
- * archive filter's control off both of them. A test that clicks a control the
- * page no longer draws is not a weakened test, it is a broken one, so it could
- * not stay there. `Choice` itself is untouched by that batch: it still does
- * every one of the things below, and after the removal there was no test in
- * this repository that asked it to.
- *
- * So it is proven where the behavior lives. That is the better home anyway —
- * `Choice` is a shared control, its keyboard contract belongs to it rather
- * than to whichever page happened to mount it, and the proof now survives the
- * next page that adopts or drops it.
- *
- * It is the kit's radio group now, which is Radix's, so the contract below is
- * no longer hand-written. It is still asked for here: what a person gets from
- * this control is the same list of promises whoever keeps them, and a later
- * change that swaps the primitive back out has to keep them too.
+ * Test Choice keyboard behavior at the shared control so coverage does not
+ * depend on which page currently uses it.
  */
 describe("a choice between two lists", () => {
   const OPTIONS = [
@@ -732,19 +671,8 @@ describe("a choice between two lists", () => {
   });
 
   /**
-   * **One Tab stop, an arrow key inside it, and selection following focus.**
-   * Roving `tabindex` is what keeps a two-option filter from costing two Tab
-   * presses on the way to the table — and a ten-option one from costing ten.
-   * Selection following focus is what keeps the keyboard and the announcement
-   * agreeing: a group that moved the highlight without moving focus would
-   * leave a screen reader saying one thing and the next keypress landing on
-   * another.
-   *
-   * Radix moves focus in a task after the key rather than during it, so React
-   * has committed the new selection before anything is focused. That is why
-   * each key here is followed by a flush: the order a caller sees is `onChange`
-   * and then the focus move, and asking for both in the same tick would be
-   * asking for an order this control does not promise.
+   * Check one Tab stop and arrow-key selection following focus. Flush after
+   * each key because Radix schedules its focus move in a later task.
    */
   it("chooses the other list from the keyboard, and says which is chosen", async () => {
     const chose = vi.fn();
@@ -931,15 +859,8 @@ describe("a page of rows", () => {
 /* ------------------------------------------------------------------------ */
 
 /**
- * A closing animation, said out loud, because jsdom runs no stylesheet.
- *
- * The kit removes a dialog on `animationend`, and it decides whether there is
- * an animation to wait for by reading the computed style. jsdom loads no CSS,
- * so every surface there claims `animationName: ""` and leaves the instant it
- * is closed — which would make "an exit runs to completion" untestable in this
- * lane. This answers the way the real theme answers: the entrance while the
- * surface is open, the exit once it is closed. Nothing else is changed, so the
- * test still drives the kit's own presence machine rather than a stand-in.
+ * Supply computed animation names because jsdom loads no stylesheet. This
+ * exercises Radix presence through an exit event without proving the theme animation.
  */
 function finishExit(surface: HTMLElement, animationName: string): void {
   // jsdom has no `AnimationEvent`, so the one property the kit reads is put on
@@ -1165,14 +1086,8 @@ describe("a dialog", () => {
   });
 
   /**
-   * "No motion delays input. A control answers on press, not after an
-   * animation."
-   *
-   * So this is about *when*, and the animation has to be real for the question
-   * to exist: with no stylesheet the panel leaves in the same tick and every
-   * naive assertion here passes without proving anything. With one in flight,
-   * the panel is still on screen, `onClose` has not been called, and the
-   * keyboard is nevertheless already back on the control that opened it.
+   * Keep an exit active to verify that focus returns on dismissal, before
+   * the panel is removed and onClose runs.
    */
   it("hands the keyboard back on the press, not at the end of the exit", () => {
     withClosingAnimation();
@@ -1336,18 +1251,8 @@ describe("a page that is not showing its data", () => {
 /* ------------------------------------------------------------------------ */
 
 /**
- * The loading state, which used to be a sentence and nothing else.
- *
- * `DESIGN.md` asks it for a "fast, quiet indicator", and none of what that
- * costs is written in these components: the wait before anything appears, the
- * breath in the bars, the phase between them and the reduced-motion form all
- * live in `tailwind-theme.css`, keyed on the slots the components publish.
- *
- * So the tests come in two halves. The first reads the DOM and proves the
- * components emit the hooks and say the true sentence. The second reads the
- * theme and proves the rules keyed on those hooks are made of egma's tokens.
- * Neither half watches anything move — jsdom computes no animation — and the
- * movement itself is proven in a browser.
+ * Check loading-state DOM hooks and their theme rules separately. These tests
+ * do not render motion; that needs browser verification.
  */
 describe("the state a page shows while it is still waiting", () => {
   function loadingState(): HTMLElement {
@@ -1980,16 +1885,8 @@ describe("the role the shell shows", () => {
   });
 
   /**
-   * **The last of the first-project fallback, and the reason ticket 12 could
-   * not tick its first two criteria until now.**
-   *
-   * The shell reads the project out of the address. Where the address named
-   * none it used to fall back to `projects[0]`, which drew a project's whole
-   * navigation on a page that is not in that project — so every link in the
-   * sidebar went somewhere the person was not, and the one page that names no
-   * project on purpose was the page it happened on. Every product area is under
-   * `/projects/:projectId/…` now, the graders screens last, so the fallback has
-   * nothing left to stand in for.
+   * A page without a project in its URL must not inherit the first project
+   * and show its navigation.
    */
   it("draws no product navigation on an address inside no project", async () => {
     routed.pathname = "/new-project";
@@ -2036,17 +1933,7 @@ describe("the role the shell shows", () => {
     }
   });
 
-  /**
-   * **Monitoring, drawn rather than declared.** The list above is read from the
-   * navigation module, so it cannot catch an item that exists in the module and
-   * never reaches the sidebar — a missing icon path would do exactly that. This
-   * asks the rendered shell for the item by the words on it, and follows where
-   * it goes.
-   *
-   * The words are the ones the groups left behind: the Monitoring group's item
-   * says `Traces`, and the Simulations group's says `Runs`. Both addresses
-   * are the ones they always were.
-   */
+  /** Check that the rendered sidebar exposes Traces and Runs with their expected URLs. */
   it("puts Traces in the sidebar, opening this project's transcript list", async () => {
     routed.pathname = "/projects/prj_2/agents";
     apiAnswers({
@@ -2322,18 +2209,9 @@ describe("the Agents page", () => {
 /* ------------------------------------------------------------------------ */
 
 /**
- * Who owns the `inert` marks the session cover puts on the document.
- *
- * The cover hides the application from eyes; `inert` is what takes it out of
- * reach of a Tab step and a screen reader as well, and the two have to end
- * together. Each cover holding its own list of what it marked does not end them
- * together: the second cover to mount skips everything the first already
- * marked — which is what keeps a surface Radix made inert from being taken over
- * — so the first cover to leave hands the whole document back while the second
- * is still standing opaque in front of it.
- *
- * Nothing produces that overlap today, and every reason is a timing invariant
- * written nowhere near the component. These hold the guarantee itself instead.
+ * Overlapping session covers share ownership of inert marks. Removing one
+ * cover must not restore access while another remains, and pre-existing inert
+ * marks must survive the last cover.
  */
 describe("the session cover's hold on the document", () => {
   /** The application's own container, rather than a cover's portal host. */

--- a/apps/web/test/data-table-row-link.test.tsx
+++ b/apps/web/test/data-table-row-link.test.tsx
@@ -133,18 +133,8 @@ describe("DataTable row links", () => {
 });
 
 /**
- * One left edge per column, header and values on it.
- *
- * The rule is written once in `components/ui/table.tsx` and every table in the
- * product inherits it, so this asserts the token rather than a pixel: a header
- * and the cells under it name the same padding, and the two deliberate
- * exceptions — the row's own control lane, and the stacked layout's
- * right-aligned values — are the ones `components/ui/table.tsx` names.
- *
- * The lane's own `px-0` is written unconditionally and applied by the
- * `data-action` attribute, so the attribute is what proves which cell is the
- * lane. The class is still read back once, on the lane itself, because the
- * mark strips nothing unless the rule stays written on the shared parts.
+ * Check shared header/cell padding tokens and the action-column exception.
+ * jsdom cannot verify pixel alignment; data-action identifies the control column.
  */
 describe("DataTable column alignment", () => {
   const LANE = "px-(--row-padding-x)";

--- a/apps/web/test/design-system.test.tsx
+++ b/apps/web/test/design-system.test.tsx
@@ -129,17 +129,8 @@ describe("the development design proof", () => {
     render(<DesignSystemProof />);
 
     /*
-     * These are class assertions rather than colour assertions because jsdom
-     * loads no stylesheet. What they guard is the mapping: the primary action
-     * asks for the theme's `primary-wash` fill and `primary` ink, and
-     * `tailwind-theme.css` is what makes those mean Ember Wash and Deep Ember.
-     * The colours themselves are proved in a real browser, by reading the
-     * computed value back off the element.
-     *
-     * **The primary is the wash button as of 2026-08-23.** It used to be a
-     * Deep Ember block with white text; the developer retired that looking at
-     * the Paper boards, so a filled fill here would be the old rule coming
-     * back rather than a passing test.
+     * Check the primary-button theme mapping. jsdom does not load the stylesheet,
+     * so this does not verify computed colors.
      */
     const start = screen.getByRole("button", { name: "Start run" });
     expect(start.getAttribute("data-slot")).toBe("button");
@@ -263,16 +254,8 @@ describe("the development design proof", () => {
     const dialog = screen.getByRole("dialog", { name: "Archive Support agent?" });
     expect(dialog).toBeTruthy();
     /*
-     * The confirmation inside the dialog is the shared button, and it is the
-     * destructive one. Two assertions because they guard two different things:
-     * `data-slot` says the element is the base component at all, and the class
-     * says which variant was asked for. The line these replace named a CSS
-     * Modules class, `buttonDestructive`, which did both at once and is gone.
-     *
-     * The variant is worth naming rather than dropping: `DESIGN.md` says a
-     * destructive action uses the failure colour, and that brand orange never
-     * means errored. A confirmation that quietly came out Deep Ember would
-     * pass a check for "is a button".
+     * Check both the shared button slot and its destructive variant. The variant
+     * must use failure styling rather than brand styling.
      */
     const confirm = within(dialog).getByRole("button", {
       name: "Archive agent",

--- a/apps/web/test/feedback.test.tsx
+++ b/apps/web/test/feedback.test.tsx
@@ -14,22 +14,9 @@ afterEach(() => {
 });
 
 /**
- * The one fact jsdom is missing, supplied so the exit can be driven.
- *
- * Radix keeps a closing panel mounted only while an exit animation is running,
- * and it decides that by reading `animation-name` off the element. jsdom loads
- * no stylesheet, so it answers "none" for everything and every exit is
- * instant — which would make an exit test pass no matter what the theme said.
- *
- * So this teaches `getComputedStyle` the two rules `tailwind-theme.css`
- * actually declares for `[data-slot="tooltip-content"]`, and nothing else. A
- * theme that stopped declaring them would not be caught here; what is caught
- * is the component half — that the panel carries the `data-state` and
- * `data-input` those rules are keyed on, and that Radix is left to wait for
- * the animation rather than being torn down under it.
- *
- * It is a live view rather than a snapshot because Radix reads the same
- * declaration object again later, after `data-state` has changed.
+ * Supply live computed animation names for tooltip open/closed states.
+ * Radix rereads the declaration after state changes, so a snapshot is insufficient.
+ * This tests exit presence, not whether the stylesheet defines the animation.
  */
 function teachJsdomTheTooltipMotion() {
   const real = window.getComputedStyle.bind(window);
@@ -101,17 +88,8 @@ describe("shared feedback", () => {
   });
 
   /**
-   * **A pointer waits before the first one, and its exit runs to completion.**
-   *
-   * The delay is what stops a tooltip flashing at every control a pointer
-   * crosses on its way somewhere else.
-   *
-   * The exit is driven rather than described. `DESIGN.md`: "An exit runs to
-   * completion and is never cut off. A surface that is closed finishes leaving
-   * before it is removed." So the pointer leaves, the panel is still there,
-   * and only the end of the animation removes it. Asserting the class that
-   * asks for the animation would pass on a misspelled keyframe and on a panel
-   * Radix tore down underneath it.
+   * Check the pointer delay and keep the tooltip mounted until the simulated
+   * exit event. Computed styles are supplied by the test.
    */
   it("delays the first pointer tooltip and lets its exit finish before it goes", () => {
     teachJsdomTheTooltipMotion();
@@ -186,20 +164,8 @@ describe("shared feedback", () => {
   });
 
   /**
-   * The one rule these two surfaces broke, held where it can fail.
-   *
-   * `DESIGN.md`: "Brand orange does not mean passed, failed, skipped, or
-   * errored." Both of these once drew their error edge in Ember, and the edge
-   * is the only thing separating either from its neutral form at a glance — so
-   * it said "look here" where it had to say "this went wrong".
-   *
-   * These are class assertions rather than colour assertions because jsdom
-   * loads no stylesheet, which is the reason `design-system.test.tsx` gives for
-   * the same shape. What they guard is the mapping: the edge asks for the
-   * theme's `failure`, and `tailwind-theme.css` is what makes `failure` mean
-   * the failure colour. Asserting the absence of `brand` is the half that
-   * matters most — a later wave flipping it back fails here rather than only
-   * looking wrong in a screenshot nobody retakes.
+   * Check that error surfaces request failure styling instead of brand styling.
+   * These class assertions do not verify computed colors.
    */
   it("draws an error edge in the failure colour and never in the brand one", () => {
     const { unmount } = render(<Notice tone="error">Egma could not sign you in.</Notice>);

--- a/apps/web/test/graders-pages.test.tsx
+++ b/apps/web/test/graders-pages.test.tsx
@@ -1008,14 +1008,8 @@ describe("the project Graders surface", () => {
   });
 
   /**
-   * A sheet that is not open holds no draft.
-   *
-   * The create sheet stays mounted after it closes — the page renders it
-   * unconditionally — and its fields are reset when it opens rather than when
-   * it closes, so what was typed survives and its `changed` stays true. With no
-   * `open` in the condition, that closed sheet kept a draft registered in the
-   * shared registry, and the next product link asked "Leave without saving?"
-   * about a grader that was already created.
+   * A closed create sheet must unregister its draft even though it remains
+   * mounted and retains field values until the next open.
    */
   it("stops protecting the custom-grader draft once the sheet closes", async () => {
     apiAnswers(answersThatCreateAGrader());

--- a/apps/web/test/menu-placement.test.tsx
+++ b/apps/web/test/menu-placement.test.tsx
@@ -70,20 +70,9 @@ describe("anchored menu placement", () => {
 });
 
 /**
- * Every anchored panel is bounded, and the primitive is what bounds it.
- *
- * Radix measures the room a panel has and publishes it, then reads it back
- * nowhere — `maxHeight` does not occur in `@radix-ui/react-popper`. A panel is
- * therefore exactly as tall as whatever it was given unless the file that
- * draws it says otherwise, and a caller who forgets gets a panel that runs off
- * the window. `ui/menu.tsx` remembered from the start; `popover.tsx` and
- * `dropdown-menu.tsx` did not, and the agents list found the second one: an
- * agent with enough connections opened a `+N` panel taller than the window
- * over `overflow: visible`, so its last rows could not be reached at all.
- *
- * These read the class list rather than a measurement because jsdom lays
- * nothing out. That is the same trade `data-table-row-link.test.tsx` makes for
- * the table's own scroller.
+ * Check that each anchored panel uses Radix's available-height value and
+ * scrolling styles. Radix supplies the measurement; the component must apply
+ * the limit. jsdom cannot verify viewport fit.
  */
 describe("anchored panels are bounded by the primitive", () => {
   const CAP = "-available-height)-var(--space-2))]";

--- a/apps/web/test/monitoring.test.tsx
+++ b/apps/web/test/monitoring.test.tsx
@@ -18,21 +18,8 @@ import type { Facts, Grade, Listed } from "../lib/transcripts.ts";
 import { observeRequest, type FetchInput } from "./platform-request.ts";
 
 /**
- * **Monitoring**, rendered and driven the way somebody with a keyboard drives
- * it.
- *
- * Two claims this file exists to defend, and neither can be made by reading a
- * source file:
- *
- * 1. **The project in the address is the project asked about, and the traffic
- *    asked for is production.** Both ride in the request, so the first thing
- *    asked of the read is what it named. A page that resolved either for itself
- *    would show one project's traffic under another's address, or a simulation
- *    on the surface that exists to keep the two apart.
- * 2. **A quiet page shows one guidance and only one.** The three answer
- *    different questions and point in different directions, so each is asserted
- *    present *and* the other two absent — showing two at once is the failure,
- *    and only a rendered page can be asked about it.
+ * Drive the Traces page with stubbed reads. Check project and source request
+ * parameters, and require each guidance state to exclude the others.
  */
 
 const routed = vi.hoisted(() => ({
@@ -270,16 +257,9 @@ function page(rows: readonly Listed[]): Stubbed {
 }
 
 /**
- * One page, with every read answered.
- *
- * `rows`, `everRecorded`, `graders` and `keys` are the four inputs the quiet
- * states are decided from, so a case says only which of them it is about.
- *
- * `everRecorded` is the widest-window probe — *has this project ever recorded
- * anything* — and it defaults to whatever `rows` says, which is the ordinary
- * case of a project that is empty everywhere or busy everywhere. A case about
- * the window sets the two apart. Any read can be refused instead, which is a
- * case of its own: a refusal is not a zero.
+ * Stub rows, wider recent history, graders, and keys independently.
+ * everRecorded is the widest-window probe, not all-time history. Refused
+ * reads remain unknown instead of becoming zero.
  */
 function stub(options: {
   readonly rows?: readonly Listed[];
@@ -1124,14 +1104,8 @@ describe("what a quiet Monitoring page says", () => {
 });
 
 /**
- * **Monitoring is one verb on this screen, and v0 shows nothing else about
- * it.**
- *
- * The separate monitoring screen is retired, so the action now enters the
- * shared setup flow on Agents. And the management half — stop
- * pulling, turn it on again, when something last arrived — has no interface at
- * launch: the API keeps `stopMonitoring`, and surfacing it is its own effort.
- * A screen that grew a stop button would be that decision made by drift.
+ * Monitoring setup enters the shared Agents flow. This surface has no stop,
+ * restart, or last-received controls.
  */
 describe("the one monitoring action this screen carries", () => {
   it("heads the page with it, and states the Monitoring goal in the address", async () => {

--- a/apps/web/test/output-lock.test.ts
+++ b/apps/web/test/output-lock.test.ts
@@ -95,14 +95,8 @@ describe("holding the web output directory", () => {
 
 describe("several processes racing for it at once", () => {
   /**
-   * The one case the six above cannot make: contention.
-   *
-   * Every sequential test passes against a lock that excludes nobody, because
-   * a lock is only wrong in the moment two processes want it. So this starts
-   * real processes, on a path nothing has touched, and asks the only question
-   * that matters — was anybody ever inside it at the same time as somebody
-   * else. `support/race-for-the-lock.ts` is the child, and it witnesses with a
-   * marker file of its own rather than with the lock it is testing.
+   * Use competing processes to test exclusion. An independent marker records
+   * overlap so the test does not rely on the lock being correct.
    */
   it("lets exactly one of them in at a time", async () => {
     const lockPath = await aLockPath();
@@ -142,17 +136,8 @@ describe("several processes racing for it at once", () => {
 
 describe("a process id the operating system has given to somebody else", () => {
   /**
-   * The way a lock used to become permanent.
-   *
-   * A holder that is killed leaves its file behind. Operating systems reuse
-   * process numbers, so sooner or later something unrelated is given that
-   * number, `kill(pid, 0)` answers yes, and every build and browser test after
-   * that is refused by a process that never held anything. The lock records
-   * when its holder started as well as which number it had, so a number
-   * wearing a different start time is a different process.
-   *
-   * The number below is this very process, so it is genuinely running — which
-   * is the whole point. Only the start time says it is not the holder.
+   * A live PID with a different start time is not the recorded holder. Use
+   * this process's PID to exercise reuse without relying on OS PID allocation.
    */
   it("is not mistaken for the holder that has gone", async () => {
     const lockPath = await aLockPath();
@@ -176,16 +161,8 @@ describe("a process id the operating system has given to somebody else", () => {
   });
 
   /**
-   * The same defect, reached through a lock file this code did not write.
-   *
-   * A `.next.lock` left by the version before start times were recorded carries
-   * a process number and nothing to confirm the number is still that process.
-   * Reading the missing field as an empty string and comparing it with another
-   * empty string is how two unknowns became a match — and how an unrelated
-   * process wearing a recycled number became the holder forever.
-   *
-   * Refused, not stolen. Unreadable is not abandoned, and a record this version
-   * cannot verify is unreadable in every way that matters.
+   * A legacy lock without a start time cannot establish holder identity.
+   * Treat it as unreadable rather than reclaiming it from a live PID.
    */
   it("is refused, not matched, when the lock predates start times", async () => {
     const shapes = [
@@ -230,14 +207,8 @@ describe("a process id the operating system has given to somebody else", () => {
 
 describe("handing the directory back", () => {
   /**
-   * `kill` is a signal, not a departure.
-   *
-   * The child below takes a moment to go after it is asked to, which is what a
-   * Next development server closing its watchers does — and it is still writing
-   * `apps/web/.next` for all of that moment. So the question is not whether the
-   * lock is eventually released; it is whether the lock was still held at the
-   * instant the child died. That is read off the file system from inside the
-   * child's own `exit` event, not inferred afterwards.
+   * Keep the lock until the child actually exits, including its shutdown delay.
+   * Check the lock from the exit event rather than after eventual cleanup.
    */
   it("keeps the lock until the process writing the directory has gone", async () => {
     const lockPath = await aLockPath();

--- a/apps/web/test/pages.test.ts
+++ b/apps/web/test/pages.test.ts
@@ -46,14 +46,8 @@ const TRANSCRIPT_PAGE =
   "app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx";
 
 /**
- * The one read in this application with a deadline on it.
- *
- * While it is in flight the whole document is covered and everything behind
- * the cover is inert, so this read failing to answer is not the same kind of
- * event as any other read failing to answer: it is a page nobody can touch.
- * A refused or dropped connection rejects and always ended the wait. A server
- * that accepts the connection and then says nothing does neither, and that is
- * the one these hold.
+ * Bound stalled session reads so the document cannot remain behind the
+ * loading cover indefinitely. Ordinary readJson calls set no default deadline.
  */
 describe("reading who is signed in", () => {
   /** A connection that is open and silent: no response, and no error either. */
@@ -107,14 +101,8 @@ describe("reading who is signed in", () => {
   });
 
   /**
-   * A deadline is only worth anything if every session read goes through it,
-   * and the invitation page is why this is written down: it asked `/api/me`
-   * with a plain fetch of its own, so it kept the exact stall the shell and
-   * the entrance had just been given a bound for — on the one page where the
-   * person waiting has no account yet and nowhere else to go.
-   *
-   * A page that asks this question again with a fetch of its own is that bug
-   * again, and this is what says so while it is being written.
+   * Reject direct session reads outside the shared helper so pages cannot
+   * bypass its deadline.
    */
   it("is the only way any page asks who is signed in", async () => {
     const allowed = new Set([
@@ -245,17 +233,7 @@ describe("the pages", () => {
     }
   });
 
-  /**
-   * The tenancy the pages show has exactly two levels and they are called
-   * `organization` and `project` — the same two words the API and the database
-   * use for the same two things.
-   *
-   * A container word invented above them is how `project` comes to mean the
-   * tenancy container in one place and something inside one in another, and a
-   * word that means two things is a word nobody can read a permission with.
-   * This costs nothing today and is written down now because the dashboard is
-   * what would grow on top of it.
-   */
+  /** Use organization for the isolation boundary and project for the resource scope. */
   it("name the two levels of tenancy, and invent no word above them", async () => {
     for (const [file, source] of await pageSources()) {
       expect(source.toLowerCase(), `${file} names a level above organization`)
@@ -398,15 +376,8 @@ describe("the pages", () => {
   });
 
   /**
-   * **The page never says a thing the API did not check**, and past the hour
-   * there is exactly one thing left to check: that the link is dead.
-   *
-   * "Your old password still works" is true of a link that ran out unused and
-   * false of one somebody already reset with, and there is one deadline now —
-   * the auth provider forgets the token at the moment egma stops honouring the
-   * link, so nothing can tell those two apart afterwards. The reassurance is
-   * therefore not on any refusal, anywhere on this page. It used to be, on the
-   * refusal that was checked; that refusal no longer exists to hold it.
+   * An expired reset link does not prove whether the old password still works.
+   * Do not offer reassurance that the API cannot verify.
    */
   it("never promise the old password still works", async () => {
     const reset = await readFile(
@@ -423,14 +394,8 @@ describe("the pages", () => {
   });
 
   /**
-   * Where somebody was going survives a reset, all the way through the message.
-   *
-   * A developer approving a terminal's login who turns out to have forgotten
-   * their password has to land back on the approval page. The sign-in page
-   * carries the destination to the form, the form sends it to the API, the API
-   * writes it into the link, and the page behind the link carries it on to
-   * sign-in. Any one of those dropping it leaves a terminal waiting on a person
-   * who is looking at the wrong page.
+   * Preserve the return path through reset submission and the link back to
+   * sign-in, so device approval can continue after a password reset.
    */
   it("carry where somebody was going through a reset, and not only up to it", async () => {
     const signIn = await readFile(path.join(WEB, "app/sign-in/page.tsx"), "utf8");
@@ -520,14 +485,8 @@ describe("the pages", () => {
   });
 
   /**
-   * The one rewrite whose caller is not a browser.
-   *
-   * A mocked run mints tool URLs on this origin under `/mock-tools/…` and
-   * writes them onto the agent under test, so the calls arrive from the
-   * agent's own platform. Without the rule they were answered by this
-   * process's not-found page: every mocked tool call on a live agent read
-   * Egma's own HTML 404, and the agent apologized to the caller for a broken
-   * backend on every call.
+   * Forward mock-tool requests from the agent platform to the API. Otherwise
+   * Next returns an HTML not-found page for the generated tool URL.
    */
   it("reach the API for a mocked run's tool calls at a path this instance rewrites", async () => {
     const rewrites = await readFile(path.join(WEB, "next.config.ts"), "utf8");
@@ -743,15 +702,8 @@ describe("coming back after signing in", () => {
   });
 
   /**
-   * A redirect decided by a query parameter is the shape of every open-redirect
-   * bug there has ever been, and this one is handed to somebody in the middle
-   * of authorizing a terminal — which is exactly when a page that looks like
-   * egma but is not would be worth the most to somebody.
-   *
-   * The rule used to be a list of the shapes that leave, and a list is a thing
-   * somebody finds the next entry in: the tab was the entry. It is resolution
-   * now — the candidate is parsed against this origin and has to land back on
-   * it — so the entries below are examples of a rule rather than the rule.
+   * Exercise same-origin URL resolution, including control characters that
+   * change how a browser parses an apparent local path.
    */
   it("refuses anywhere that is not this instance", () => {
     for (const elsewhere of [
@@ -788,14 +740,8 @@ describe("coming back after signing in", () => {
 });
 
 /**
- * When a page that was offered a recording shows nothing at all, and when it
- * speaks.
- *
- * It is the whole substance of the player's honesty rule, and it has been got
- * wrong twice — once by hiding a failure that arrived after a player was
- * already on screen, once by hiding every fault egma could have. Both times it
- * was carried entirely by a render branch, which nothing could reach. It is a
- * function now, and this is where it is held.
+ * Hide only expected absence before a recording is known to exist. Failures
+ * after a player has worked must remain visible.
  */
 describe("a refusal of a recording", () => {
   const A_TRANSCRIPT = { knownToExist: false, afterOneWorked: false };
@@ -823,15 +769,8 @@ describe("a refusal of a recording", () => {
   });
 
   /**
-   * Everything about **egma** rather than about the conversation. A store
-   * nobody configured, a fault, an egma that answered nothing at all, and a row
-   * carrying a reference no simulator could have written — the last of which
-   * has a code of its own precisely so it is not mistaken for an absence.
-   *
-   * A deployment that is broken must never look like a product working
-   * correctly. That is the failure the recordings effort exists to end, and the
-   * surface that asks about every conversation somebody opens is where it would
-   * spread furthest.
+   * Configuration, transport, and unsignable-reference failures must not look
+   * like a simulation that recorded no audio.
    */
   it("is said out loud when it is about egma rather than about the conversation", () => {
     for (const code of [
@@ -846,15 +785,8 @@ describe("a refusal of a recording", () => {
   });
 
   /**
-   * And an answer that was not egma's at all.
-   *
-   * Fastify's own not-found reply is `{"statusCode":404,"error":"Not
-   * Found","message":"Route GET:… not found"}` — a 404 carrying a message, from
-   * a route that is not mounted, a container running a different version, or a
-   * proxy that has stopped forwarding this path. Reading the presence of a
-   * message would have gone quiet on every one of those. A code is the API's
-   * own promise and nobody else's, so a code is what is read; `Not Found` with
-   * a capital and a space is not one of them.
+   * A generic HTTP 404 is not the API's expected-absence code. Show it because
+   * it can indicate a missing route or proxy failure.
    */
   it("is said out loud when the answer did not come from egma", () => {
     expect(offersNothing({ code: undefined }, A_TRANSCRIPT)).toBe(false);

--- a/apps/web/test/personas.test.tsx
+++ b/apps/web/test/personas.test.tsx
@@ -455,7 +455,7 @@ describe("the Personas list", () => {
       }),
       { key: "Escape" },
     );
-    /* A Egma-provided persona cannot be deleted, so it is not offered. */
+    /* An Egma-provided persona cannot be deleted, so it is not offered. */
     expect(await rowMenuItems("Everyday caller")).toEqual(["Clone"]);
   });
 

--- a/apps/web/test/personas.test.tsx
+++ b/apps/web/test/personas.test.tsx
@@ -20,25 +20,8 @@ import type {
 import { observeRequest, type FetchInput } from "./platform-request.ts";
 
 /**
- * The Personas screen, rendered and driven the way somebody with a keyboard
- * drives it.
- *
- * Nothing here asserts that a component exists or that a source file contains
- * a string. Every test puts the API's real answers in front of a real
- * component and reads what the DOM then says — which is the only kind of proof
- * that survives the page being rewritten.
- *
- * **The contract these hold to is the approved boards** (Paper page `03C —
- * Persona rework`, boards 01–06): one address with panels over it, a sectioned
- * form under the star-and-`[optional]` label grammar, Predefined and Custom as
- * square chips, `Fork` and `Delete` in a row's ⋮, the record's own actions in
- * the sheet's ⋮, one item per line when a persona is read, and the open row in
- * the grey soft surface rather than the wash.
- *
- * Three of these exist because ticket 02 shipped the defects they name and had
- * to fix them: a role guessed while the session is in flight, an answer
- * rendered into a project it was not fetched for, and a failed request
- * swallowed. Every list page after that one walks into all three.
+ * Drive persona lists and sheets with stubbed API responses. Cover role
+ * loading, project changes, refused reads, and persona actions through the DOM.
  */
 
 /*
@@ -472,7 +455,7 @@ describe("the Personas list", () => {
       }),
       { key: "Escape" },
     );
-    /* A Predefined persona cannot be deleted, so it is not offered. */
+    /* A Egma-provided persona cannot be deleted, so it is not offered. */
     expect(await rowMenuItems("Everyday caller")).toEqual(["Clone"]);
   });
 
@@ -1019,16 +1002,8 @@ describe("one persona's sheet", () => {
   });
 
   /*
-   * **All three ways out ask the same question.** The boards give this panel a
-   * close control, an outside click and Escape, and a draft that only one of
-   * them protected would be a draft lost by whichever way somebody happened to
-   * reach for. All three land on one `onOpenChange`, which is the gate.
-   *
-   * Escape is proved above and the close control here. **The outside click is
-   * proved in the real browser instead**, in `apps/api/test/browser.test.ts`:
-   * that gesture is Radix's own, dispatched from a document listener that
-   * jsdom's synthetic events never reach, and a test that faked its way past
-   * that would be proving the fake rather than the panel.
+   * All dismissal paths use the draft guard. This file drives Escape and the
+   * close control; apps/api/test/browser.test.ts covers outside-click dismissal.
    */
   it("asks before discarding when the close control is pressed", async () => {
     withClosingSheetAnimation();
@@ -1056,14 +1031,8 @@ describe("one persona's sheet", () => {
   });
 
   /**
-   * **A panel belongs to the project it was opened in.**
-   *
-   * Changing project does not remount this screen — it is the same page with
-   * another id in its address — so a sheet left open would still be holding a
-   * persona the next project has never heard of. Asking for it answers 404 and
-   * fills the panel with "not found" over a list that is perfectly fine, so
-   * the panel is not drawn for another project at all and the request is never
-   * made.
+   * Project changes must close a persona sheet without reading the old
+   * project's persona under the new project ID.
    */
   it("closes the panel when the project changes, and asks the next project for nothing of the last one", async () => {
     const { asked } = ritaOpen({

--- a/apps/web/test/presentation.test.ts
+++ b/apps/web/test/presentation.test.ts
@@ -106,21 +106,9 @@ describe("the shared form controls", () => {
   });
 
   /*
-   * The picker is the product's box to size once `base-select` is asked for,
-   * and Chrome's default for a box nobody sized is `max-height: stretch` —
-   * as tall as the space allows. A project with thirty test suites opened a
-   * picker 584px tall whose lower edge sat flush against the window, which
-   * reads as a broken render rather than as a list that scrolls. A short list
-   * hides the fault entirely, so no page test can be trusted to catch it
-   * coming back; the cap itself is what this holds.
-   *
-   * **The scope is asserted, not just the words.** A first version of this
-   * test matched the two declarations anywhere in the file, so moving the cap
-   * out of its media query — or out of `@supports` — would have left it green
-   * while the behaviour it names was gone. Both declarations are now read out
-   * of the `@supports (appearance: base-select)` block they belong to, and the
-   * cap out of the viewport query inside it. (Raised by Greptile on the pull
-   * request.)
+   * Check that the picker height cap and scrolling rules occur inside their
+   * support and viewport conditions. Matching declarations anywhere in the file
+   * would miss a rule moved outside the intended scope.
    */
   it("bounds the open select picker instead of letting it fill the window", async () => {
     const css = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");

--- a/apps/web/test/project-shell.test.ts
+++ b/apps/web/test/project-shell.test.ts
@@ -95,14 +95,8 @@ describe("which project a tab is looking at", () => {
 
 describe("the product navigation", () => {
   /**
-   * **The addresses this bar offered before it had groups.**
-   *
-   * Written out rather than derived, because deriving them from the module
-   * under test would make this assertion agree with whatever the module says
-   * today.
-   *
-   * The groups are presentation. Each expected address is written out so the
-   * test cannot copy a wrong address from the module under test.
+   * Write expected URLs independently so the test cannot copy an incorrect
+   * address from the navigation module.
    */
   const BAR_HREFS = [
     "/projects/prj_2/agents",

--- a/apps/web/test/settings.test.tsx
+++ b/apps/web/test/settings.test.tsx
@@ -21,19 +21,9 @@ import { REPLAY_PRIVATE_ATTRIBUTE } from "../lib/replay-privacy.ts";
 import { observeRequest, type FetchInput } from "./platform-request.ts";
 
 /**
- * The Settings area, rendered and driven the way somebody with a keyboard
- * drives it.
- *
- * **Nothing here asserts that a component exists or that a source file contains
- * a string.** Every test puts the API's real answers in front of a real page
- * and reads what the DOM then says.
- *
- * The claims worth having in the fast lane are the ones these pages decide for
- * themselves: that a save carries the revision it was opened at and a stale one
- * keeps the typing, that a viewer's own-key controls stay live while every
- * other mutation control is present and genuinely inert, that a secret is shown
- * once and never again, and that an organization-wide page says out loud that
- * it is not about the project the selector is showing.
+ * Drive settings pages with stubbed API responses. Check project revision
+ * saves, retained drafts, viewer key controls, one-time secret display, and
+ * organization-wide scope labels.
  */
 
 const routed = vi.hoisted(() => {
@@ -607,16 +597,8 @@ describe("project settings", () => {
   );
 
   /**
-   * The half of "disable, do not hide" that a pointer never needed.
-   *
-   * A disabled control cannot take focus, so a reason reachable only through a
-   * `title` is a reason only a mouse gets. The CSS Modules button drew the
-   * sentence itself and pointed the control at it; the base button is a bare
-   * `<button>` and draws nothing beside itself, so the page now does both.
-   *
-   * **This asserts the link and not the sentence.** The sentence is already
-   * asserted above, and it went on passing while the link did not exist — which
-   * is exactly the failure worth a test of its own.
+   * Check the disabled control's accessible description link, not just the
+   * visible explanation. A title alone is insufficient for keyboard access.
    */
   it("points a disabled Save at the sentence that says why", async () => {
     open("viewer", { ...PROJECT, mayManageProjects: false });
@@ -631,18 +613,8 @@ describe("project settings", () => {
   });
 
   /**
-   * The server says who may edit, and this page believes it.
-   *
-   * The two tests above cannot tell the difference, and that is the point: for
-   * a viewer, *not an admin* and *not permitted* are true at the same time, so
-   * a page reading either one passes. They part company only here — somebody
-   * the server permits who is not an admin.
-   *
-   * `mayManageProjects` is computed by the API from the same permission check
-   * that decides whether the write lands. A page deriving it from the role
-   * instead is a second opinion about what `manage_projects` means, and the
-   * moment that permission moves the two disagree: controls withheld from
-   * somebody who may act, or controls offered whose writes come back refused.
+   * Use a permitted non-admin to distinguish the API's mayManageProjects
+   * answer from a local role guess.
    */
   it("lets a non-admin edit when the server says the permission is theirs", async () => {
     open("member", { ...PROJECT, mayManageProjects: true });

--- a/apps/web/test/sidebar-groups.test.tsx
+++ b/apps/web/test/sidebar-groups.test.tsx
@@ -6,18 +6,8 @@ import type { Me } from "../lib/me.ts";
 import { AppShell } from "../ui/shell.tsx";
 
 /**
- * The grouped sidebar, drawn.
- *
- * The module test beside this one says what the three groups *are*. This says
- * what a person meets: three labelled groups in one navigation landmark, the
- * row they are on lit and saying so, the same six addresses the flat bar
- * offered, and the same three groups inside the mobile drawer rather than a
- * second, shorter list of where they may go.
- *
- * jsdom loads no stylesheet, so the Ember Wash and the Ember mark are asserted
- * as the mapping that produces them — the class that turns them on is bound to
- * the same `data-active` the row carries. The colours themselves were read back
- * in a real browser, in both themes, at both widths.
+ * Check rendered navigation groups, active state, links, and mobile parity.
+ * Class assertions cover theme mappings; jsdom does not verify computed colors.
  */
 
 const routed = vi.hoisted(() => ({ pathname: "/projects/prj_2/agents" }));
@@ -159,14 +149,8 @@ describe("the grouped sidebar", () => {
   });
 
   /**
-   * **A sectioned navigation is walked by heading.**
-   *
-   * The accessible name above says which group somebody is *in*. This is how
-   * they get to one at all: the heading list is Simulations and Monitoring, and
-   * moving between them is one keystroke rather than six arrow presses. The two
-   * mechanisms are wired to the same element on purpose — one word, said twice,
-   * that cannot come apart. The top cluster is in neither list, because it is
-   * drawn with no word at all: it is where a person already is.
+   * Use visible headings as the accessible names of labeled navigation groups.
+   * The unlabeled top group must add no empty heading.
    */
   it("offers every labelled group as a heading, in the order the bar reads", () => {
     drawShell();
@@ -273,16 +257,8 @@ describe("the grouped sidebar", () => {
   });
 
   /**
-   * **The row moves two properties, and `outline-color` is deliberately not one
-   * of them.**
-   *
-   * `transition-colors` looks like the right class and is not: Tailwind's
-   * colour group sweeps in `outline-color`, this product's focus indicator is
-   * an outline, and the result was a focus ring that faded up from the row's
-   * text colour over 140ms on every Tab step. `DESIGN.md` names keyboard
-   * navigation first among the things not to animate, so the two properties
-   * hover actually changes are named instead. A keyboard pass found this; only
-   * this assertion can keep it found.
+   * Transition only hover background and text colors. Including outline color
+   * would delay the keyboard focus indicator.
    */
   it("moves the hover colours without dragging the focus ring with them", () => {
     drawShell();

--- a/apps/web/test/simulation-evidence.test.tsx
+++ b/apps/web/test/simulation-evidence.test.tsx
@@ -699,14 +699,8 @@ describe("the transcript time rail", () => {
   });
 
   /**
-   * **Who answered a tool call, said once and quietly.**
-   *
-   * A mock tool answered this call, read by name off the test version this
-   * simulation pinned, so a reader knows the answer in front of them came from
-   * the test rather than from their own backend. The mock tool's own name is
-   * the tool's name, already on the row, so the mark does not repeat it. A real
-   * call is the ordinary case and says nothing extra — there is no second word
-   * for "not mocked" to learn.
+   * Render the supplied mocked provenance mark without repeating the tool name.
+   * An unmarked tool call gets no extra label. This does not verify tool execution.
    */
   it("marks a call a mock tool answered, and leaves a real one unmarked", () => {
     const read = evidence();
@@ -1163,18 +1157,9 @@ describe("the transcript time rail", () => {
 });
 
 /**
- * **The run view shows the agent's POV, and one conversation once.**
- *
- * A simulation stores both accounts of the same call: the persona's, which is
- * what egma's own simulator said, heard and recorded, and the agent's, which is
- * what the agent's own process reported — every tool call with the arguments
- * its model emitted and the result it received. The transcript a developer
- * reads is the agent's. There is no side-by-side, no threshold and no diff:
- * the persona's POV is stored, and what it is still drawn for is the recording
- * underneath and the origin every row seeks against.
- *
- * The conversation here is the one that opened this effort — a booking, three
- * tool calls, one of them mocked and one of them refused.
+ * Use the agent POV for the readable transcript. The persona POV supplies
+ * recording evidence and the seek origin. This fixture contains a booking
+ * with three tool calls, including mocked and refused results.
  */
 describe("the agent's POV is what a reader is shown", () => {
   const AGENT_TURNS = [

--- a/apps/web/test/support/race-for-the-lock.ts
+++ b/apps/web/test/support/race-for-the-lock.ts
@@ -4,21 +4,11 @@ import process from "node:process";
 import { holdWebOutputLock } from "../../tools/output-lock.ts";
 
 /**
- * One of several processes all trying to hold the same lock at once.
+ * Compete for a lock and report acquisitions and overlaps on stdout. Inside
+ * the critical section, create a separate marker with wx so overlap detection
+ * does not depend on the lock implementation.
  *
- * The lock is a claim about what happens between processes, so nothing but
- * processes can test it. This is the child: it races for the lock over and over
- * and reports, on stdout, how often it got in and how often somebody else was
- * already inside when it did.
- *
- * **The witness is a second file, not the lock.** Inside the critical section
- * this creates a marker with `wx` — the kernel's own answer to "does this path
- * already exist" — so the check does not lean on the code under test to decide
- * whether the code under test worked. A marker that is already there means two
- * processes were inside at the same moment, which is the whole thing the lock
- * exists to prevent.
- *
- *   node race-for-the-lock.ts <lock path> <marker path> <attempts>
+ * Usage: node race-for-the-lock.ts <lock path> <marker path> <attempts>
  */
 
 const [lockPath, markerPath, attempts] = process.argv.slice(2);

--- a/apps/web/test/test-suites-pages.test.tsx
+++ b/apps/web/test/test-suites-pages.test.tsx
@@ -234,15 +234,8 @@ async function chooseRunTarget(): Promise<void> {
 
 beforeEach(() => {
   /*
-   * `cmdk` measures its list with `ResizeObserver` and scrolls the row the
-   * arrow keys are on into view. jsdom implements neither, and without them the
-   * persona picker's panel throws the moment it opens or a row is picked — the
-   * second one silently, from inside `cmdk`, so the row's click simply did
-   * nothing.
-   *
-   * Stubs rather than polyfills, for the reason `design-system.test.tsx` gives:
-   * nothing here asserts a measurement or a scroll, and real ones would only
-   * let these tests lean on layout jsdom never computes.
+   * Stub ResizeObserver and scrollIntoView for cmdk in jsdom. These tests
+   * exercise selection, not layout measurements or scrolling.
    */
   Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
     configurable: true,
@@ -1221,18 +1214,7 @@ describe("the suite-first Tests route", () => {
     );
   });
 
-  /**
-   * **The two JSON fields, in a table that has to stay scannable.**
-   *
-   * A mock tool's answer is arbitrary JSON and an env is two nested objects.
-   * Neither fits beside a scenario, so the cell carries one quiet summary and
-   * the writing happens in the smallest dialog that holds an editor, a reason
-   * and two buttons.
-   *
-   * A full Env cell says `View env variables` rather than naming its keys: the
-   * two platform key names are 47 characters of identifier and ran out through
-   * the narrowest lane in the grid (founder, 2026-09-04).
-   */
+  /** Keep JSON summaries in cells and edit full mock-tool/env values in dialogs. */
   it("summarizes mock tools and env in their cells, and offers to fill an empty one", async () => {
     gridAnswers({
       tests: [
@@ -1335,16 +1317,8 @@ describe("the suite-first Tests route", () => {
   });
 
   /**
-   * **An empty JSON cell says how to fill it — quietly in a written row, and
-   * out loud in the row being written.**
-   *
-   * The cells used to be blank until a pointer went over them, so the only
-   * thing saying a mock tool or an env could be written here was the cursor
-   * changing shape. Offering in brand on every row was the other extreme: two
-   * orange lines down a suite of forty tests, in a table whose job is to be
-   * scanned. A written row rests on `None` and offers when it is reached for;
-   * the entry row offers always, because that row is the authoring (founder,
-   * 2026-09-04).
+   * Written rows show None for empty JSON cells; the entry row exposes the
+   * add action without requiring hover.
    */
   it("keeps the add line quiet in a written row and plain in the entry row, and each opens its dialog", async () => {
     gridAnswers({ tests: [testBody({ personas: [PERSONA] })] });
@@ -1994,20 +1968,9 @@ describe("the suite-first Tests route", () => {
     });
 
     /*
-     * …and that answer lands on a cell whose picking is long gone, so the entry
-     * row is free to open its own and be the only one standing.
-     *
-     * **The press above dismissed rather than swapped, and that is this
-     * renderer rather than the product.** In a browser one press on another
-     * trigger closes the open panel and opens that one; jsdom is given the
-     * three events by hand and the click that follows a dismissal does not
-     * reach the trigger, so the swap takes a second press here. What the first
-     * press had to prove — that shutting is what saves, and that the ticks went
-     * with it — is proved above, and that is the defect this test is named for.
-     *
-     * Whose picker is open is read off the trigger, not off the row: the panel
-     * is drawn in a portal now, which is what let the grid keep its sideways
-     * scrolling, so `within(row)` can no longer see it.
+     * This jsdom event sequence needs a second press to open the next picker
+     * after dismissal. Check which picker is open through its trigger because
+     * the panel is portaled outside the row.
      */
     fireEvent.click(entryTrigger);
     expect(screen.getAllByRole("dialog", { name: "Choose personas" })).toHaveLength(1);

--- a/apps/web/test/transcript-detail.test.tsx
+++ b/apps/web/test/transcript-detail.test.tsx
@@ -24,25 +24,8 @@ import type {
 import { observeRequest, type FetchInput } from "./platform-request.ts";
 
 /**
- * **One transcript**, rendered rather than read as source.
- *
- * This page had no rendered proof at all. Everything asserted about it lived in
- * `pages.test.ts` and `transcripts.test.ts` as source-text matches, which is a
- * real claim about wiring and
- * says nothing whatever about what a person ends up looking at. A page can hold
- * every one of those strings and draw an empty screen.
- *
- * That mattered the day its layout moved off the last CSS Module in the
- * application. A migration of 54 class names has one failure mode, and it is
- * silent: a state that used to draw now draws nothing, or draws twice, and no
- * source match notices. So the states are asserted here first, through the DOM,
- * and the migration is held against them.
- *
- * **What is asserted is what a reader can see and reach**, never a class list.
- * Class names are the thing being changed; a test that read them would fail on
- * every correct migration and pass on none of the wrong ones. So each case asks
- * for a heading, a role, a label, or a sentence — the page's own words, from
- * `transcript-copy.ts`, which is where they are checkable.
+ * Drive transcript detail states through rendered headings, roles, labels,
+ * and text. Source checks alone cannot establish that a state is visible.
  */
 
 const routed = vi.hoisted(() => ({
@@ -966,14 +949,8 @@ describe("the inspector", () => {
   });
 
   /**
-   * **Provenance names the platform that ran the agent**, which is the answer
-   * production monitoring replaced a single *Connection* row with: a person
-   * looking at a production exchange cannot open the connection egma dialled,
-   * because egma dialled nothing. What identifies the agent is the platform's
-   * own name for it, its identifier there, and the version that answered.
-   *
-   * The platform is read out in a reader's words rather than in the wire's —
-   * `livekit` is what arrives and **LiveKit** is what is drawn.
+   * Production provenance names the agent platform, its agent ID, and version.
+   * Display platform labels such as LiveKit instead of raw identifiers.
    */
   it("names the platform, and the agent the platform ran", async () => {
     stub({ status: 200, body: detail() });

--- a/apps/web/test/transcripts.test.ts
+++ b/apps/web/test/transcripts.test.ts
@@ -254,14 +254,8 @@ describe("the addresses the monitoring section holds", () => {
 });
 
 /**
- * What a quiet Monitoring page owes its reader — four states, and never two at
- * once.
- *
- * Each answers a different question, and the wrong one costs an afternoon:
- * somebody with a week of traffic reading the last hour told to set up an
- * export they already have, somebody with no export told that no grader watches
- * production, somebody whose key names the whole organization told to point an
- * export at egma a second time.
+ * Choose one guidance state from window contents, wider history, visible
+ * key scopes, and production grader coverage.
  */
 describe("which guidance a quiet page shows", () => {
   /** An empty page in a project that has never recorded anything, nothing failed. */
@@ -290,14 +284,8 @@ describe("which guidance a quiet page shows", () => {
   });
 
   /**
-   * **And nothing anywhere is the day-one page, whatever window is selected.**
-   *
-   * A developer who has just signed up lands on the default window, not on the
-   * widest, and an empty page is the one thing standing between them and a
-   * working export. Deciding this by the selected window alone would put a
-   * click in front of the teaching written for exactly this moment — so the
-   * question asked is "has this project ever recorded anything", which the
-   * window cannot answer and one extra read can.
+   * Use the wider recent-history probe for setup guidance, regardless of the
+   * selected window. It does not establish that the project has never recorded a trace.
    */
   it("teaches the setup whenever nothing has ever arrived, at any window", () => {
     expect(seen({ listed: 0, everRecorded: 0 })).toBe("set-up-capture");
@@ -541,14 +529,8 @@ describe("what a stored kind is called where somebody reads it", () => {
 });
 
 /**
- * Two different things with one word between them.
- *
- * A step on this page can carry audio the agent's **own telemetry** attached to
- * it — somebody else's file, at somebody else's address. Beside it now sits
- * egma's own recording of the exchange, both channels, measured off the line
- * egma drove. Hearing one while believing it is the other is a wrong conclusion
- * about a production agent, so the rule is that neither is ever called just
- * "audio": every label that names audio names whose it is.
+ * Keep labels for Egma's recording distinct from external audio attached
+ * to the agent's spans.
  */
 describe("the two kinds of audio a transcript can offer", () => {
   const NAMES_WHOSE_IT_IS = /\begma\b|\byour\b/iu;
@@ -725,14 +707,8 @@ describe("the transcript pages", () => {
 });
 
 /**
- * The metrics display: what this exchange measured, shown beside the exchange.
- *
- * **The page derives no number.** Every figure it shows arrived already computed
- * by the platform's one shared measure module — the same module a future
- * metric-based grader can read — so a duration worked out in a browser would be a
- * second answer about one exchange and exactly what that module exists to
- * prevent. What the page decides is which of the samples to lead with, and it
- * says which one that is.
+ * Check source wiring to API metrics and shared formatting. These assertions
+ * do not independently prove that no browser code derives a metric.
  */
 describe("what the exchange measured", () => {
   it("is read from the answer, and never worked out from the timings", async () => {
@@ -754,19 +730,8 @@ describe("what the exchange measured", () => {
   });
 
   /**
-   * **The reduction is the platform's, and this application must not be able
-   * to repeat it.**
-   *
-   * The number the pages lead with arrives on the answer as `mean`, rounded
-   * once by the shared measure module. Averaging the samples here instead
-   * would look harmless and would be a second implementation of exactly that
-   * figure — correct until the rounding or the samples change under one of
-   * them, with nothing anywhere failing.
-   *
-   * The words live in one shared formatter (`metricLine`), so the transcript
-   * page and the simulation evidence cannot come to word one conversation's
-   * numbers two ways. What is asserted here is the positive half: the
-   * formatter reads the reduced figure it was sent.
+   * Check that metricLine reads and rounds the API's p90 and uses sample
+   * length for the count. The test checks source patterns, not arbitrary arithmetic.
    */
   it("prints the reduction it was handed, and never computes one", async () => {
     const shared = await readFile(
@@ -817,16 +782,8 @@ describe("what the exchange measured", () => {
 });
 
 /**
- * Where a number came from, said on the page that shows it.
- *
- * **A grade's evidence must never be a surprise.** Some figures on this
- * page were not timed by anybody: Egma worked them out from the timings the
- * agent's own framework already records. A developer whose latency check starts
- * failing is owed that sentence beside the number, not in a document.
- *
- * And the quiet sentence for an exchange that measured nothing stays exactly as
- * it was, because it is still exactly as true — a framework emitting nothing
- * Egma recognises still measures nothing.
+ * Check text and wiring for framework-derived metrics and missing measurements.
+ * Missing recognized evidence does not prove the agent measured nothing.
  */
 describe("saying which numbers Egma worked out", () => {
   it("adds a clause only when a worked-out figure is on the page", async () => {
@@ -865,15 +822,8 @@ describe("saying which numbers Egma worked out", () => {
   });
 
   /**
-   * **The wording that must never come back.** A figure a platform reported
-   * arrives `derived: true` as well, because Egma did not time it either — so a
-   * page reading `derived` alone would tell a developer their platform's number
-   * was "worked out from your framework's own timings", about an observation
-   * Egma never made. A caveat that is itself untrue is worse than none: it is
-   * the sentence somebody decides how far to believe a failing check on.
-   *
-   * One predicate answers it for both the mark and the panel's sentence, so the
-   * two can never come to disagree about a figure.
+   * A platform-reported metric can also have derived=true. Both the inline mark
+   * and panel explanation must use the predicate that excludes reportedBy.
    */
   it("never words a platform-reported figure as one Egma worked out", async () => {
     const page = await readFile(path.join(WEB, DETAIL_PAGE), "utf8");

--- a/apps/web/tools/output-lock.ts
+++ b/apps/web/tools/output-lock.ts
@@ -11,55 +11,13 @@ import {
 import path from "node:path";
 
 /**
- * One writer at a time for `apps/web/.next`.
+ * Serialize writers to this checkout's .next directory. A build and browser
+ * test cannot share generated output; a live holder causes an immediate refusal.
  *
- * Two things in this repository write that directory. `next build` writes the
- * production build into it, and the real-browser test starts `next dev`, which
- * compiles into the same place. Run both in one checkout at once and each ends
- * up reading half of the other's output: the build ships pages it did not
- * compile, or the browser test fails somewhere deep inside Next with a message
- * about a missing chunk, and neither failure names the cause.
- *
- * Pointing the two at different output directories does work and costs more
- * than it buys — Next writes the directory it is using back into the checked-in
- * `tsconfig.json` and `next-env.d.ts`, so running the suite would leave the
- * repository dirty. So instead there is one lock file beside the directory, and
- * whoever is second is **refused with a sentence** rather than left to find out.
- *
- * Refused, not queued. A build that waited would look like a build that had
- * hung, and the honest answer to "these two cannot run at once" is to say so
- * while somebody is still watching the terminal.
- *
- * The lock is per checkout, which is exactly the scope of the problem: two
- * worktrees have two `.next` directories and never collide.
- *
- * ## What makes it actually exclusive
- *
- * Three rules, and each one is a way this was wrong before.
- *
- * 1. **The lock file is never seen empty.** Its content is written to a private
- *    path first and the file appears at the lock's own path already holding it,
- *    through `link`, which the kernel refuses when the path exists. Creating an
- *    empty file and filling it in afterwards leaves a window in which the lock
- *    exists but says nothing — and a lock that says nothing was read as one
- *    nobody was behind, and stolen. Four processes racing found that window in
- *    24 rounds out of 30.
- * 2. **Unreadable is not abandoned.** A lock whose content cannot be understood
- *    is refused, never cleared. The only honest thing to say about a file this
- *    code did not write is that somebody has to look at it.
- * 3. **Clearing an abandoned lock is itself serialised, and giving it back is
- *    checked.** Two processes that both decide a lock is abandoned must not
- *    both remove it and both claim — the second would remove the first's fresh
- *    lock. So clearing happens behind a second, briefly-held file, and
- *    `release` removes the lock only when the token in it is still the token it
- *    wrote.
- * 4. **A process id is not an identity.** Operating systems reuse them. A
- *    holder that was killed leaves its lock behind, and the moment something
- *    unrelated is given its number the lock reads as held by a living process
- *    and every later build and browser test is refused until somebody deletes
- *    the file by hand. So the lock records *when* the holder started as well as
- *    which number it had, and a number wearing a different start time is a
- *    different process — see `processIdentity`.
+ * Write complete metadata before claiming the path with an exclusive hard link.
+ * Refuse unreadable locks. Serialize abandoned-lock cleanup with a second file
+ * and verify the recorded holder again before removal. Release only the matching
+ * token. Record PID and process start time to detect PID reuse.
  */
 
 /** The two holders, named once so both sides say the same words. */
@@ -181,17 +139,9 @@ function numberInUse(pid: number): boolean {
 }
 
 /**
- * When a process started, as the machine reports it — the half of a process's
- * identity that a recycled number cannot bring with it.
- *
- * `/proc` first, which is Linux, every container and all of CI, and costs a
- * file read. `ps` second, which is what a developer's macOS answers, and costs
- * one short-lived process — paid only when a lock file is already there, so
- * never on the path that simply takes the lock.
- *
- * `undefined` means this machine would not say. That is read as "still the
- * holder" everywhere below, because refusing a build is a smaller harm than
- * two processes writing one directory.
+ * Read process start identity from Linux /proc, falling back to ps. Acquisition
+ * also reads this process's identity. Unknown identity prevents reclaiming a live
+ * holder and prevents this process from creating a new lock.
  */
 function processIdentity(pid: number): string | undefined {
   try {
@@ -262,16 +212,9 @@ function claim(lockPath: string, holder: Holder): boolean {
 }
 
 /**
- * Remove a lock nobody is behind — one process at a time.
- *
- * The second file is what makes this safe. Only the process that creates it may
- * clear, and while it exists no other process can be inside this function, so
- * the read and the removal below cannot be split by anybody. Nothing else can
- * change the lock in that moment either: claiming is `link`, which fails while
- * the file is there.
- *
- * Answers whether the caller may now try to claim. `false` means somebody else
- * is doing this, and the caller should look again rather than assume anything.
+ * Serialize abandoned-lock removal with an exclusive cleanup file. Recheck
+ * the holder token, PID, and liveness before unlinking. Return false when
+ * another process is clearing so the caller retries.
  */
 function clearAbandoned(lockPath: string, abandoned: Holder): boolean {
   const clearing = `${lockPath}.clearing`;
@@ -419,16 +362,8 @@ function before(finished: Promise<void>, milliseconds: number): Promise<boolean>
 }
 
 /**
- * Ask a process to stop, and wait until it really has.
- *
- * `kill` only sends a signal. A Next development server given `SIGTERM` keeps
- * writing `apps/web/.next` while it closes its watchers, so a caller that
- * signalled and moved on would hand the output directory to the next holder
- * while the last one was still writing it — the exact corruption the lock
- * exists to prevent, arrived at through the lock.
- *
- * Bounded, and then insistent: a process that ignores `SIGTERM` must not hold a
- * suite open for as long as it likes.
+ * Send SIGTERM and wait for exit, then try SIGKILL with another bounded wait.
+ * This can return after the second timeout even without a confirmed exit.
  */
 export async function stopped(
   child: ChildProcess,

--- a/apps/web/ui/choice.tsx
+++ b/apps/web/ui/choice.tsx
@@ -3,24 +3,8 @@
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 
 /**
- * Which of two lists a page is showing.
- *
- * **Two lists, chosen deliberately, never one list with a column saying which
- * rows are archived.** A mixed list is a list somebody picks the wrong row out
- * of.
- *
- * It is announced as a radio group because that is what it is — exactly one of
- * a small closed set is chosen. The group is one Tab stop, the arrow keys move
- * inside it and come back round, Home and End reach the ends, and selection
- * follows focus so the keyboard and the announcement never disagree. None of
- * that is written here any more: it is the kit's radio group, which is Radix's,
- * and every part of it used to be hand-written in this file where a refactor
- * could lose it without one visible pixel changing.
- *
- * It is not a shadcn Tabs or ToggleGroup. Both would draw this, and both would
- * say something else about it: tabs name panels that a page is switching
- * between, and this switches which rows a table is asked for. The radio group
- * is what a person's assistive technology is told.
+ * Choose one list filter with a radio group. The shared primitive owns arrow
+ * keys and focus; this changes queried rows rather than switching tab panels.
  */
 export function Choice<Value extends string>({
   label,

--- a/apps/web/ui/data-table.tsx
+++ b/apps/web/ui/data-table.tsx
@@ -17,38 +17,10 @@ import { cn } from "@/lib/utils";
 import { ROW_HOVER } from "./evidence.tsx";
 
 /**
- * A page of rows, described once and drawn once.
- *
- * **One semantic table produces both layouts.** A wide screen gets a dense
- * table; CSS turns that same tree into a stack of labelled rows on a narrow
- * screen. The column marked `primary` becomes the row's name and the rest
- * become its facts. Drawing a table and a mobile list side by side would put
- * every control and id in the document twice, even though only one copy is
- * visible.
- *
- * **A row is a line of reading, not a card.** The height is a token, cells do
- * not wrap, and the vertical padding is deliberately small: a list of forty
- * agents should be a list of forty agents rather than four screens of scroll.
- *
- * **The frame is the kit's `Table`, and the numbers are the boards'.** A Pure
- * Paper panel inside one hairline with no corner; a 40px header of quiet
- * labels; rows at least 52px with a hairline between them and none after the
- * last; and a fixed 48px slot at the trailing edge that every row carries, so
- * the ⋮ menus line up in one lane down the table whether or not a given row
- * has one. Read off `6ZM-0`, `71F-0` and `710-0` on 2026-08-23. The lane is a
- * floor as well as a width — see `floorOf`, which is what stopped a crowded
- * table squeezing it.
- *
- * Paging is keyset, so "more" means *carry on from where that page stopped*
- * rather than *skip a number of rows*. The control is here rather than in each
- * page so that every list in the product asks for the next page the same way.
- *
- * **What each cell is, is on the cell.** The narrow layout has to reach the
- * primary cell and the action cell from a stylesheet, and the wide layout has
- * to reach real controls inside a row whose primary link has been stretched
- * over it. Those hooks are `data-primary` and `data-action` rather than class
- * names, because a page composing this table can read them, a test can assert
- * them, and neither depends on what the styling is written in.
+ * Render one semantic table in wide and stacked layouts so controls and IDs
+ * are not duplicated. Columns define headers and cells together; primary and
+ * action attributes identify their roles for layout and tests.
+ * Use the shared trailing action slot and next-page control across lists.
  */
 
 export type Column<Row> = {
@@ -64,21 +36,9 @@ export type Column<Row> = {
   /** A row control. It stays at the trailing edge in both table layouts. */
   readonly action?: boolean;
   /**
-   * How wide this column is, when the boards say.
-   *
-   * **It is a real width, not a hint, and that was worth measuring.** The table
-   * lays out `auto`, where a declared width is only a preference — but every
-   * cell's content is clipped to one line, so a column's own minimum is its
-   * padding and nothing pushes back. A browser then gives the widths that were
-   * asked for and hands the slack to the columns that asked for none.
-   *
-   * Measured at 1440 on 2026-08-23, against `6ZM-0` and `8XV-0`: the agents
-   * list lands 260 / 160 / 360 with Created taking the 338 left over, and
-   * personas lands 260 / 140 / 110 / 90 / 130 with Description taking the
-   * slack. Both are the boards, to the pixel. So `table-fixed` is not needed,
-   * and a list that wants the boards' proportions only has to say them.
-   *
-   * A row control's slot is not a caller's to set: see `widthOf`.
+   * Requested column width in automatic table layout. Unspecified columns share
+   * remaining space; constrained content can still affect sizing. Action columns
+   * use the shared width and minimum-width rules below.
    */
   readonly width?: string;
 };
@@ -129,14 +89,9 @@ export function DataTable<Row>({
    */
   readonly stretchPrimaryLink?: boolean;
   /**
-   * Makes the whole row a pointer target for one action that opens in place —
-   * a sheet, not a URL. `stretchPrimaryLink` is for rows whose name is a real
-   * link; this is for rows whose name is a real button. The row answers the
-   * pointer and lights up under it with the evidence surface's own hover mix;
-   * the keyboard path stays the primary cell's button, so the accessibility
-   * tree still holds exactly one control for the one action. A click that
-   * lands on a control inside the row — the ⋮ menu, the name button itself —
-   * is that control's, not the row's.
+   * Activate the row on pointer clicks outside its child controls. Keep a real
+   * button in the primary cell for keyboard access. Use stretchPrimaryLink for
+   * rows whose primary action is navigation.
    */
   readonly onRowActivate?: (
     row: Row,
@@ -175,34 +130,16 @@ export function DataTable<Row>({
   const primary = columns.find((column) => column.primary) ?? columns[0];
   const pageLabel = pagination?.pageLabel(pagination.page);
   /**
-   * How wide a column is, and the one width this component decides for itself.
-   *
-   * A row control's slot is the theme's, not the caller's: it is what makes
-   * the trailing lane straight, and a page choosing its own would bend it. A
-   * caller may still say `width` on any other column.
-   *
-   * It is written on the header cell alone. A column width set there governs
-   * the whole column, and a width on the body cells as well would survive into
-   * the stacked layout — where the cells are no longer a table and a 48px
-   * "column" is a 48px box with a menu falling out of it.
+   * The theme owns action-column width; callers may size other columns. Apply
+   * width to headers only so it does not constrain body cells in stacked layout.
    */
   function widthOf(column: Column<Row>): string | undefined {
     if (column.action === true) return "var(--table-action-width)";
     return column.width;
   }
   /**
-   * The one width that is a floor rather than a preference.
-   *
-   * **A declared width on a table is a request, and an over-constrained table
-   * refuses it.** The layout is `auto`, so when the columns' own minimums add
-   * up to more than the table has — which every list with a long name in it
-   * reaches — a browser takes the shortfall out of the columns that can give
-   * it, and the trailing lane gives most: its content is one 36px glyph, or on
-   * a row with no control, nothing at all. That is how the same 48px
-   * declaration measured 48 on Agents, 40 on Personas and 0 on Runs.
-   *
-   * `min-width` is what the lane cannot be argued out of. It is written beside
-   * the width, on the header cell alone and for the same reason.
+   * Give the action column a min-width as well as width. Automatic table layout
+   * can otherwise shrink an empty action column below its intended size.
    */
   function floorOf(column: Column<Row>): string | undefined {
     return column.action === true ? "var(--table-action-width)" : undefined;
@@ -350,22 +287,9 @@ export function DataTable<Row>({
                       ],
                       "data-[action=true]:px-0 data-[action=true]:text-center",
                       /*
-                       * **A column the narrow layout omits takes the stacked
-                       * layout's `display` and nothing else.** Writing the two
-                       * as separate rules — `stacked:flex` for every cell and
-                       * `max-[900px]:hidden` for this one — put two `display`
-                       * declarations of equal weight under one query, and the
-                       * one Tailwind happened to emit last won. It was `flex`,
-                       * so `hideOnMobile` hid nothing on a phone: the personas
-                       * list still drew Description and Version, and the
-                       * agents list still drew Created.
-                       *
-                       * There is no rule to outrank now, and the second half
-                       * is the same fix: the omission follows `stacked`, so a
-                       * table that stacks because its own container is narrow
-                       * omits the same columns a phone does. `hideOnMobile`
-                       * has always meant "the narrow layout may leave this
-                       * out", and `stacked` is what "narrow layout" means.
+                       * Choose hidden or flex within the same stacked variant. Competing display
+                       * rules could make hideOnMobile ineffective; container-based stacking must
+                       * hide the same optional columns as a narrow viewport.
                        */
                       stacks && hiddenWhenStacked(column)
                         ? "stacked:hidden"

--- a/apps/web/ui/dialog.tsx
+++ b/apps/web/ui/dialog.tsx
@@ -16,39 +16,13 @@ export type OutsidePointerDismiss =
   | ((target: EventTarget | null) => boolean);
 
 /**
- * A layer that is answered or dismissed before the page goes on.
+ * Compose shared dialog primitives into modal dialogs/drawers and nonmodal
+ * reading sheets. Manage opener focus and delay owner removal until exit
+ * finishes, with a watchdog for missing completion events.
  *
- * The compact mobile shell uses one for its navigation, confirmations use one
- * to name what they are about, and the evidence panel is the same surface
- * attached to an edge. So the two rules that are always forgotten are here
- * rather than in each caller: **Escape closes it**, and **opening it moves
- * focus inside** so that a keyboard is not still driving the page underneath.
- *
- * **The modal lifecycle is the kit's.** `components/ui/dialog.tsx` is Radix,
- * and Radix traps focus, makes the page behind it inert, turns Escape into a
- * close, and blocks the page to the pointer while it is up. This file used to
- * do all of that by hand on a native `<dialog>`; it now says only what the kit
- * does not know — which of the three shapes to wear, which of them takes the
- * screen, where focus goes back to, and when the owner may remove it.
- *
- * **`onClose` still means "now take me away", and it is called last.** Owners
- * mount this component and remove it, so an exit has to finish before React
- * unmounts anything: `ExitGate` below sits inside the panel and reports the
- * moment Radix lets go of it, which is the moment the closing animation ended.
- * A dialog is never the security boundary and never the only place a fact is
- * stated. It is a way of asking, and closing one always leaves the page as it
- * was.
- *
- * A child function receives the same dismiss path as the close button and the
- * scrim. Successful writes may still call the owner's `onClose` directly,
- * because the system response should not wait for decoration — the gate below
- * stays quiet on that path rather than closing the same dialog twice.
- *
- * **The motion is not here.** `tailwind-theme.css` keys the entrance, the exit
- * and the reduced-motion form of both on the `data-slot`, `data-kind` and
- * `data-state` the kit and this file write — the centred dialog and the
- * drawer's edge travel alike. The one piece left below is the sheet's travel,
- * which has no token pair of its own to be given a rule for.
+ * Children receive the shared dismiss path. Owners may close immediately after
+ * a successful write; ExitGate must not report a second close on that path.
+ * Theme selectors own motion through the data attributes.
  */
 
 /**
@@ -69,17 +43,8 @@ const PANEL_SHAPE = {
     "overflow-y-auto border-y-0 border-l-0",
   ],
   /*
-   * **One side sheet look, with reading widths chosen by content.** This is the
-   * same panel `components/ui/sheet.tsx` draws — right-anchored, Pure Paper
-   * behind a hairline on its left edge, no corner, the same travel — and every
-   * width is the theme's rather than a number written here.
-   *
-   * The two components are still two, and the difference is behaviour: this
-   * one is a *reading* surface that deliberately leaves the page beside it
-   * usable, and that one is a modal form portaled inside `<main>`.
-   * `size="wide"` and `size="extra-wide"` are for reading surfaces, where the
-   * content is a transcript rather than a form and 440px is not enough of a
-   * page.
+   * Reading sheets share the form sheet's appearance but remain nonmodal.
+   * Wide sizes provide room for transcript content while leaving the page usable.
    */
   sheet: [
     "top-0 right-0 left-auto h-full max-h-none",
@@ -123,16 +88,8 @@ const HEAD_SHAPE = {
 } as const;
 
 /**
- * How long a stuck exit is given before the dialog is taken away anyway.
- *
- * Not a motion value, and deliberately not on the motion scale: it is longer
- * than every exit token so it can never pre-empt one. Both implementations this
- * file replaced carried the same guard, for the same reason — an exit that ends
- * in an event ends in an event that can go missing. A browser that never fires
- * `animationend`, an injected stylesheet that removes the animation, or a tab
- * that was hidden mid-exit would otherwise leave a dismissed dialog mounted,
- * the page behind it hidden from assistive technology, and `onClose` never
- * called.
+ * Fallback deadline for an exit that never reports completion. Keep it longer
+ * than normal exit motion so dismissal cannot leave the owner mounted indefinitely.
  */
 const EXIT_WATCHDOG_MS = 600;
 
@@ -153,22 +110,8 @@ function ExitGate({ onGone }: { readonly onGone: () => void }) {
 }
 
 /**
- * Which of the three shapes takes the screen, and which sits beside the work.
- *
- * A confirmation and the mobile navigation are questions: nothing behind them
- * can be reached until they are answered, which is `DESIGN.md`'s "dialogs trap
- * focus, make the background inert". A sheet is not that. It is a panel docked
- * to an edge, the simulation page opens one by default, and that page is built
- * to be read with the transcript open beside the grader results — so a sheet
- * that put the page behind it out of reach would break the page it belongs to.
- *
- * A sheet keeps everything else a dialog has: focus moves into it, Escape
- * closes it, and the control that opened it is focused again afterwards. What
- * it drops is the scrim, the scroll lock, and the inert page.
- *
- * **This is a design call rather than a fact, and it is called out in the pull
- * request for the developer to overrule.** The surface it changes is the
- * transcript-and-audio sheet and the persona version history.
+ * Dialogs and navigation drawers are modal. Reading sheets leave the adjacent
+ * page usable without an overlay or focus trap.
  */
 const TAKES_THE_SCREEN = { dialog: true, drawer: true, sheet: false } as const;
 
@@ -237,23 +180,9 @@ export function Dialog({
   };
 
   /**
-   * The keyboard goes back on the press, not at the end of the exit.
-   *
-   * `DESIGN.md`: "No motion delays input. A control answers on press, not
-   * after an animation." Waiting for the panel to finish leaving is a fifth of
-   * a second with focus sitting on a button that is on its way out, inside a
-   * layer the page behind is still hidden from — a Tab in that window goes
-   * nowhere useful. So focus moves the moment the dialog is told to close.
-   *
-   * **It is an effect rather than a line inside `dismiss`, and the ordering is
-   * the reason.** While the dialog is open the kit traps focus and pulls
-   * anything that leaves straight back in, so focusing the opener during the
-   * press would simply be undone. The trap is released in the same render that
-   * closes the dialog, and React runs that release before this effect — so
-   * this is the first moment the move can stick, and it is still the same
-   * frame as the press.
-   *
-   * The timer is the other half. See `EXIT_WATCHDOG_MS`.
+   * Restore focus after the closing render releases the modal trap, without
+   * waiting for animation. Preserve focus already moved outside, including the
+   * control clicked to dismiss a nonmodal sheet. Arm the exit watchdog.
    */
   useEffect(() => {
     if (open) return undefined;
@@ -306,14 +235,9 @@ export function Dialog({
         aria-describedby={undefined}
         onCloseAutoFocus={(event) => {
           /*
-           * The kit's own answer here is its `DialogTrigger`, which these
-           * callers do not use, so left alone it would drop focus on the page
-           * body. Saying no to it is most of the job — focus has already gone
-           * back, above, at the press. What is left is the case where it fell
-           * to the body anyway, and then this puts it where it belongs. It is
-           * deliberately not unconditional: the exit is long enough to Tab
-           * during, and pulling focus back off somebody mid-exit would be the
-           * same rudeness in the other direction.
+           * These callers do not use DialogTrigger. Suppress default restoration and
+           * restore the opener only if focus fell to body; do not steal focus that the
+           * user moved during exit.
            */
           event.preventDefault();
           if (

--- a/apps/web/ui/draft-navigation.tsx
+++ b/apps/web/ui/draft-navigation.tsx
@@ -40,17 +40,9 @@ type DraftNavigation = {
 const DraftNavigationContext = createContext<DraftNavigation | null>(null);
 
 /**
- * Product navigation for controls that do not use an anchor.
- *
- * Ordinary Next links need no page code: the provider catches their same-origin
- * click before Next changes the route. Controls such as the project selector
- * call `push`, while an in-page tab can call `request` with its own state
- * change. All three paths use the same dialog and the same draft state.
- *
- * Browser Back is different: `popstate` is not cancellable. The provider does
- * not claim it can stop a full route change after the browser has made it.
- * Address-owned state inside one mounted page may restore its address and ask
- * after the fact, as the People tabs do.
+ * Share the unsaved-draft prompt across anchor clicks, imperative navigation,
+ * and in-page changes. Browser popstate is not cancellable; a mounted page
+ * may restore its own address before asking, but this cannot block every Back action.
  */
 export function useDraftNavigation(): DraftNavigation {
   const router = useRouter();

--- a/apps/web/ui/evidence.tsx
+++ b/apps/web/ui/evidence.tsx
@@ -12,54 +12,12 @@ import { howFarIn, howLong } from "../lib/transcripts.ts";
 import { Empty } from "./page-state.tsx";
 
 /**
- * The parts one conversation's evidence page is built from.
- *
- * **Each one takes finished data and decides nothing.** A transcript is handed
- * turns; the grade block is handed a completed grade. That is what makes them
- * reusable and what makes them tunable: their appearance is the class list on
- * each element and their contract is `lib/simulations.ts`, and neither can be
- * changed by touching the other. A component that fetched, folded or filtered
- * would put a second opinion inside the page and the two would disagree the day
- * somebody changed one.
- *
- * They live in their own file, beside `run-status.tsx` and for the same
- * reason: the shared component set is deliberately held closed.
- *
- * **Speech, timing and grading stay three things.** The transcript is what was
- * said and nothing else — tool calls and system work are not interleaved into
- * it, because a transcript with machinery in the middle of it stops being
- * readable as a conversation. A page that wants speech and machinery on one
- * clock builds that view for itself; it is not one of these. And a grade is
- * never drawn inside a turn: grading is a separate act from speaking, and a
- * page that mixed them would let a reader take a grader's sentence for
- * something the agent said.
- *
- * **The appearance is Tailwind on the shadcn base**, and `evidence.module.css`
- * is gone with it. What it said about these surfaces still holds and is worth
- * keeping: a transcript stays prose, a measure stays a number, and a grade
- * stays a grade. They share the palette and the hairlines without those three
- * different facts becoming one card pattern.
- *
- * What each surface *is* moved from a module class name onto `data-slot`, and
- * the one state a class name used to carry moved onto `data-cited`. Neither is
- * styled by anything. They are there because a name like `turnCited` was
- * readable in an inspector or a test and a class list is not.
+ * Render supplied transcript and grading data without fetching it. Keep speech,
+ * timing details, and grades distinct so grader text cannot be mistaken for
+ * agent speech. Data attributes identify semantic roles for inspection and tests.
  */
 
-/**
- * The quiet hover tint on a row, and the one colour here that is written out
- * rather than named.
- *
- * The theme names the derived values that mean something on their own — a
- * status chip's edge, the dialog scrim. This is not one of those. It is
- * `--surface-soft` held back to 62% so a row lights up under the pointer
- * without becoming a surface of its own, and nothing else in the product wants
- * it. A token would be a name with one caller, so the recipe stays an arbitrary
- * value here; a second surface that ever wants the same tint earns the token
- * then. The data table's activatable rows are that second surface, so the
- * recipe is exported rather than retyped — still one string, now with two
- * callers instead of a copy.
- */
+/** Share this muted hover tint between evidence rows and activatable data-table rows. */
 export const ROW_HOVER =
   "pointer-hover:bg-[color-mix(in_srgb,var(--surface-soft)_62%,transparent)]";
 
@@ -93,17 +51,8 @@ export type TranscriptProps = {
 };
 
 /**
- * What the persona and the agent said, in the order they said it.
- *
- * Compact `human:` / `agent:` labels and normal reading density, on purpose. A
- * stack of oversized message cards puts two turns on a screen, and this is the
- * one surface where somebody is trying to hold a whole conversation in their
- * head at once.
- *
- * What happened *inside* a turn is counted here and drawn nowhere here.
- * Putting a tool call between two sentences would break the reading, and
- * dropping the count would lose it — so the count is named and the detail
- * belongs to whatever timed view a page builds for it.
+ * Render supplied turns with compact speaker labels. Count work within turns
+ * here; detailed tool and timing views are composed separately.
  */
 export function Transcript({
   transcript,

--- a/apps/web/ui/feedback.tsx
+++ b/apps/web/ui/feedback.tsx
@@ -20,34 +20,10 @@ import { cn } from "@/lib/utils";
 export type FeedbackInput = "keyboard" | "pointer";
 
 /**
- * A short explanation attached to one control.
- *
- * Keyboard focus shows it at once and without movement. A pointer gets a short
- * delay before the first one, which prevents accidental flashes while it
- * crosses the page, and the same trigger hovered again straight after opens at
- * once. The tooltip never holds an action; interactive help belongs in a menu
- * or dialog.
- *
- * **All of the timing, the positioning, the Escape, and the `aria-describedby`
- * are the kit's now**, which is Radix's. What used to be here was a hand-written
- * pair of timers, a module-level timestamp shared between every tooltip on the
- * page, and a panel hard-centred over its trigger that ran off the side of a
- * narrow window rather than answering the edge.
- *
- * One thing that global timestamp did is not replaced, and mounting a provider
- * would not replace it. Radix keeps the "open the next one at once" window on
- * the provider, and the kit's `Tooltip` wraps every root in a provider of its
- * own, so each tooltip only ever groups with itself: this trigger re-hovered
- * is instant, its neighbour still waits the full delay. A provider mounted
- * higher up changes nothing, because the nearest one wins and the nearest one
- * is always the inner one. Restoring the shared window means removing that
- * wrapper *and* mounting one provider above the product — two files at once,
- * recorded with the coordinator rather than done here.
- *
- * `data-input` is only read by the exit: Radix reports "closed" the same way
- * whichever input opened it, and a keyboard close must not wait for a movement.
- * It is set on the way in rather than on the way out, so it is already true by
- * the time the exit runs.
+ * Use shared tooltip behavior for timing, placement, Escape, and accessible
+ * descriptions. Track input type for keyboard-specific exit styling.
+ * Each tooltip owns a provider, so the instant-reopen window is per tooltip,
+ * not shared across neighboring controls. Tooltips must contain no actions.
  */
 export function Tooltip({
   label,
@@ -86,23 +62,9 @@ export function Tooltip({
 }
 
 /**
- * One controlled, interruptible product notification.
- *
- * It stays mounted for a pointer dismissal so its exit can finish. Keyboard
- * activation and dismissal are instant. The visible word and symbol carry the
- * state together, so the notification never depends on color alone.
- *
- * **It is not built on the kit's sonner Toaster, deliberately.** `DESIGN.md`
- * asks a toast for a short translate plus opacity on an *interruptible
- * transition*; sonner leaves on a CSS animation and a fixed unmount timer, so
- * a dismissal cannot be answered at once. A page here also says whether this
- * notification is open, rather than pushing into a queue that owns it.
- * `components/ui/sonner.tsx` is house-correct and waiting for the surface that
- * wants a queue; the icons below are its icons, so the two read as one product.
- *
- * The motion itself is in `tailwind-theme.css`, keyed on `data-slot`,
- * `data-input` and `data-closing`, so position and motion never share a
- * property and the reduced-motion form is written beside the full one.
+ * Controlled notification with pointer exit motion and immediate keyboard
+ * dismissal. Keep it mounted while closing and cancel closure when reopened.
+ * Theme attributes select motion; text and icons convey status without color alone.
  */
 export function Toast({
   open,
@@ -183,15 +145,8 @@ export function Toast({
       }}
     >
       {/*
-       * The shape says which state this is and the colour only supports it: a
-       * ticked circle against a crossed octagon reads as two different things
-       * with no colour at all. Neutral for "this happened" and the failure
-       * colour for "this went wrong" — never the brand colour, which
-       * `DESIGN.md` keeps away from every semantic result.
-       *
-       * They are the icons `components/ui/sonner.tsx` draws for the same two
-       * states, so a queued notification and this one would not arrive looking
-       * like two different products.
+       * Use the same status/error icons as queued notifications. Shape and text
+       * carry the meaning; color is supporting information.
        */}
       <Mark
         className={cn(

--- a/apps/web/ui/field-hint.ts
+++ b/apps/web/ui/field-hint.ts
@@ -3,21 +3,9 @@
 import { createContext, useContext } from "react";
 
 /**
- * The id of the hint a field is wearing, offered to whatever control it wraps.
- *
- * **A hint nothing points at is a hint only a sighted reader ever gets.** It
- * travels through context rather than through a prop because the alternative
- * is every caller remembering to wire `aria-describedby` on every control —
- * and the ones they forget are exactly the ones nobody notices, because the
- * page still looks right.
- *
- * It lives in its own file rather than inside the component that provides it,
- * because the two halves of the product sat on either side of it while they
- * were being migrated: a shadcn primitive reaching into the legacy control set
- * for a context would have been a dependency pointing the wrong way, and would
- * have broken when that file was retired. It was, and this module outlived it —
- * `ui/form.tsx` provides the context and `components/ui/input`, `textarea`,
- * `select` and `checkbox` read it, with neither importing the other.
+ * Share hint IDs through context so wrapped inputs can set aria-describedby.
+ * Keep the context separate from both Field and the input primitives to avoid
+ * a dependency cycle.
  */
 export const FieldHintContext = createContext<string | undefined>(undefined);
 

--- a/apps/web/ui/form.tsx
+++ b/apps/web/ui/form.tsx
@@ -8,39 +8,14 @@ import { cn } from "@/lib/utils";
 import { FieldHintContext } from "./field-hint.ts";
 
 /**
- * A form, the rows it is laid out in, the fields inside it, and the three
- * sentences a form says.
- *
- * The seven pieces are one file because they are one thing: no page decides
- * for itself how far a form runs across a wide screen, how two fields sit
- * beside each other, or what a refusal looks like above the form it refused.
- *
- * They are here rather than in `components/ui/` because that directory holds
- * shadcn's own primitives, added with its CLI and named as the registry names
- * them. These are egma's compositions *of* those primitives — a `Field` wraps
- * whichever control it is given — so they live beside the product's other
- * shared components, which is where every page already looks for them.
+ * Shared form compositions built from input primitives: layout, fields,
+ * hints, and save/refusal feedback.
  */
 
 /**
- * A label's own words, with a mandatory field's star drawn in Ember.
- *
- * `DESIGN.md` sets one label grammar for the whole product: a mandatory
- * field's label ends in `*` and an optional one ends in `[optional]`. The
- * colour of that star is Ember, and it is decided here rather than by each
- * screen, so no two form labels can wear a different one.
- *
- * The tests grid's column headings are the one place outside a form that draws
- * the star, and they draw it in the heading's own muted colour: a heading row
- * carries four of them side by side, and four Ember marks across it read as a
- * state the table is in (founder, 2026-09-04). That is a heading rather than a
- * label, and it does not come through here.
- *
- * **The star stays inside the label's own text.** It is a `<span>` for its
- * colour and its 4px of air, not a separate element beside the label, so the
- * name a screen reader announces is exactly the name it announced before —
- * and the star's promise is still kept by `aria-required` on the control,
- * which is the half no styling can stand in for.
+ * Render trailing required stars in the form accent color and preserve them
+ * inside the label. Controls still need aria-required. Grid column headings
+ * use their own muted marker and accessible name.
  */
 export function LabelText({ label }: { readonly label: string }) {
   if (!label.endsWith("*")) return <>{label}</>;
@@ -52,18 +27,7 @@ export function LabelText({ label }: { readonly label: string }) {
   );
 }
 
-/**
- * A labelled field, and the hint it lends to whatever control it wraps.
- *
- * The hint's id travels through context rather than through a prop: a caller
- * wiring `aria-describedby` by hand forgets exactly the fields nobody checks,
- * because the page still looks right without it. `field-hint.ts` says why it
- * is a context and holds the context itself.
- *
- * The label is the kit's, which is Radix's: a double click on a plain `<label>`
- * selects the words around it, which is what a person sees when they meant to
- * select the value in the field beside it.
- */
+/** Provide the hint ID to nested controls and render the shared label primitive. */
 export function Field({
   label,
   htmlFor,
@@ -74,14 +38,8 @@ export function Field({
   readonly label: string;
   readonly htmlFor: string;
   /**
-   * A quiet fact about the value, beside the label rather than inside it.
-   *
-   * `scores · 1` is what the answer means, not what to write, so it is neither
-   * a second help line nor part of the label's own words: the form still reads
-   * in plain language and the mapping is still there to find. It stays outside
-   * the `<label>` element, so the name a screen reader announces does not
-   * change — the control describes itself with it instead. Square brackets are
-   * reserved for `[optional]`, so an annotation never wears them.
+   * Describe a value mapping beside the label without changing the control's
+   * accessible name. Reserve square brackets for the optional-field marker.
    */
   readonly annotation?: string;
   /** One line saying what belongs here, for a field whose name is not enough. */
@@ -123,16 +81,8 @@ export function Field({
 }
 
 /**
- * The form itself.
- *
- * It is held to 72ch because a line somebody has to read across is a line they
- * lose their place in, and it is the same measure every editor in the product
- * is set at.
- *
- * The first `Section` inside a form loses its top margin: the form's own
- * padding has already opened the space, and the margin on top of it read as a
- * gap nobody asked for. The rule is on the form rather than on the section
- * because it is the form that knows it is first.
+ * Limit form reading width and remove the first section's extra top margin
+ * where form padding already supplies separation.
  */
 export function Form({
   onSubmit,
@@ -210,16 +160,7 @@ export function Help({
   );
 }
 
-/**
- * What went wrong with one field, or with the whole form.
- *
- * It is announced rather than merely coloured, and it never replaces what
- * somebody typed. A refusal that cleared the form would make the person type
- * their work again to find out whether the second attempt fails the same way.
- *
- * `Refused` is the same news one level up: this one names a field, that one
- * heads the form it refused and can carry the way to ask again.
- */
+/** Announce field or form refusal without clearing the user's draft. */
 export function Problem({
   id,
   children,

--- a/apps/web/ui/menu.tsx
+++ b/apps/web/ui/menu.tsx
@@ -11,45 +11,12 @@ import {
 import { cn } from "@/lib/utils";
 
 /**
- * A button that opens a small panel, and everything that has to be true of one
- * before somebody without a pointer can use it.
+ * Use a popover for anchored placement and dismissal, with keyboard navigation
+ * over data-menu-item controls. Prefer data-menu-focus-first on the initial target.
  *
- * The organization and project controls, account menu, and editor choosers all
- * use this behavior. Writing it once is what stops a later control being the
- * first one with the keyboard left out.
- *
- * **The panel is the kit's anchored surface.** `components/ui/popover.tsx` is
- * Radix, so it owns what a hand-written panel keeps getting wrong: it opens
- * against the trigger and stays on screen when there is no room below it,
- * Escape closes it and puts focus back on the button, a press outside or a
- * focus that leaves closes it, and the exit finishes before the panel is
- * removed. Radix also publishes the corner it grew from, which is how
- * `tailwind-theme.css` scales it from the trigger without this file saying so.
- *
- * **The list of items is still this file's, and that is the reason for
- * `Popover` rather than the kit's `DropdownMenu`.** A dropdown menu keeps its
- * own register of items: only what it was handed as an item takes the arrow
- * keys, and it reads every printable key as a jump to a matching item. Some
- * panels here hold a field to type in, which that would take the keys away
- * from, and the account menu's dark-theme switch is a `role="switch"` rather
- * than an item, which that would leave reachable by pointer alone. So the
- * items are found in the DOM by `data-menu-item` — a panel that grows a row
- * gets the arrow keys for free, whatever that row is.
- *
- * - **The arrow keys move between items**, Home and End reach the ends, and
- *   opening moves focus into the panel.
- * - An item marked `data-menu-focus-first` takes focus when the panel opens.
- *   This lets a panel with a field put the keyboard there before its rows.
- *
- * **A panel holding a text field is not a `menu`.** `role="menu"` promises a
- * list of commands, and neither ARIA nor a screen reader's menu mode expects a
- * textbox inside one. A panel that has something to type in is a `dialog`
- * holding ordinary controls; a panel that is only commands stays a `menu`.
- * That is `panelRole`, and it is why `MenuItem` can leave its role off.
- *
- * **Home and End belong to the caret while somebody is typing.** Stealing them
- * to jump to the ends of the list means the ends of the *text* cannot be
- * reached, which is a worse trade than the one it buys.
+ * Command-only panels use menu semantics; panels containing text inputs use
+ * dialog semantics. Keep Home/End with the caret while typing. A dropdown
+ * menu primitive would impose item and typeahead behavior on mixed controls.
  */
 
 export type MenuProps = {
@@ -161,23 +128,9 @@ export function Menu({
   const anchor = ANCHOR[placement];
 
   /**
-   * Handing the keyboard back, now rather than after the panel has gone.
-   *
-   * Radix restores focus itself, one task after the panel is removed. That is
-   * right for a panel somebody clicked away from and wrong for the two ways of
-   * *finishing* with one — Escape, and choosing something — because
-   * `DESIGN.md` says a control answers on press and never after an animation.
-   * So those two paths put focus back on the button first and let the panel
-   * leave behind them. Radix then sees focus has moved out, stops restoring it
-   * a second time, and the panel's exit runs to its end regardless.
-   *
-   * It is also what keeps the project selector's unsaved-work dialog pointing
-   * at the right control. That page walks up from whatever has focus to
-   * `[data-slot="menu"]` to find its own trigger — a walk that now finds
-   * nothing, because the panel is drawn at the end of the page rather than
-   * inside that root, so the walk starts outside it and its answer is always
-   * null. What saves it is the fallback: the dialog it opens takes whatever
-   * has focus, and by then this has already put that back on the trigger.
+   * Return focus to the trigger when choosing an item or pressing Escape, before
+   * exit motion finishes. This also gives a subsequent unsaved-work dialog a
+   * stable return target outside the portaled menu.
    */
   const returnFocus = useCallback(() => triggerRef.current?.focus(), []);
 

--- a/apps/web/ui/number-field.tsx
+++ b/apps/web/ui/number-field.tsx
@@ -8,37 +8,9 @@ import { cn } from "@/lib/utils";
 import { LabelText } from "./form.tsx";
 
 /**
- * A field whose value is a number, with its bounds and its unit on it.
- *
- * The shared control set has never had one. Two places in the product needed
- * one and got a text field told to look numeric instead: a grader's pass
- * threshold, and the share of production traffic its project scope selects.
- * Both then had to say the rest in prose — "a whole percentage from 0 to 100" is a
- * sentence beside a control that would happily take 900, and a bound with a
- * unit had the unit written into its hint because the field could not show it.
- *
- * So this control carries the three things that sentence was standing in for:
- *
- * - **The bounds are on the field.** `min`, `max` and `step` are the browser's
- *   own validation and the browser's own arrow-key stepping. A caller that
- *   knows the range says it once here instead of twice, once in prose.
- * - **The unit is beside the value**, inside the field and at the trailing
- *   edge, and it is part of what the field is described by rather than being
- *   hidden decoration. A person reading with a screen reader is told the unit.
- * - **The digits are tabular**, because `DESIGN.md` asks that of every metric,
- *   and a value somebody is editing against a limit is exactly that.
- *
- * **The value stays a string, and that is deliberate.** An input's value is a
- * string whatever type it wears, and this product converts at the edge that
- * sends — `filledParams` is where a bound becomes a number. A control that
- * handed back a number would have to decide what an empty field and a
- * half-typed minus sign are, and it would decide differently from that edge.
- *
- * The native spin buttons are hidden. They are drawn differently by every
- * browser, they are the one part of a form that never matches the rest of it,
- * and they take a pointer to a target smaller than this product allows
- * anywhere else. Nothing is lost to the keyboard: the arrow keys still step
- * the value, because the field is still `type="number"`.
+ * Numeric input with native min/max/step, tabular digits, and an accessible unit.
+ * Keep values as strings until submission so empty and partial drafts survive.
+ * Hide native spin buttons while retaining keyboard stepping.
  */
 export function NumberField({
   id,
@@ -123,14 +95,8 @@ export function NumberField({
         <LabelText label={label} />
       </label>
       {/*
-       * The unit sits beside the field rather than inside it.
-       *
-       * Inside, the field has to reserve room for it, and the room has to be a
-       * fixed number — which is a guess about the longest unit anybody will
-       * ever pass. The first guess was 56px, and "seconds" already needs more
-       * than that, so a value long enough to reach it would have slid under
-       * the word. Beside it, the field takes whatever is left and every unit
-       * fits, including ones nobody has written yet.
+       * Place the unit beside the input so it takes its measured width instead of
+       * a fixed inset that could overlap a long value.
        */}
       <div className="flex items-center gap-2">
         <Input

--- a/apps/web/ui/page-navigation.tsx
+++ b/apps/web/ui/page-navigation.tsx
@@ -29,30 +29,8 @@ export type PageNavigationItems = readonly [
 ];
 
 /**
- * The one navigation model for a page below a product section.
- *
- * The shell says which stable product section somebody is in. This module says
- * where the current record sits inside that section: run, then simulation;
- * agent, then connection; Settings, then one settings page. Pages provide only
- * the ordered labels and parent addresses. List navigation, separators,
- * current-page heading and narrow-screen wrapping stay here. Every segment is
- * the same 14px / 400 text; colour and the slash communicate hierarchy without
- * changing the current page's size or weight.
- *
- * Operational controls never belong here. Cancel, Retry, Edit, Archive and
- * Save remain page actions because they change the current record rather than
- * move through its hierarchy.
- *
- * **This one is not built on a kit primitive, and that is the finding rather
- * than an omission.** The structure-and-navigation migration rebuilt its two
- * neighbours — a tab strip became the kit's tabs, a hand-drawn rule became the
- * kit's separator — and looked for the same here. There is nothing to move to:
- * the kit holds no breadcrumb, the trail is an ordered list because that is
- * what a trail is, and the separator between two crumbs is a `/` a reader
- * understands and not a rule. The rest of the file was already on the shared
- * vocabulary — semantic tokens, the fine-pointer hover variant, a coarse-
- * pointer target — and carries no motion, which is what `DESIGN.md` asks of a
- * navigation row. Rewriting it would have been churn with a diff attached.
+ * Render ordered parent links and the current page heading with shared
+ * separators and responsive wrapping. Keep operational actions outside the trail.
  */
 export function PageNavigation({ items }: { readonly items: PageNavigationItems }) {
   return (
@@ -78,17 +56,8 @@ export function PageNavigation({ items }: { readonly items: PageNavigationItems 
           >
             {item.href === undefined ? (
               /*
-               * The last step is the page, so it is the page's `<h1>`. It
-               * carries the line's own type rather than a heading size: the
-               * trail is one line of navigation, and a step in a different
-               * size would say the two halves are different kinds of thing.
-               *
-               * **It truncates only where the bar is one line.** Above 900px
-               * that bar is a fixed 56px strip, so a record name as long as
-               * somebody typed it has to end in an ellipsis or spill over the
-               * strip's own border. Under 900px the bar is `h-auto` and the
-               * trail is the page's first lines, so the name wraps there and
-               * a reader gets all of it.
+               * Use the final segment as h1. Truncate in the fixed-height wide header and
+               * allow wrapping when the narrow header grows with its content.
                */
               <h1
                 className={cn(

--- a/apps/web/ui/page-state.tsx
+++ b/apps/web/ui/page-state.tsx
@@ -7,19 +7,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
 /**
- * What a page shows when it is not showing its data.
- *
- * Loading, empty, failed and not-found are four different sentences and they
- * must never be collapsed into one. "Nothing here" and "egma could not answer"
- * point somebody in opposite directions, and a spinner that stays forever
- * because a request failed is the worst of the four.
- *
- * Every state is the same component with a different tone, so a page that
- * grows a fifth state cannot invent a fifth appearance for it.
- *
- * The tone is also on the element as `data-tone`, because the appearance is now
- * a class list rather than a named module class. A page under test, or a person
- * reading the inspector, can still ask which of the four this is.
+ * Keep loading, empty, failed, and missing states distinct. Data-tone exposes
+ * the state for styling and tests.
  */
 
 export type StateTone = "quiet" | "plain" | "bad";
@@ -76,27 +65,9 @@ function PageState({
 }
 
 /**
- * Waiting on egma. It says what it is waiting for, not just that it is waiting.
- *
- * **The sentence is the state; the bars are the proof it is still running.**
- * `DESIGN.md` asks a loading state for a "fast, quiet indicator", and a page
- * that only wrote "Loading agents…" and then held perfectly still could not be
- * told from one that had given up. Three neutral bars breathing under the
- * sentence say the wait is alive. They are `aria-hidden`, because the sentence
- * above them is already announced by this section's `role="status"` and a
- * screen reader gains nothing from three rectangles.
- *
- * **No motion is written here, and the slot names are why.** The wait before
- * this appears, the breath in the bars and the phase between them are all in
- * `tailwind-theme.css`, under the same `DESIGN.md` rule as the run state
- * mark's turn and keyed on the two names this component publishes:
- * `page-state` on the section and `loading-indicator` on the group below. That
- * is what lets one rule treat a route fallback, the card inside it and the
- * bars inside that as a single arrival rather than three overlapping ones —
- * something three separate class lists could never agree on.
- *
- * Nothing here flashes on a fast read, and reduced motion keeps the meaning:
- * both are properties of those rules, and both are argued where they live.
+ * Announce what is loading; hide decorative bars from assistive technology.
+ * The theme owns delay, animation, and reduced-motion behavior. Animation
+ * indicates a waiting state, not proof that the request is progressing.
  */
 export function Loading({ what }: { readonly what: string }) {
   return (
@@ -115,24 +86,8 @@ export function Loading({ what }: { readonly what: string }) {
 }
 
 /**
- * There is nothing here, and that is a fact about the project, not a fault.
- *
- * **It is drawn here rather than through `PageState`, and the reason is what
- * the four states are about.** Loading, failed and not-available are about
- * *egma* — a wait, a refusal, an address that leads nowhere. They interrupt,
- * so they are set apart from the page. An empty list is about the *project*:
- * it is the ordinary first day of a list nobody has written to yet, it belongs
- * on the page, and it is the one state that offers an action.
- *
- * `AN8-0` (page `B-0`) draws exactly that and it is what this matches, value
- * for value: a solid `--surface` card inside one `--border` hairline with no
- * corner, 40px of padding, a 16px weight-500 title over one 14px sentence at
- * the board's measure, and the primary action under them as the wash button.
- * The dashed outline and 24px heading it wore before said "something has gone
- * wrong here", which is the one thing an empty list has not done.
- *
- * The gap inside the head block is the board's 6px rounded to the 4px grid,
- * the same rounding ticket 01 made for the sheet's padding.
+ * Render an empty collection as a normal page state with an optional next
+ * action. Keep its appearance distinct from loading and failure.
  */
 export function Empty({
   title,

--- a/apps/web/ui/project-selector.tsx
+++ b/apps/web/ui/project-selector.tsx
@@ -12,40 +12,14 @@ import { useDraftNavigation } from "./draft-navigation.tsx";
 import { Menu, MenuDivider, MenuItem, MenuLabel } from "./menu.tsx";
 
 /**
- * The project where you are working.
- *
- * **It is on screen even when there is one project.** An earlier rule hid a
- * level with one thing in it as clutter. It is not clutter — it is the answer
- * to *why is this list empty*, and somebody who cannot see which project they
- * are in cannot tell an empty project from a broken page.
- *
- * **Choosing a project changes the address**, and the address is the only place
- * a choice is kept. Nothing is written to storage and nothing is posted to the
- * server, which is exactly what lets two tabs sit on two projects and lets a
- * pasted link open the project it was copied from. Reload, Back and Forward
- * work because they always did — they restore an address, and an address is the
- * whole of the state.
- *
- * Organization identity now has its own control in the shell. It is still
- * passed here because the chooser names the organization whose projects it
- * lists, but it is no longer repeated in this trigger.
+ * Keep the current project visible even when only one exists. Selection lives
+ * in the URL, independently per tab; this control does not store a session-wide
+ * choice. The organization has a separate shell control.
  */
 
 /**
- * The trigger: an explicit label over the current project.
- *
- * The word **Project** stays visible even when there is only one. Organization
- * and project are different scopes, so a quiet label is the small amount of
- * copy that prevents the current project's name from being mistaken for an
- * organization. The organization sits in the bar above it.
- *
- * The project name stays neutral while the menu is open. Opening a chooser is
- * not a brand state, and changing its text colour made the current context look
- * like an action. The menu is a direct list: no search field stands between a
- * person and the projects they can choose.
- *
- * The compact form is the mobile top bar's, where the control shares a 56px row
- * with a drawer button and the account, so it stays held to a width of its own.
+ * Label the current project explicitly and keep its text neutral while the
+ * menu opens. The compact trigger fits beside mobile navigation and account controls.
  */
 const TRIGGER = [
   "flex w-full min-w-0 flex-col items-stretch gap-1.5",
@@ -87,16 +61,8 @@ export function ProjectSelector({
   const organizationName = organization?.name ?? "No organization";
 
   /**
-   * What this control says it is showing — and it never says a project the
-   * address does not name.
-   *
-   * Two ways that could go wrong and both are closed. An address naming a
-   * project this membership does not hold says **Unknown project**: falling
-   * back to the first project's name would tell somebody they are working in
-   * Default while the page beside it refuses everything they ask for. And an
-   * address naming no project at all says **No project** — it used to say the
-   * first project's name, which is the same lie told on the one page that is
-   * deliberately outside every project.
+   * Show Unknown project for an inaccessible ID and No project when the URL
+   * has none. Never substitute the first project's label.
    */
   const projectName =
     current?.name ?? (projectId === null ? "No project" : "Unknown project");

--- a/apps/web/ui/relative-time.tsx
+++ b/apps/web/ui/relative-time.tsx
@@ -55,17 +55,8 @@ export function RelativeInstant({
 }
 
 /**
- * A settled date in a list column: the boards' `Aug 16, 2026`.
- *
- * **This is the element every list's date column uses, and `RelativeInstant`
- * is not.** The two are one decision written twice — see `asListInstant` for
- * why a column of ages cannot be scanned — and they share everything else: the
- * RFC 3339 value stays on the element, the exact viewer-local moment with its
- * zone stays in the title, and the figures are tabular so a column of dates is
- * one column rather than a ragged edge.
- *
- * There is no page clock, because a settled date does not change. That is the
- * whole difference in the signature.
+ * Render a fixed list date with a machine-readable instant and an exact
+ * viewer-local timestamp in the title. Unlike relative age, it needs no page clock.
  */
 export function ListInstant({
   instant,

--- a/apps/web/ui/resource.ts
+++ b/apps/web/ui/resource.ts
@@ -5,14 +5,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { Answer } from "../lib/api.ts";
 
 /**
- * One product read, with its four answers and a way to ask again.
- *
- * **Every product request names its project**, which is the whole point of this
- * hook existing rather than each page calling `fetch`. A page cannot forget the
- * project, and a page cannot invent a second way of deciding what a 404 means.
- *
- * `null` is still loading. It is deliberately not a fifth `Answer` variant: an
- * answer is something egma said, and "nothing yet" is not.
+ * Pass project context to the supplied read and retain only answers matching
+ * the current project and request key. Callers must use that project in their
+ * request. null means pending; reload and refresh control whether old data stays visible.
  */
 export function useProjectRead<T>(
   read: (projectId: string) => Promise<Answer<T>>,

--- a/apps/web/ui/row-menu.tsx
+++ b/apps/web/ui/row-menu.tsx
@@ -7,25 +7,8 @@ import { cn } from "@/lib/utils";
 import { Menu, MenuItem } from "./menu.tsx";
 
 /**
- * The ⋮ at the end of a row, and the things it offers.
- *
- * **It lives in the table's own trailing slot** — a fixed
- * `--table-action-width` lane that every row carries whether or not it has a
- * menu — so the triggers line up in one column down the table and a row with no
- * menu still holds the lane open (`6ZM-0`, `8YA-0`, `A3H-0`). The lane belongs
- * to `ui/data-table.tsx`; what is here is the control that stands in it.
- *
- * **It is shared rather than a route's, and the move is the one this pair asked
- * for.** These lived in `app/projects/[projectId]/tests/parts.tsx` while the
- * Tests screens were the only two drawing them, with a note saying they move
- * here as soon as a third area grows the same pair. Runs and Running graders
- * are the third and fourth: both had their acts drawn as buttons inside the
- * cell, which bent the lane out of line — 0px on Runs, where a finished run
- * offers nothing, and 156px on Running graders, where two buttons pushed it
- * open. (2026-08-23.)
- *
- * **The control draws no box.** What the boards give it is the dots and
- * nothing else; the hover fill is the only thing that answers a pointer.
+ * Shared row actions placed in the data table's trailing slot. Keep the
+ * trigger compact and let the table own column alignment.
  */
 export function RowMenu({
   label,

--- a/apps/web/ui/run-note.tsx
+++ b/apps/web/ui/run-note.tsx
@@ -5,40 +5,10 @@ import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * What this run's connection will and will not do with the tests' own data.
- *
- * **A test carries mock tools and env now, and a connection either uses them or
- * cannot.** A person about to start a run has to know which, because the
- * failure this exists to stop is somebody believing a call was mocked when it
- * reached their real backend. One fact is not about the test's data at all: a
- * LiveKit run needs the Egma SDK in the customer's own agent or the simulation
- * fails, so that requirement is said on every LiveKit run. The support table
- * below is the whole of the rule.
- *
- * **It is one quiet box, under the Connection field of the run-start sheet**
- * (founder, 2026-09-04): the house hairline, the surface fill, no corner, no
- * icon and no title. Muted text at the table's 14px, one short line per fact,
- * one or two of them in the ordinary case. The box's own edge carries the
- * warning colour where a connection cannot use what a test holds, so a "cannot
- * use" case is still read before an informative one without a coloured bar
- * beside every line. The words themselves say "cannot", so the colour stays
- * supporting information rather than the whole of the news.
- *
- * **The note is said once, where the choice is made.** It used to be drawn on
- * the run page as well, from the versions that run's simulations pinned. That
- * reading cost two walks of the run — every page of simulations, then every
- * version they named — to repeat a sentence the person had already read and
- * acted on, at the one moment they can no longer act on it. (Founder,
- * 2026-09-04.)
- *
- * **A fact is a title and the lines that explain it, and the ceiling drops a
- * fact whole.** Cutting the list wherever the last line fell left a title
- * standing with its explanation gone — a note that names a rule and never says
- * what the rule is.
- *
- * **Nothing here is stored.** The lines are computed from the connection and
- * the suite's tests every time they are drawn. Two runs of one suite can
- * therefore say different things, which is the truth.
+ * Describe connection support for the selected tests' mock tools and env at
+ * run setup. Include LiveKit SDK requirements and unsupported capabilities.
+ * Compute notes from current selections; if limiting output, omit whole facts
+ * rather than separating a title from its explanation.
  */
 
 /** How loudly one line speaks, and the only three volumes there are. */

--- a/apps/web/ui/run-status.tsx
+++ b/apps/web/ui/run-status.tsx
@@ -14,21 +14,8 @@ import { Badge, badgeVariants } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 /**
- * The parts every surface that shows a run is built from — and the reason they
- * are shared rather than written per page.
- *
- * Run state, simulation state, and grading state answer different questions.
- * An execution failure must never look like a low grade, and unfinished grading
- * must never look like a failure.
- *
- * A page that decided its own colours for those words would be free to decide
- * differently from its neighbour, and the first one to paint `completed` green
- * would have turned a machinery word into a quality result. So the mapping from word
- * to appearance is here, once, and the pages ask for it.
- *
- * These live in their own file with their own stylesheet rather than in
- * the shared control set, which the shared system deliberately
- * holds closed.
+ * Share status appearance across run, simulation, and grading views. Execution
+ * completion is not a quality verdict, and pending grading is not failure.
  */
 
 /* ------------------------------------------------------------------------ *
@@ -67,14 +54,8 @@ export type StateMarkKind =
   | "error";
 
 /**
- * A second, non-colour signal for simulation, grading, and result states.
- *
- * The word remains the source of meaning. A square anchors those states and
- * keeps their marks distinct from radio controls and progress dots. Failed and
- * errored states use the shared failure fill so they do not read as empty
- * checkboxes; progress, success, stopped, and not-requested states keep the
- * quiet outline. A run uses plain text instead, with a loader only while it is
- * running.
+ * Use text plus distinct marks for simulation, grading, and result states.
+ * Run status uses text, with a loader while running.
  */
 export function StateMark({
   kind,
@@ -321,16 +302,7 @@ export function RunProgress({
       <span
         className={cn(
           "block size-full origin-left rounded-chip bg-foreground",
-          /*
-           * 200ms is written here rather than read from the theme, and it is
-           * the one duration in this file that is not a `DESIGN.md` motion
-           * token. Those name interface motion — a press, a popover, a dialog
-           * — and this is a value catching up to a new value, which
-           * `DESIGN.md` gives a behaviour for ("transform-based fill, linear
-           * while active") and no token. It is the duration the stylesheet
-           * this replaces already used and it is under the 300ms ceiling.
-           * Called out in the pull request for the developer to overrule.
-           */
+          /* Use a short linear transform transition when the progress value changes. */
           "transition-transform duration-200 ease-linear",
           "motion-reduce:transition-none",
         )}

--- a/apps/web/ui/section.tsx
+++ b/apps/web/ui/section.tsx
@@ -17,20 +17,7 @@ import { cn } from "@/lib/utils";
  * than inventing a second row.
  */
 
-/**
- * A titled block of one page: connections, traits, or history.
- *
- * A detail page is a stack of these rather than one long form, because the
- * blocks answer different questions and are written at different times — and
- * because a heading is what lets somebody land on the part they came for.
- *
- * **There used to be two of these**, one in the old control set and one in the
- * shell, drawn from the same stylesheet classes and differing only in whether
- * the head was a `<header>` and whether the action was wrapped. Ticket 14 asked
- * whether the product keeps one control vocabulary or two; this is the answer
- * for this component. The `<header>` won, because it is what thirteen of the
- * fourteen callers were already getting and because it is what the element is.
- */
+/** Shared titled section with optional actions for related page content. */
 export function Section({
   title,
   lead,
@@ -66,19 +53,8 @@ export function Section({
 }
 
 /**
- * A strip of controls above a list: the filters, and the one action the list
- * itself offers.
- *
- * **One shape on every list page, because the developer read five of them side
- * by side and none of them agreed.** Filters go left, in the order a person
- * narrows by; the action goes hard right. The Agents page used to do the
- * opposite — an oversized-looking button leading the row and a search box
- * running the whole remaining width behind it — and that single row is what
- * made the product look like a side project beside a competitor's dashboard.
- *
- * The action is a slot rather than the last child, so a page cannot put it
- * anywhere else by accident. It is `flex-none`: an action is the width of its
- * own label, and the filters take what is left.
+ * Place list filters on the left and the action in a separate right-hand slot.
+ * Keep the action at its content width while filters use remaining space.
  */
 export function Toolbar({
   children,
@@ -113,20 +89,8 @@ export function Toolbar({
 }
 
 /**
- * The search box every list is filtered with: 300 by 36, with a magnifier.
- *
- * **One box, one size, on every list page.** `71Q-0` is 300px wide and 36px
- * tall with 12px of side padding and an 8px gap to the icon, and it is that on
- * the agents board, the personas board and the tests board alike — which is the
- * point of drawing it once here. A page that reached for a bare `Input` got a
- * 44px form control that ran to whatever width was left.
- *
- * The icon is decoration: the field carries its own `aria-label`, and a
- * magnifier read out as "search" beside a field already called "Search agents
- * by name" is the word twice.
- *
- * `TOOLBAR_SEARCH` below is the same shape as a class list, for the pages that
- * have not moved onto this component yet.
+ * Shared compact toolbar search. Give the input an accessible label and keep
+ * the magnifier decorative.
  */
 export function SearchField({
   className,
@@ -145,23 +109,8 @@ export function SearchField({
 }
 
 /**
- * How wide a control in a toolbar is allowed to be.
- *
- * **Declared once here rather than page by page**, which is the whole point:
- * five pages each choosing a width is what a person sees as five different
- * products. A search box was `width: 100%` of whatever was left, so on a wide
- * screen it ran to 1500px for a field holding a name; a filter that names one
- * column never needs more room than its longest option.
- *
- * `min-w-*` keeps both usable at the wrap point, where the strip becomes two
- * rows and each control is on its own line.
- *
- * **`flex-1` on the search is load-bearing, and a screenshot is what found
- * it.** The shared `Input` is `width: 100%`, which in a wrapping flex row means
- * 100% *of the row* — so the search box claimed the whole line and pushed the
- * agent filter beside it onto a second one. `flex-1` sets `flex-basis: 0%`,
- * which wins the main axis back from `width`: the box grows into whatever the
- * filters leave and stops at its maximum.
+ * Bound toolbar controls while allowing wrapping. flex-1 gives search a zero
+ * basis so Input's full width does not push adjacent filters to another row.
  */
 export const TOOLBAR_SEARCH = [
   "w-(--search-width) max-w-full min-h-(--control-md) text-sm",
@@ -240,18 +189,8 @@ export function Facts({
   if (!panel) return list;
 
   /*
-   * **The panel is the shared card, not a second one written here.**
-   *
-   * It used to draw `rounded-card border border-border bg-surface p-6` itself,
-   * which is the kit `Card`'s declaration copied out — and `DESIGN.md` is
-   * explicit that no page or component adds a one-off where a shared component
-   * already owns the behaviour. Two copies is how a product ends up with two
-   * card looks: the next change to a card reaches one of them.
-   *
-   * `Card` is a `<div>` and cannot become the `<dl>`, so the list goes inside
-   * it rather than wearing it. That is the honest arrangement anyway — the card
-   * is the surface, the definition list is the content, and a screen reader
-   * still reads each fact with the name of the fact.
+   * Compose a definition list inside the shared Card instead of copying its
+   * surface styles onto a separate element.
    */
   return <Card className="max-[40rem]:p-5">{list}</Card>;
 }

--- a/apps/web/ui/session-loading.tsx
+++ b/apps/web/ui/session-loading.tsx
@@ -4,61 +4,13 @@ import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
 /**
- * The one screen egma shows while it does not yet know who is here.
- *
- * **It guesses nothing.** Opening the product used to draw the signed-in shell
- * — sidebar, navigation, account menu — over the sentence "Checking your
- * session", and replace the whole of it a moment later. Somebody signed out
- * met a dashboard that was never theirs; somebody signed in met a page saying
- * egma was unsure. Both are a screen chosen before the answer arrived. This is
- * what stands there instead, everywhere the session is unresolved or changing:
- * the entrance, any product address on a cold load, signing in, signing up,
- * and signing out.
- *
- * **The mark is still.** `DESIGN.md` forbids animating the logo, so what moves
- * is a separate indicator under it — the "fast, quiet indicator" that file
- * gives a loading state — and its motion lives in `tailwind-theme.css` beside
- * the run mark's turn, keyed on the `session-progress` slot below. The segment
- * is ink rather than the brand orange, which is the ruling `progress.tsx`
- * already wrote down for the one other bar in this product that fills.
- *
- * **It says what it is waiting for.** A wordmark and a moving bar alone are a
- * screen with no words on it, and `DESIGN.md` asks every state to say what
- * happened. The line is short, quiet, and different on each moment, because
- * they are different waits.
- *
- * **It is opaque on its first frame**, and deliberately does not take the wait
- * every other loading state here takes. A route fallback fades in after
- * `--duration-popover-in` so a warm route is never covered by a box that
- * appears and vanishes. This one has the opposite job: a shell is mounted
- * behind it, so a screen that spent a fifth of a second transparent would show
- * exactly the guess it exists to cover.
- *
- * **It leaves the document behind it, and takes it out of reach.** The cover
- * goes to the end of `document.body` so nothing anchored inside the shell — a
- * sticky sidebar at `z-20`, a sheet at `z-30`, a toast at `z-50` — floats over
- * it. Everything else in the body goes `inert` while it stands, because a
- * control hidden from eyes and still reachable by Tab or by a screen reader is
- * worse than one that is simply there. That is the trade a dialog already
- * makes.
+ * Cover unresolved session state with a static logo, status text, and separate
+ * progress indicator. Mount through a body portal without the usual route
+ * loading delay. Existing body siblings become inert until the last cover closes.
  */
 /**
- * The marks, owned by all the covers together rather than by each of them.
- *
- * **Two covers can stand at once, and each holding its own list is a hole.**
- * The second one to mount skips everything the first already marked — that is
- * what keeps a surface Radix made inert from being taken over — so its list is
- * empty, and the first one to unmount then hands the document back while the
- * second is still standing opaque in front of it. A keyboard or a screen reader
- * reaches controls nobody can see.
- *
- * Nothing today produces that overlap: the shell leaves the entrance to cover
- * itself, signing out needs a settled session, and React runs a fallback's
- * cleanup before the page that replaces it mounts. All three are true and none
- * of them is written down anywhere near this file, which is the kind of
- * invariant that survives exactly until somebody adds a fifth mount point. So
- * the count decides instead: the first cover takes the marks, the last one
- * gives them back, and what is given back is what was taken.
+ * Reference-count overlapping covers. The first records elements it makes
+ * inert; the last restores only those elements, preserving preexisting inert state.
  */
 let covers = 0;
 let marked: readonly Element[] = [];

--- a/apps/web/ui/settings-nav.tsx
+++ b/apps/web/ui/settings-nav.tsx
@@ -10,27 +10,8 @@ import { cn } from "@/lib/utils";
 import { projectPath } from "../lib/project-context.ts";
 
 /**
- * The navigation every Settings page wears, and the one thing it exists to make
- * unmissable: **which of these settings belong to the project, and which belong
- * to the organization.**
- *
- * The project selector stays on screen throughout Settings, because somebody
- * has to be able to see where they are and to leave. That is also the trap: a
- * flat list under a visible project control reads as settings *of that
- * project*, but organization details, people and API keys are organization
- * settings. An admin who changed one
- * believing it applied to Outbound only would be wrong in a way no page told
- * them about.
- *
- * So the two scopes are two labelled groups. It is the smallest arrangement
- * that states the fact rather than leaving it to be inferred.
- *
- * **Every address carries the project**, including the organization-wide ones.
- * They are not project settings, and they still have to be reachable without
- * leaving the product shell — the selector needs a project to show, and
- * switching project from Settings has to land back in Settings rather than
- * throwing somebody out to Agents. The grouped navigation states the scope
- * once, without repeating a callout on every organization page.
+ * Group project and organization settings explicitly. Organization settings
+ * retain project-scoped URLs for shell navigation without changing their scope.
  */
 
 export type SettingsSection =
@@ -68,37 +49,15 @@ export function settingsPath(
 }
 
 /**
- * One link in the navigation.
- *
- * The current one is Ember Wash plus a narrow Ember mark down its leading edge,
- * because state is never colour alone — the mark is the half of it somebody
- * reading in greyscale still gets.
- *
- * **It is the sidebar's row, down to the last value** — 36px on a fine pointer
- * and 44px on a coarse one, 12px of side padding, the 14px step, and the 2px
- * mark inset 8px from either end (`72Y-0`, `72Z-0`). Settings navigation is
- * navigation: a rail that drew its rows at a different height beside the bar
- * that drew them at the board's would read as a second product, and a person
- * moving between the two would feel the change without being able to name it.
+ * Match sidebar navigation sizing and targets. The active edge mark supports
+ * the current-page color treatment.
  */
 const NAV_ITEM = [
   "relative flex w-full min-h-(--control-md) items-center px-3",
   "rounded-button text-sm whitespace-nowrap text-muted-foreground no-underline",
   /*
-   * **Colour, and nothing that moves.** `DESIGN.md`: "Navigation row — support
-   * routine navigation — colour feedback only." These rows used to answer a
-   * press with `scale(0.97)`, borrowed from the button, and a button is the one
-   * component that rule is written *against*: a person crosses this list many
-   * times a day and never once needs it confirmed that a row was pressed —
-   * the page changing says that. The transition names its two properties for
-   * the reason `button.tsx` gives.
-   *
-   * **`motion-reduce:transition-none` went with the movement, on purpose.**
-   * `DESIGN.md` asks every movement for "a reduced-motion form with useful
-   * opacity or colour feedback" — a colour fade *is* that form. Switching it
-   * off under reduced motion removes the fallback instead of the motion, and
-   * leaves somebody who asked for less movement with less feedback than
-   * everybody else. `sidebar.tsx` came to the same form in the closing sweep.
+   * Use color feedback without spatial press motion for routine navigation.
+   * Reduced motion retains that non-spatial feedback.
    */
   "transition-[color,background-color] duration-(--duration-hover) ease-out",
   "pointer-coarse:h-(--tap-target) pointer-coarse:min-h-(--tap-target)",
@@ -107,15 +66,8 @@ const NAV_ITEM = [
 ];
 
 /**
- * The rows somebody might go to.
- *
- * **Hover belongs here rather than on every row, and a browser is what said
- * so.** The neutral hover plate and Ember Wash are both a background, and with
- * the hover written for all four rows it won: pointing at the row you are
- * already on turned its wash grey, which is the "current" half of the state
- * disappearing under the pointer. Naming the two sets apart is the fix that
- * needs no rule to outrank another — a row is either current or it is not, and
- * only one of these two lists ever reaches it.
+ * Apply neutral hover styling only to inactive rows so it cannot replace the
+ * current row's selected background.
  */
 const NAV_ITEM_QUIET = [
   "pointer-hover:bg-surface-soft pointer-hover:text-foreground",
@@ -159,14 +111,8 @@ export function SettingsNav({
         aria-labelledby={labelId}
       >
         {/*
-         * Which scope a run of items belongs to, said out loud above them.
-         *
-         * **This label is the whole reason the navigation is grouped rather
-         * than one flat row.** Members, invitations, retention and API keys
-         * belong to the organization; a page that listed them beside the
-         * project's own settings, with the project selector on screen, would be
-         * quietly saying they belong to whichever project is selected — and
-         * somebody would eventually believe it.
+         * Label each settings group by scope so organization settings are not mistaken
+         * for settings of the selected project.
          */}
         <p
           className={cn(
@@ -233,26 +179,9 @@ export function SettingsNav({
 }
 
 /**
- * Switch between peer views inside one Settings page.
- *
- * This is a tab list, not a form choice: changing it changes the visible panel
- * and does not submit a value. Roving focus gives the group one Tab stop, while
- * arrow, Home and End keys follow the tabs pattern.
- *
- * **All of that now comes from the kit rather than from a listener here.** The
- * hand-written version read every key itself, wrapped the index by hand, kept
- * an array of refs so it could move focus, and mapped Up and Down onto a
- * horizontal strip — which the tabs pattern does not do, because Up and Down in
- * a horizontal tablist belong to whatever is around it. Radix publishes the
- * roving tab stop once and gets `dir`, looping, and a disabled tab right in
- * one place. Fifty lines of keyboard code left this file and no behaviour a
- * person relies on left with them.
- *
- * **The panel is not ours.** A caller draws its own `role="tabpanel"` and names
- * it `{id}-{value}-panel`, so the trigger's `id` and `aria-controls` are stated
- * here rather than left to Radix's generated pair. Radix writes both before it
- * spreads a caller's props, so saying them is enough to keep the promise every
- * Settings page was already written against.
+ * Use shared tabs for peer settings panels. Callers render their own tabpanel
+ * with ID {id}-{value}-panel; explicit trigger IDs and aria-controls preserve
+ * that association.
  */
 export function SettingsTabs<Value extends string>({
   id,
@@ -296,18 +225,8 @@ export function SettingsTabs<Value extends string>({
 }
 
 /**
- * The stable frame every Settings state uses.
- *
- * Settings navigation is local to this area, so it stays beside the page on a
- * wide screen instead of running across the top of every form. On a narrow
- * screen the same card moves above the page and its links wrap into a compact
- * grid, without creating a second horizontal scroll area. Loading and failure
- * states use this frame too, which stops the page from moving when its data
- * arrives.
- *
- * The rules for `section`, `region` and `tabpanel` reach into whatever the page
- * puts here, because the page supplies its own states and this frame is what
- * spaces them. They are child selectors for that reason and not by preference.
+ * Keep settings navigation beside content on wide screens and above it on
+ * narrow screens. Share this frame across loaded, loading, and failed states.
  */
 export function SettingsLayout({
   projectId,
@@ -338,20 +257,8 @@ export function SettingsLayout({
           "flex h-full min-w-0 min-h-0 flex-col gap-8 overflow-y-auto",
           "overscroll-contain pr-2 pb-10 [scrollbar-gutter:stable]",
           /*
-           * This container owns the gap between Settings groups, so the
-           * `Section`s inside it give up their own top margin. Without it the
-           * gap is `Section`'s 32px of margin on top of this container's 32px
-           * of gap, and the first group starts 32px below where the navigation
-           * does. Measured at `margin-top: 0px` in a browser.
-           *
-           * **The `!` these carried is gone with the stylesheet it was
-           * fighting.** `Section` drew its margin from `system.module.css`,
-           * and a CSS Module is unlayered — it beat every Tailwind utility
-           * whatever the specificity, because a layer loses to no layer.
-           * `Section` is a utility now, so this is an ordinary specificity
-           * question and these rules already win it: a class plus a child
-           * combinator and an element outranks the plain class the margin
-           * comes from.
+           * Remove child Section top margins because this container already supplies
+           * the gaps between settings groups.
            */
           "[&>section]:mt-0",
           "[&>[role=region]]:flex [&>[role=region]]:flex-col [&>[role=region]]:gap-8",

--- a/apps/web/ui/settings-read.ts
+++ b/apps/web/ui/settings-read.ts
@@ -66,19 +66,8 @@ function beginProtectingDraft(busy: boolean): () => void {
 }
 
 /**
- * One read that names **no project**, with the same four answers every product
- * read has and a way to ask again.
- *
- * **Its own hook rather than `useProjectRead` with the project left off**, and
- * the difference is the whole point: that one exists so a product page cannot
- * forget to say which project it is asking about. Members, invitations, API
- * keys, the organization itself and the list of projects are not asked about a
- * project — they belong to the customer — and sending `?project=` with them
- * would put a claim in the request that the route does not read and that is not
- * true.
- *
- * `null` is still loading, on the same terms: an answer is something egma said,
- * and "nothing yet" is not.
+ * Read organization-scoped settings without adding project context. null
+ * means pending; expose the shared Answer states and a reload action.
  */
 export function useOrganizationRead<T>(read: () => Promise<Answer<T>>): {
   readonly answer: Answer<T> | null;
@@ -111,14 +100,9 @@ export function useOrganizationRead<T>(read: () => Promise<Answer<T>>): {
 }
 
 /**
- * Keep an in-product link, a project switch, a reload, or a closed tab from
- * silently throwing an editable product draft away.
- *
- * The browser owns the warning for reload, tab close, and external unload.
- * Same-origin product navigation uses the shared Egma dialog instead. A busy
- * write blocks in-product navigation because there is no safe discard decision
- * while its result is unknown. Callers turn protection off after the draft or
- * write is safe. The return value lets an editor show its state if that helps.
+ * Protect dirty drafts with the browser unload prompt and the shared in-app
+ * navigation dialog. Busy writes block guarded navigation while their result
+ * is unknown. Callers disable protection after successful save or discard.
  */
 export function useUnsavedChanges(
   unsaved: boolean,

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -67,25 +67,9 @@ import { settingsPath } from "./settings-nav.tsx";
 import { useTheme } from "./theme.tsx";
 
 /**
- * The frame every signed-in product page is drawn inside.
- *
- * **Compact, because the product is the data.** A narrow sidebar, a page title
- * that is a label rather than a headline, and controls that sit in a toolbar
- * instead of becoming one. Every measurement is a theme value, so the hands-on
- * tuning pass at the end of this effort is an edit to the theme rather than an
- * edit to every page.
- *
- * **Where you are comes from the address.** The project is read out of the
- * path, the navigation item is read out of the path, and nothing here keeps a
- * chosen project of its own. Two tabs on two projects are therefore two
- * ordinary tabs.
- *
- * **There is no fallback left, and this paragraph used to describe one.** While
- * pages were being converted to explicit project context the selector fell back
- * to the first project so that it had something to say; that half of the
- * expand-contract change is finished, and both fallbacks — this shell's and the
- * selector's own — are gone. An address inside no project draws no product
- * navigation and says **No project**, which is the honest answer.
+ * Shared signed-in frame using theme dimensions. Derive project and current
+ * navigation from the URL; an address without a project shows no project
+ * navigation rather than selecting a fallback.
  */
 
 export type Session = {
@@ -196,20 +180,8 @@ export function ProductShellBoundary({ children }: { readonly children: ReactNod
 }
 
 /**
- * One line symbol per product area, from one set.
- *
- * **They are lucide's, and the point is that they are all lucide's.** These
- * were six hand-drawn path lists before, each authored against a different idea
- * of how heavy a line should be and how much of a 20px box to fill — a star
- * that read as solid beside a figure that read as a sketch. A person does not
- * name that when they call a bar unprofessional; they see it. One set, drawn on
- * one grid at one weight, is what removes it. lucide is already a dependency of
- * this application, so nothing was added to get it.
- *
- * Each icon says what its row says. `MessageSquareText` for the monitoring row
- * because the row says Transcripts, and `ScaleIcon` for graders because a
- * grader weighs a trace and returns a score — neither imitates the Egma mark,
- * which `DESIGN.md` forbids of a product icon.
+ * Use one icon set for product navigation, keeping product icons distinct
+ * from the Egma logo.
  */
 const NAVIGATION_ICONS: Record<SectionId, LucideIcon> = {
   agents: BotIcon,
@@ -237,16 +209,8 @@ function NavigationIcon({ section }: { readonly section: SectionId }) {
 }
 
 /**
- * The three groups, drawn once for wherever the bar is being shown.
- *
- * **One navigation model.** The docked bar and the mobile drawer render this
- * same component, so the drawer cannot drift into a second, shorter list of
- * where a person may go. The drawer passes `onNavigate` and the bar does not,
- * which is the only difference between them: a drawer closes behind the choice
- * it was opened to make.
- *
- * Where an item is lit still comes from the address, never from which group it
- * happens to be in.
+ * Render the same navigation groups in the sidebar and mobile drawer. The
+ * drawer closes through onNavigate; active state comes from the URL.
  */
 function Navigation({
   projectId,
@@ -263,18 +227,8 @@ function Navigation({
   return (
     <SidebarProvider onNavigate={onNavigate}>
       {/*
-       * The 16px gutter is the bar's, and it is on every block in the column
-       * rather than on the column itself. The organization bar's hairline has
-       * to run the full 224px, so the `<aside>` can carry no side padding.
-       *
-       * **8px here, because the gutter belongs to the row's icon and not to the
-       * row's plate.** The Egma mark, the word `Project`, the project name and
-       * every group label all start at 16px; a row whose own padding is 8 puts
-       * its icon on that same line, so the bar reads as one lane top to bottom
-       * instead of a project block and a navigation block 12px apart. The plate
-       * is 8px in from both edges as a result, 208px wide, and the Ember mark
-       * rides its leading edge — absolutely placed, so the icon lane is the same
-       * on the lit row and on every quiet one.
+       * Pad sidebar blocks separately so the organization divider spans the full
+       * width. Row inset plus row padding align icons with project text and group labels.
        */}
       <SidebarContent className="px-2" asChild>
         <nav aria-label="Product navigation">
@@ -304,32 +258,8 @@ function Navigation({
 }
 
 /**
- * The organization identity at the top of the signed-in sidebar.
- *
- * There is one organization per session today, so this panel gives context and
- * does not offer a false switcher. The paired arrows still open a small
- * surface: the organization's mark, the quiet word `Organization`, and the name
- * that word names. Organization settings stay out until that product level
- * exists.
- *
- * **Neither the bar nor the panel claims anything about the organization but
- * its name.** Both used to carry a "Free" chip and a "Free Plan · Admin" line
- * under the name. Billing is not part of `/api/me`, so that plan was
- * hard-written copy standing where a fact belongs, and the role it sat beside
- * is already said by the account control at the foot of the same sidebar. Two
- * claims, one of them invented and one of them repeated, above the name they
- * were meant to describe.
- *
- * What stands there now is a label rather than a claim. The panel opens on a
- * name with no page around it, so the grey `Organization` over it says which
- * kind of name it is — the same thing the word `Project` does for the control
- * directly below, drawn the same way. (Developer decision, 2026-08-25 on the
- * Paper canvas.)
- *
- * **The mark is identity, not a control.** It sits beside the menu trigger
- * rather than inside it, so the hover plate, focus indicator and press feedback
- * cover only the organization control. The organization name stays on the
- * 14px product-text step; making it smaller would leave the accepted scale.
+ * Show the session's organization name without inventing billing or switcher
+ * state. Keep its mark separate from the interactive trigger.
  */
 function OrganizationMenu({
   organization,
@@ -358,14 +288,8 @@ function OrganizationMenu({
           data-slot="organization-status"
         >
           {/*
-           * **A bar, not a sentence, while nobody has answered.** This slot
-           * used to say "Checking your session…" — the sentence the developer
-           * met on opening the product, one control down. It is also a claim
-           * this bar has no business making: the session is the whole
-           * application's business, `SessionLoading` is what says it, and a
-           * sidebar row saying it too is the same news twice from a place that
-           * cannot act on it. What belongs here is what belongs in any slot
-           * whose value has not arrived: the shape of the value.
+           * Use a placeholder for the organization name while unresolved. SessionLoading
+           * owns the application-wide waiting message.
            */}
           {settled ? (
             <span className="min-w-0 overflow-hidden text-sm text-ellipsis whitespace-nowrap text-muted-foreground">
@@ -466,14 +390,8 @@ function AccountMenu({
   readonly role: Role | null;
   readonly placement: "below-end" | "right-end";
   /**
-   * The mobile top bar, where the control is the avatar and nothing else.
-   *
-   * It used to be the shell's stylesheet reaching into this control by class
-   * name — `.topbar .account`, `.topbar .accountText`, `.topbar .avatar` —
-   * which meant the control's own size depended on which region had drawn it.
-   * It is a prop now, the way the project selector already took the same
-   * question. The hidden text is not rendered rather than `display: none`,
-   * which is the same thing for a screen reader and one element less.
+   * Compact account variant for the mobile bar: render the avatar without the
+   * desktop text block.
    */
   readonly compact?: boolean;
   /**
@@ -489,14 +407,8 @@ function AccountMenu({
   const [signingOut, setSigningOut] = useState(false);
   const email = me?.user.email ?? "";
   /**
-   * The control's own name for whoever it stands for.
-   *
-   * Three states, and the middle one used to be "Checking your session…" —
-   * the application's news, said by a control that is not the application. It
-   * is "Loading account" now: this control is loading this account, which is
-   * both true and the only part of it this control knows. The visible slot
-   * draws a bar rather than the words, because a sentence in a name slot is a
-   * value that is not a name.
+   * Name this control by account state while the visual slot uses a placeholder
+   * until the account label is available.
    */
   const standing = me !== null ? email : settled ? "Session unavailable" : "Loading account";
   const initial = me !== null ? (email.trim().slice(0, 1).toUpperCase() || "E") : "·";
@@ -525,15 +437,8 @@ function AccountMenu({
         triggerClassName={cn(
           "grid w-full min-w-0 items-center gap-3",
           /*
-           * **7px, and the missing pixel is the plate's own hairline.** This
-           * trigger reserves its hover border as a transparent one so hovering
-           * shifts nothing, and `box-sizing: border-box` means that border spends
-           * a pixel of the inset before the padding starts. Written as 8px it put
-           * the avatar on 17 while every nav icon stood on 16 — the one thing
-           * still out of the bar's lane. Written as 8 minus the hairline it lands
-           * on 16 exactly, and the gap from the plate's visible edge to the
-           * avatar is a true 8px, which is what a borderless nav row already
-           * draws between its plate and its icon.
+           * Subtract the reserved border from trigger padding so the avatar aligns
+           * with borderless navigation icons without shifting on hover.
            */
           "grid-cols-[var(--control-md)_minmax(0,1fr)] min-h-(--control-lg) py-1",
           "px-[calc(var(--space-2)-1px)]",
@@ -696,21 +601,8 @@ function ShellFrame({
 
   const projects: readonly Project[] = me?.projects ?? [];
   /**
-   * The project this address names, and **nothing at all when it names none.**
-   *
-   * There used to be a fallback here — `named ?? projects[0]?.id` — left over
-   * from the pages that had not yet been converted to explicit project context.
-   * It is gone with the last of them, and it had to go rather than be left
-   * harmlessly unused: what it did was draw a project's navigation on an
-   * address that is not in that project, so a person with three projects met
-   * links into whichever came first in their list, with nothing saying so. The
-   * grader screens were the last pages it was standing in for, and they are
-   * under `/projects/:projectId/graders` now.
-   *
-   * `/new-project` names no project on purpose. It does not draw project
-   * navigation or a mobile navigation button, because an address that names no
-   * project cannot honestly say which project's links it is opening. The
-   * selector stays visible, so choosing one remains the way into the product.
+   * Show project navigation only for a project named in the URL. /new-project
+   * keeps the selector available without inventing a current project.
    */
   const shown = projectIdIn(pathname);
   const settingsHref =
@@ -742,18 +634,8 @@ function ShellFrame({
   );
 
   /**
-   * A cold load of a product address, before the session read has answered.
-   *
-   * Opening `/projects/…` from a bookmark, or pressing reload on one, mounts
-   * this whole frame with nobody in it — an organization bar, a project
-   * selector and an account control all standing there with no facts behind
-   * them. That is the same guessed screen the entrance used to draw, on every
-   * other address in the product, so it takes the same cover.
-   *
-   * **The entrance is left to draw its own**, and that is the one exception. It
-   * has to stay covered past the moment the session settles, because `/` never
-   * stops there: it is on its way to a project or to sign-in, and a shell
-   * uncovered between those two moments is the flash all of this removes.
+   * Cover cold product loads until session resolution. The root entrance owns
+   * its own cover because it must remain covered through the subsequent redirect.
    */
   const unresolved = !session.settled && pathname !== "/";
 
@@ -887,28 +769,9 @@ function ShellFrame({
 }
 
 /**
- * The page itself: a 56px title bar, then the page's own toolbar, then its
- * content, all inside 24px gutters.
- *
- * **The content frame centres only after it reaches its maximum.** Below that
- * point the ordinary 24px page gutters still own both edges. Above it, the
- * unused width is split equally instead of collecting at the right edge. The
- * title bar, toolbar and body all use the same frame, so centring never moves
- * a title away from the table or form below it. This supersedes the earlier
- * left-anchored capped frame after the 2026-08-26 browser review found the
- * unequal trailing space across list pages.
- *
- * `wide` is for a page whose subject is wide by nature — a transcript beside
- * the timing of what happened during it, a run beside its simulations. It is a
- * different maximum and not a different layout, so a page asks for room rather
- * than styling itself. It is published as `--page-content-max` because the two
- * blocks that read it, `PageHeader` and `PageBody`, are this component's
- * siblings' children rather than its own props.
- *
- * **The sheet host is drawn last, inside `<main>`.** Every create, edit and
- * read panel in the product is portaled into it, so the browser walk's
- * `page.innerText("main")` reads what a person is actually looking at.
- * `components/ui/sheet.tsx` records the whole argument.
+ * Share one centered, capped content frame across the title, toolbar, and body.
+ * The wide option changes the maximum through --page-content-max. Provide a
+ * sheet portal host inside main for product forms.
  */
 export function ProductPage({
   wide = false,
@@ -989,55 +852,12 @@ function PageContentFrame({
 }
 
 /**
- * The title bar, and the strip of controls under it.
- *
- * **The title moved into a bar of its own**, 56px tall over a hairline with
- * 24px of side padding, which is `71V-0`. It is where a person looks to answer
- * "what am I on", so it stays put while the page scrolls under it and it is
- * the same 56px as the organization bar across the divider from it.
- *
- * **The page's actions are not in that bar.** They sit in the toolbar row
- * below it, hard right, opposite whatever the page filters by — which is the
- * one shape every list in the product now has (`71N-0`). `toolbar` is the left
- * half of that row and is new; `action` is the right half and is the prop
- * every page already passes.
- *
- * **The bar holds the page title and nothing else**, which is what `71V-0`
- * draws. `lead` is a quiet line at the top of the page's own block — the
- * purpose statement `DESIGN.md` asks for, kept where somebody reads it rather
- * than squeezed into a 56px strip beside the title it explains.
- *
- * **A page with a trail draws one line, and the record is the last step of
- * it.** "Tests / Livekit agent suite", every step in the trail's own type,
- * with the section linked and the record the `<h1>` — so the current page
- * appears once and keeps the same 14px / 400 treatment as its parents. It used
- * to be two things in one bar — the trail cut short of the record, then the
- * record beside it as a larger heading — which read as a small link stuck to a
- * big title with no slash between them (developer decision, 2026-08-26). A
- * page with no trail keeps its own title bar, because there is no line for it
- * to join.
- *
- * **So a page with a trail names itself in that trail's last step**, and
- * `title` is what a page without one draws. The two must say the same thing:
- * a page whose last step and `title` differ shows the step and hides the
- * title, which is why the transcript's two state pages carry their state
- * sentence in the trail rather than beside it.
- *
- * `eyebrow` moved out of the bar with it, and is drawn in the same quiet
- * block. **It is not decoration on every page**: the transcript screen puts the
- * trace's source and environment there — "production / default" — which is a
- * fact about the record and the only place the page states it. On a list page
- * it says "Project" over a page whose project the sidebar already names twice,
- * which is noise; delete the prop when you next touch such a page, and the
- * label goes with it. Real `breadcrumbs` still draw in the bar, as the trail
- * into the record being read.
- *
- * **One `<header>` wraps both rows, and it is `display: contents`.** A page
- * that walks up from its own title to find its own controls — the persona page
- * does exactly that, and a test holds it to it — has to find one element
- * holding both. A header that generates no box gives them that ancestor while
- * the two rows still lay out as children of `<main>`, so the bar goes on
- * sticking to the top of the page rather than to the header.
+ * Render the sticky title bar above a separate toolbar, with filters left and
+ * actions right. Breadcrumbs include the current h1; otherwise render title.
+ * Keep the final breadcrumb and title consistent. Lead and eyebrow belong
+ * below the bar.
+ * A display:contents header groups title and controls semantically while
+ * allowing both rows to participate in the page layout.
  */
 export function PageHeader({
   eyebrow,
@@ -1145,24 +965,9 @@ export function PageHeader({
 }
 
 /**
- * The page's content, under the bar and the toolbar.
- *
- * The gutters are the board's — 24px at the sides, 24px above and 40px below —
- * and the inner block is where `--page-content-max` is spent. It shares the
- * centred capped frame used by the title and toolbar: see `ProductPage`.
- *
- * **The top gutter goes when a toolbar row was drawn, because that row already
- * carries it.** `71N-0` is a 52px strip — a 36px control with 16px under it —
- * and `6ZM-0`, the table, starts at the pixel the strip ends on: 132 from the
- * top of the page, which is the 56px title bar, the 24px gutter and the 52px
- * strip and nothing else. A body that added a gutter of its own under that
- * strip put the panel at 156. A page whose header drew no toolbar row keeps the
- * 24px, because then there is nothing above to carry it. (Read off `6ZJ-0`,
- * 2026-08-23.)
- *
- * `flex-1 min-h-0` on the inner block is what lets a viewport page hand its
- * remaining height to whatever it holds. `SettingsLayout` asks for `h-full`,
- * and a percentage height needs a parent with a settled one.
+ * Use the shared capped content frame. Remove the body's top gutter when the
+ * toolbar already supplies separation. flex-1 min-h-0 lets viewport layouts
+ * give the remaining height to their content.
  */
 export function PageBody({ children }: { readonly children: ReactNode }) {
   return (

--- a/apps/web/ui/simulation-evidence.tsx
+++ b/apps/web/ui/simulation-evidence.tsx
@@ -89,17 +89,9 @@ export type RecordingSpeakerTimeline = {
 };
 
 /**
- * The speaker bands drawn over the recording, from the POV that recorded it.
- *
- * The recording is egma's own: the persona's POV heard this conversation,
- * timed it and wrote the audio, so its turn boundaries are measured on the
- * recording's own clock and land where the sound is. The agent's clock is a
- * different clock — near enough to read a transcript by and not near enough to
- * draw on a waveform — so the bands stay the persona's even while the
- * transcript beside them is the agent's. This, and the origin a row seeks
- * against, is the whole of what the persona's POV is still drawn for.
- *
- * A record with no persona turns is drawn with the turns it has.
+ * Prefer persona POV turn timing for recording speaker bands because the
+ * simulator records that POV. Fall back to available turns when persona turns
+ * are absent; agent timings can differ from the recording clock.
  */
 export function recordingSpeakerTimeline(
   transcript: EvidenceTranscript,
@@ -180,19 +172,8 @@ const SUMMARY_STRIP_CELL = cn(
 const SUMMARY_STRIP_LABEL = cn(SUMMARY_LABEL, "whitespace-nowrap");
 
 /**
- * What this simulation measured — the observed metrics, mean-led, under the
- * summary facts and apart from the verdicts for the transcript page's exact
- * reason: a metric measures and a grader judges, and a number is not good or
- * bad until a grader has been asked.
- *
- * **Every figure came off the platform's one shared measure module through the
- * one shared projection**, and the words come off the one shared formatter —
- * so this strip and the production transcript's can never come to word one
- * conversation's numbers two ways.
- *
- * A simulation whose spans carried no metrics renders nothing here: a measure
- * the conversation did not produce is absent, not zero, and the summary facts
- * above already say what the machinery recorded.
+ * Render observed metrics separately from grades using shared API projections
+ * and formatting. Omit the strip when no metrics are available.
  */
 export function SimulationMetrics({
   metrics,
@@ -1368,26 +1349,9 @@ export function RecordingEvidence({
 }
 
 /**
- * **One conversation, told once**: the steps of one POV where the record holds
- * any, and every step where it holds none.
- *
- * A simulation stores both POVs of the same conversation under one trace — the
- * persona's, which is what egma's own simulator said, heard, measured and
- * recorded, and the agent's, which is what the agent's own process reported.
- * They describe the same turns and the same calls, so every reader that shows,
- * counts or judges them chooses one, and they all choose the same way or one
- * surface says a thirteen-turn conversation had twenty-six while another says
- * thirteen.
- *
- * **The same rule as `fromOnePov` in `@egma/db`**, which the trace facts and
- * the graders read by, written again here for one reason: this module is a
- * browser bundle and reaches only `@egma/platform-api`, so it cannot import the
- * package that owns the read. Change one and change the other.
- *
- * Falling back to every step is what makes it safe. A chat simulation, a
- * production transcript and a conversation whose agent never reached egma each
- * hold one POV, and it is the one to show — asking for a POV that is not there
- * must never empty a transcript.
+ * Select the requested POV when present; otherwise retain all supplied steps.
+ * Keep this behavior aligned with @egma/db fromOnePov. The browser cannot
+ * import the database package directly.
  */
 function fromOnePov<Step extends { readonly pov: EvidenceStep["pov"] }>(
   steps: readonly Step[],
@@ -1751,15 +1715,9 @@ const TranscriptToolCall = memo(function TranscriptToolCall({
             )}
           >
             {/*
-              **Who answered, beside what happened.** A mock tool answered this
-              call, read by name off the test version this simulation pinned, so
-              a reader knows the answer in front of them came from the test
-              rather than from their own backend. The mock tool's own name is
-              not repeated here: it is the tool's name, already on this row in
-              mono one slot away. One muted word at the same size — no chip and
-              no colour of its own, because a real call is the ordinary case and
-              says nothing extra.
-            */}
+             * Show the API's derived mock-coverage mark beside the tool result without
+             * repeating the tool name or presenting it as a quality verdict.
+             */}
             {mocked ? (
               <span className="text-muted-foreground">mocked · </span>
             ) : null}
@@ -2428,32 +2386,9 @@ export function SimulationEvidenceReview({
       className={cn(
         REVIEW,
         /*
-         * **The sheet is docked beside this page, so the page steps aside for
-         * it.** That is what a non-modal reading surface promises — the test
-         * covering this panel says it in as many words: "a panel docked beside
-         * this page rather than a layer over it, so the grader results stay
-         * reachable while the transcript is open". The panel is `position:
-         * fixed` against the viewport's right edge, so nothing under it moves
-         * on its own: at 1440 the transcript covered the grader findings it is
-         * evidence *for*, and a reader had to close the transcript to read the
-         * finding that cited it.
-         *
-         * **The room is reserved here, on the block that holds both halves**,
-         * and not on the review panel alone. The summary strip is that panel's
-         * sibling, so padding the panel left the strip running on under the
-         * sheet — Duration cut in half and Total turns gone — while the panel
-         * beside it sat clear of it. One ancestor pays, and every child is
-         * inside what is left.
-         *
-         * The room is the sheet's own width from the theme plus one gutter,
-         * and only where there is room to give: below 1100px the sheet is
-         * most of the screen and reading it *is* the mode, so the page stays
-         * where it is and the sheet covers it.
-         *
-         * It is not animated. `DESIGN.md` asks motion to run on `transform`
-         * and `opacity`, and this is padding — a layout property, on a block
-         * holding a whole review. The sheet's own entrance already explains
-         * where the room went.
+         * Reserve reading-sheet width plus a gutter on the ancestor of summary and
+         * grades so neither sits behind the sheet. Below 1100px, let the sheet cover
+         * the page. Do not animate layout padding; the sheet has its own entrance motion.
          */
         evidenceOpen &&
           "min-[1100px]:pe-[calc(var(--sheet-width-wide)+var(--page-gutter))]",

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -1,81 +1,15 @@
 /*
- * Egma's values, and the theme that hands them to Tailwind.
- *
- * `DESIGN.md` decides the values; this file declares them and is the only
- * place Tailwind learns them. The two halves are deliberately separate and
- * deliberately in one file:
- *
- * - The `:root` blocks below are egma's own vocabulary — `--action`,
- *   `--space-5`, `--duration-press`. They are plain CSS in no cascade layer.
- * - The `@theme` blocks after them are the handoff. **Every key in them is a
- *   `var()` pointing at a declaration above, never a copied colour, radius, or
- *   size.** Changing a value means editing the declaration; editing it in the
- *   theme is not possible, because there is nothing there to edit.
- *
- * They used to be two files — `tokens.css` beside this one — because a CSS
- * Modules surface read the first and a Tailwind surface read the second, and
- * the split was what stopped the two halves of the product drifting apart.
- * There is no CSS Modules surface left to serve — the last one,
- * `app/ui.module.css`, retired with the transcript detail migration. The
- * declarations stay as they are: still `:root`, still unlayered, still loaded
- * by `globals.css` first. Two files for one idea outlived the reason for it.
- *
- * Two mechanisms carry the handoff, and both are worth knowing:
- *
- * 1. **`@theme inline`.** Tailwind normally emits its own custom property and
- *    makes utilities point at that, which would be a second copy of the value.
- *    `inline` makes the utility carry the reference instead, so `bg-primary`
- *    compiles to `background-color: var(--action)` — egma's declaration, in the
- *    rule itself.
- * 2. **Unlayered outranks `@layer theme`.** Tailwind's defaults are declared
- *    inside a cascade layer and the blocks below are `:root` outside every
- *    layer, so unlayered wins whatever the specificity.
- *
- *    **Five names are declared twice, and egma wins all five.** The whole
- *    list, because a partial one invites somebody to move the block into a
- *    layer believing the rest are safe:
- *
- *    | Name | Tailwind's | egma's |
- *    | --- | --- | --- |
- *    | `--radius-sm` | `0.25rem` | `0px` |
- *    | `--radius-md` | `0.375rem` | `0px` |
- *    | `--radius-lg` | `0.5rem` | `0px` |
- *    | `--ease-out` | `cubic-bezier(0, 0, 0.2, 1)` | `cubic-bezier(0.23, 1, 0.32, 1)` |
- *    | `--ease-in-out` | `cubic-bezier(0.4, 0, 0.2, 1)` | `cubic-bezier(0.77, 0, 0.175, 1)` |
- *
- *    This is load-bearing rather than incidental: moving these declarations
- *    into `@theme` would put them in that layer and hand all five names back
- *    to Tailwind — every radius in the product and two of its easings. The
- *    three radii all read `0px` now, and that makes the trick *more*
- *    load-bearing rather than less: hand them back and every component in the
- *    product grows a corner again, quietly, in a commit that touched no
- *    component.
- *
- * A key may not reference its own name. `@theme inline { --text-sm:
- * var(--text-sm) }` compiles, but it emits a circular declaration that only
- * resolves because the unlayered block happens to overrule it. So every key
- * references the `DESIGN.md`-named value underneath — `--text-sm` reads
- * `--text-caption` — which says what it means and cannot go round in a circle.
- *
- * Where shadcn has a default and `DESIGN.md` has a rule, `DESIGN.md` wins. The
- * weights above 500, the cool grey shadow ladder, the radius steps that belong
- * to no component, and the type steps outside the accepted scale are deleted
- * below rather than left available to be reached for by accident.
+ * Theme values from DESIGN.md and their Tailwind aliases. Keep the :root
+ * values unlayered so they override Tailwind theme defaults, including shared
+ * radius and easing names. @theme inline maps utilities to these values.
+ * Do not create aliases that reference themselves. Remove unsupported defaults
+ * so components cannot silently use values outside the design system.
  */
 
 /*
- * Markup only, and deliberately narrow.
- *
- * Tailwind mints a utility from any bare word it finds that happens to name
- * one, and this repository writes long prose comments — a sentence with
- * "rounded" or "block" in it was minting `.rounded` and `.block` out of
- * explanation. Scanning only the files that carry class attributes stops the
- * prose being read as markup. No `.ts` file under `apps/web` holds a class
- * name; a future one that does has to be added here.
- *
- * `../ui` is the third glob because the shared components live there, and it
- * is load-bearing: every one of them is on this theme now, so a class name it
- * uses that is not scanned is a class name that is never generated.
+ * Scan component markup directories explicitly. These globs omit .ts files;
+ * add a source if class names move there. Comments in scanned files can still
+ * produce utilities, so avoid unused class examples.
  */
 @source "../app/**/*.tsx";
 @source "../components/**/*.tsx";
@@ -123,18 +57,8 @@
   --action-text: var(--color-paper);
 
   /*
-   * The primary action's fill, and its two feedback steps.
-   *
-   * The boards draw the primary button as Ember Wash behind Deep Ember text on
-   * a neutral hairline (`71O-0`), not as a Deep Ember block with white text.
-   * The developer ruled that the wash button *is* the primary action on
-   * 2026-08-23 and retired the filled one. `--action` is still the ink, so the
-   * text steps above are the text's; these three are the fill's.
-   *
-   * Derived rather than fixed, so one declaration follows both themes: each
-   * step pulls a little more Ember into whatever `--surface-active` is in
-   * force. Light theme starts at `#fff5f2` and warms; dark theme starts at
-   * Ember-on-dark and warms the same way.
+   * Primary actions use action-colored text on a wash. Derive hover and press
+   * fills from the active surface so they follow both themes.
    */
   --action-wash: var(--surface-active);
   --action-wash-hover: color-mix(in srgb, var(--color-ember) 8%, var(--surface-active));
@@ -171,14 +95,8 @@
   --bad-surface: color-mix(in srgb, var(--bad) 6%, var(--surface));
 
   /*
-   * The dialog scrim, which is what makes the page behind one read as inert.
-   *
-   * It is mixed from Midnight Ink rather than from `--foreground`, and that is
-   * the whole point: `--foreground` flips to near-white in dark theme, so a
-   * scrim derived from it *brightened* the page it was supposed to put behind
-   * a dialog. A scrim is dark in both themes because dimming is what it means.
-   * In light theme `--foreground` is Midnight Ink, so this is the value that
-   * was already being drawn.
+   * Derive the scrim from fixed dark ink, not the foreground that becomes
+   * light in dark mode.
    */
   --scrim: color-mix(in srgb, var(--color-midnight) 32%, transparent);
 
@@ -198,34 +116,15 @@
   --space-13: 100px;
 
   /*
-   * Component shape: one radius, and it is none.
-   *
-   * The four names stay because forty class lists read them — `rounded-button`
-   * on a button, `rounded-card` on a panel — and because a name says which
-   * component asked. What changed is every value. The developer ruled it on
-   * 2026-08-23 looking at the Paper boards: "0px radius, sharp corners, on
-   * every component". `DESIGN.md`'s per-component radius table collapsed to
-   * one line in the same change.
-   *
-   * **A round *shape* is not a component corner and is not drawn from here.**
-   * A radio button stays circular because its shape distinguishes it from a
-   * checkbox. The account avatar is square with every other component.
+   * Component corners are square. Keep semantic radius names for their callers;
+   * round control shapes such as radio indicators use separate styling.
    */
   --radius-sm: 0px;
   --radius-md: 0px;
   --radius-lg: 0px;
   --radius-pill: 0px;
 
-  /*
-   * The accepted type scale.
-   *
-   * **`system-ui` leads, and the reason is the boards.** Paper renders its
-   * artboards in `system-ui`, so a product drawn in Arial first would not look
-   * like the thing that was approved — on a Mac the two are a different face,
-   * not a different hinting. Helvetica and Arial stay behind it, so a machine
-   * with no `system-ui` lands exactly where this product used to. Developer
-   * decision, 2026-08-23. Weights are still 400 and 500 and nothing else.
-   */
+  /* Use the system UI font first, with the accepted type scale and weights. */
   --sans: system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
   --mono: var(--egma-mono), "IBM Plex Mono", ui-monospace, monospace;
   /*
@@ -337,62 +236,20 @@
   --table-action-width: 48px;
 
   /*
-   * The same lane, on a table that says **Actions** over it.
-   *
-   * A ⋮ needs 48px and a word does not: "Actions" at `--text-sm` is about
-   * 54px, and the header padding either side of it is `--row-padding-x`, so
-   * the lane a labelled trailing column needs is a little over 86px. The
-   * tests grid names its lane out loud and was drawing it at the unlabelled
-   * width, which put the word through the table's own right hairline.
-   *
-   * It is a second token rather than a wider first one because the two are
-   * different facts: a lane holding only a ⋮ is 48px in every list in the
-   * product, and widening all of them to suit one heading would move a lane
-   * a person's eye follows down every table.
+   * A labeled action column needs room for its heading and padding. Keep its
+   * width separate from the compact column that holds only a menu trigger.
    */
   --table-action-labelled-width: 96px;
 
   /*
-   * The narrowest the suite grid may be drawn before it scrolls sideways.
-   *
-   * That grid is the one table in the product with no narrow layout: its cells
-   * are edited in place, so the stacked label-and-value form every list uses
-   * on a phone is a screen of its own rather than a variant, and it is not
-   * written yet. Until it is, six percentage columns and a 96px lane share
-   * whatever width there is, and each floor below is the width at which the
-   * narrowest of them stops holding its own heading on one line.
-   *
-   * **900px, and it is no longer under the tablet width.** The floor was 720
-   * for four columns, chosen to sit under 768 so only a phone scrolled. Mock
-   * tools and Env are two more columns of the test's own content, and six
-   * columns plus the lane do not hold their headings inside a tablet — the
-   * arithmetic is `Mock tools` at 14px inside `--row-padding-x` either side,
-   * which wants about 100px, and `Personas` about 90. A tablet scrolls the
-   * grid now. A table that scrolls inside its own panel is the honest failure
-   * here; headings broken across two lines are not.
-   *
-   * The proportions moved on 2026-09-04, when the two JSON cells started
-   * saying sentences rather than counts, and the floor did not have to move
-   * with them: `Personas` at 12% is 108px here and is now the tightest
-   * heading of the six.
+   * The editable test grid keeps its columns and scrolls horizontally below
+   * this minimum width. It has no stacked mobile form.
    */
   --tests-grid-min-width: 900px;
 
   /*
-   * How wide each surface is. Every one of these lived in a class list as a
-   * bare number until 2026-08-23; a size is a design value like a colour is,
-   * and `DESIGN.md` says a component holds neither.
-   *
-   * **Two side-sheet behaviours, with one production reading variant.**
-   * `--sheet-width` is the modal panel the boards draw one record in (`77F-0`):
-   * create, read and edit, over a scrim, with the page behind it inert.
-   * `--sheet-width-wide` is the *reading* surface `ui/dialog.tsx` opens beside
-   * a page that stays usable — a transcript against its grader results, a
-   * persona's version history. A production trace uses the same behaviour but
-   * gets more reading room on a large viewport; the clamp keeps its existing
-   * width until the viewport can give it that room. Collapsing the reading
-   * surface into the form width took 200px off a transcript to make a number
-   * match, which is a worse product for a tidier theme.
+   * Shared surface widths. Form sheets are modal; reading sheets keep the page
+   * usable. Production trace reading sheets gain more room on large viewports.
    */
   --sheet-width: 440px;
   --sheet-width-wide: 640px;
@@ -424,18 +281,8 @@
   --grade-fact-min: 150px;
 
   /*
-   * Orange-brown elevation, reserved for what is raised off the page.
-   *
-   * **There used to be two recipes and the boards draw one.** The row menu
-   * (`9AH-0`), the side sheet (`77F-0`) and the confirm dialog (`BEM-0`) were
-   * read with `get_computed_styles` on 2026-08-23 and all three carry the same
-   * two-layer stack — the short menu shadow is not on any of them. So
-   * `--shadow-menu` reads the same declaration rather than holding a second
-   * value that nothing draws. The name stays because `shadow-popover` reads
-   * it and because a menu is still what asks.
-   *
-   * Everything the boards give a hairline and no shadow — the table panel, the
-   * sidebar, the topbar, inputs, the search box — keeps the hairline alone.
+   * Raised surfaces share one warm shadow recipe. Flat panels and controls
+   * use borders without elevation.
    */
   --shadow-dialog:
     rgb(122 49 23 / 0.12) -8px 16px 39px 0,
@@ -448,17 +295,7 @@
     rgb(122 49 23 / 0.02) -130px 256px 115px 0;
 }
 
-/*
- * Dark theme semantic overrides.
- *
- * **Two selectors, and the second one is what makes the proof page honest.**
- * The document carries `data-theme` on `<html>`, which is what the theme
- * script writes and what every real page reads. `/design-system` also has to
- * draw the dark theme *beside* the light one, in a frame, so a person can hold
- * the two against each other without reloading — and a rule bound to `:root`
- * alone cannot dress a `<div>`. The attribute means the same thing in both
- * places: everything inside me is dark.
- */
+/* Apply dark values to both the document root and nested design-system previews. */
 :root[data-theme="dark"],
 [data-theme="dark"] {
   --background: #151514;
@@ -475,26 +312,7 @@
   --foreground: #f2f2ed;
   --muted: #a3a39b;
   --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='m4 6 4 4 4-4' fill='none' stroke='%23a3a39b' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-  /*
-   * Lifted from `#82827b`, which failed AA on the surface it is most often
-   * drawn on.
-   *
-   * The tertiary step has two grounds in dark theme and they are not the same
-   * test. On the canvas, `#151514`, the old value measured 4.73:1 and passed.
-   * On the raised surface, `#1b1b1a` — a table panel, a form group, a menu —
-   * it measured **4.46:1 and failed**, and that is where a timestamp, a hint
-   * and an empty-state line actually live. A value that passes on the page and
-   * fails inside every panel on it is a value that fails.
-   *
-   * `#94948c` measures 5.98:1 on the canvas and 5.64:1 on the raised surface,
-   * so the worst ground now clears AA with room rather than by a rounding
-   * step. It stays a step below `--muted`, which is 6.79:1 on the same ground:
-   * the three-level hierarchy is what it was, one rung less quiet at the
-   * bottom.
-   *
-   * Light theme was measured too and did not move — its `--faint` is 5.33:1 on
-   * Pure Paper.
-   */
+  /* Keep tertiary text readable on the raised dark surface as well as the canvas. */
   --faint: #94948c;
   --border: #30302d;
   --border-strong: #4a4a44;
@@ -503,22 +321,8 @@
   --waveform-user: color-mix(in srgb, var(--foreground) 76%, transparent);
   --waveform-agent: color-mix(in srgb, var(--color-ember) 84%, transparent);
   /*
-   * The primary action's ink, lightened for the dark wash it sits on.
-   *
-   * **Deep Ember on the dark wash is 2.69:1, which fails AA and fails even the
-   * 3:1 a non-text control gets.** That was true before this theme change as
-   * well — the wash was already Ember-on-dark and the ink was already
-   * `#c2410c` — so this is a fault being fixed rather than one being created.
-   * Ember alone is 4.3:1, still short. Ember pulled 20% towards paper is
-   * `#ff7554` at **5.26:1**, which passes AA for the 14px label a button
-   * carries, and it is the same colour family the light theme uses.
-   *
-   * Hover and press move *further* towards paper, which is "further from the
-   * surface it sits on" — the same direction, in dark, that the light theme's
-   * darker steps take. `--destructive` above already works this way.
-   *
-   * `DESIGN.md`: "Dark theme uses lighter status values that keep the same
-   * meanings." This is that rule applied to the action family.
+   * Lighten action text for contrast against dark washes. Hover and press
+   * move further toward paper.
    */
   --action: color-mix(in srgb, var(--color-ember) 80%, var(--color-paper));
   --action-hover: color-mix(in srgb, var(--color-ember) 62%, var(--color-paper));
@@ -529,19 +333,8 @@
   --bad: #e27373;
 
   /*
-   * Destructive follows the failure colour, in both themes.
-   *
-   * `DESIGN.md`: "Dark theme uses lighter status values that keep the same
-   * meanings." Light theme already has one red — `--destructive` and `--bad`
-   * are the same value — and dark theme lightened `--bad` alone, so a dark
-   * page showed a `#b44444` destructive button beside an `#e27373` destructive
-   * menu item and asked somebody to read them as one meaning.
-   *
-   * White text on the lighter red is 3.0:1 and fails AA, so the text on it
-   * flips to Midnight Ink at 5.4:1 — the same contrast the light theme gets
-   * from white on `#b44444`. Hover and press move *towards paper* here, where
-   * light theme moves away from it: both directions are "further from the page
-   * it sits on", which is what the feedback has to say.
+   * Match destructive styling to the failure color. Use dark text on the
+   * lighter dark-theme fill to preserve contrast.
    */
   --destructive: var(--bad);
   --destructive-hover: color-mix(in srgb, var(--bad) 86%, var(--color-paper));
@@ -569,19 +362,8 @@
 }
 
 /*
- * "Mobile may restyle the same DOM as rows." When a table does that is two
- * questions rather than one, and both have to be asked of every rule.
- *
- * A table normally stacks when the *browser* is too narrow — the same 900px at
- * which the shell stops being two columns. A table inside a narrow content area
- * can run out of room long before that, so a page may opt in by naming its
- * wrapper a `data-table` container, and then the table's own width decides.
- *
- * A container query against a container that does not exist is false, so the
- * second half costs nothing on a table that did not opt in, and both halves
- * apply to one that did. Writing it as one variant is what keeps the two
- * layouts from drifting: a rule added to `stacked:` cannot be added to one
- * question and forgotten in the other.
+ * Stack tables at the viewport breakpoint or when an opted-in data-table
+ * container is narrow. Keep both conditions in this shared variant.
  */
 @custom-variant stacked {
   @media (max-width: 900px) {
@@ -672,14 +454,8 @@
   --color-selected-foreground: var(--foreground);
 
   /*
-   * The primary action.
-   *
-   * `--color-primary` and its two steps are the *ink* — Deep Ember, and the
-   * two darker Ember steps under pointer feedback. `--color-primary-wash` and
-   * its two are the *fill* the boards put behind that ink. `-foreground` is
-   * kept pointing at white for the one thing that still fills with Deep Ember
-   * (nothing in the product today; a pasted shadcn component tomorrow), so a
-   * component that reaches for it lands somewhere legible rather than nowhere.
+   * Keep primary ink and wash aliases separate. The foreground alias remains
+   * for components using a filled primary surface; callers must check contrast.
    */
   --color-primary: var(--action);
   --color-primary-foreground: var(--action-text);
@@ -690,20 +466,8 @@
   --color-primary-wash-pressed: var(--action-wash-pressed);
 
   /*
-   * The same seven declarations under the product's own word.
-   *
-   * **`primary` is shadcn's name for this and `action` is egma's, and a class
-   * that names a key the theme does not publish fails in silence.** `DESIGN.md`
-   * and the spec both say `--action`; the theme published only `--color-primary`,
-   * so `text-action` compiled to nothing at all, drew the inherited body colour,
-   * and looked exactly like somebody's decision. That is how "+ Add a behavior"
-   * shipped as ordinary text until a screenshot caught it.
-   *
-   * Both words now read one declaration. `primary` stays because a component
-   * pasted from the registry arrives asking for it; `action` is what the rest
-   * of the product writes. The two feedback fills are aliased as well, on
-   * purpose: publishing `action-wash` but not `action-wash-hover` would put
-   * the same silent hole back one name along.
+   * Publish action and registry-compatible primary aliases from the same
+   * values, including hover and press states.
    */
   --color-action: var(--action);
   --color-action-hover: var(--action-hover);
@@ -836,28 +600,10 @@
 }
 
 /*
- * Motion, at the theme rather than on each component.
- *
- * `DESIGN.md` asks for things a class list says badly: an exit that finishes
- * before the element unmounts, a popover that grows from the control that
- * opened it, and a reduced-motion form of every one of them. Radix already
- * publishes what is needed — `data-state` for open and closed, and a
- * transform-origin measured from the trigger — so the rules key off those and
- * the component files stay stock shadcn.
- *
- * A sub-menu is named beside its parent in every list below rather than being
- * handed the parent's `data-slot`. Sharing the name is the shorter way to make
- * a sub-menu move, and it costs the ability to ever address the two apart: a
- * later rule meant for one silently reaches the other, and the component stops
- * matching the registry it came from.
- *
- * Exits are animations rather than transitions on purpose: Radix waits for
- * `animationend` before unmounting, and a transition would be cut off halfway.
- *
- * The polish bar is "fast, modern, slick" and the floor is unchanged — every
- * duration here is a `DESIGN.md` motion token, every one is under 300ms, only
- * `transform` and `opacity` move, and reduced motion keeps the meaning while
- * dropping the movement.
+ * Use Radix state attributes and measured trigger origins for surface motion.
+ * Keep submenu slots distinct. Exit animations let Radix retain a surface
+ * until animationend; transitions alone do not supply that signal. Theme
+ * tokens define timing, and reduced-motion rules remove spatial movement.
  */
 
 @keyframes egma-fade-in {
@@ -926,24 +672,8 @@
 }
 
 /*
- * The dialog scales on the `scale` property rather than inside `transform`,
- * and that is load-bearing rather than a style preference.
- *
- * A centred dialog is held in place by a half-its-own-size shift, and
- * `transform` is a single property: a keyframe that sets `transform: scale()`
- * replaces whatever shift was there, and the panel slides down and right for
- * the length of the animation before snapping back at the end. Today that does
- * not happen, because Tailwind 4 compiles `-translate-x-1/2` to the separate
- * `translate` property, which composes with `transform` instead of being
- * overwritten by it — so the two never meet. But that is Tailwind's
- * implementation detail holding the dialog together, not anything this file
- * says, and it was different in Tailwind 3.
- *
- * Animating `scale` puts the movement on its own property too. Position lives
- * on `translate`, motion lives on `scale`, `transform` is written by neither,
- * and no future centring — however it is expressed — can be cancelled by this
- * animation. `transform-origin` still applies, so the panel still scales about
- * its own centre.
+ * Animate scale separately from the translate used to center the dialog,
+ * so the keyframes do not replace its positioning transform.
  */
 @keyframes egma-dialog-in {
   from { opacity: 0; scale: 0.98; }
@@ -956,20 +686,8 @@
 }
 
 /*
- * The drawer, which travels and does not fade.
- *
- * `DESIGN.md` gives a mobile drawer its own line: "translate from its attached
- * edge", and its own pair of tokens. Fading or scaling it as well reads as two
- * events rather than one movement, so these keyframes write `translate` and
- * nothing else. `translate` is a property of its own, so the panel's resting
- * position is still whatever its class list says and this only moves it.
- *
- * **The length of the exit is load-bearing rather than decoration.** Radix
- * removes the panel on `animationend`, so whatever animation is running is
- * what holds the drawer on screen while it leaves. Writing the travel as a
- * transition instead left it racing the centred dialog's 180ms `scale`, which
- * is why the drawer used to be cut off at its own edge; an animation of its
- * own means the drawer waits for the drawer.
+ * Drawer keyframes translate from the attached edge without fading. Use
+ * an animation so Radix waits for the drawer's own exit event.
  */
 @keyframes egma-drawer-in {
   from { translate: -100% 0; }
@@ -982,18 +700,8 @@
 }
 
 /*
- * The side sheet, which comes in from the right edge and fades with it.
- *
- * `DESIGN.md` gives an edge-attached surface one behaviour — "translate from
- * its attached edge" — and one pair of tokens, the drawer's. A sheet is that
- * surface on the other edge, so it takes the same movement and the same
- * durations. The opacity travels with it because a sheet lands over a scrim
- * rather than over the bare page, and a panel that only slid would look like it
- * had always been there, just off screen.
- *
- * `translate` and nothing else, for the reason the drawer's keyframes give: the
- * panel's resting position is whatever its class list says, and an animation
- * that wrote `transform` would replace it.
+ * Sheets translate from the right and fade using drawer timing tokens.
+ * Keep movement on the separate translate property.
  */
 @keyframes egma-sheet-in {
   from { opacity: 0; translate: 100% 0; }
@@ -1022,16 +730,8 @@
   }
 
   /*
-   * "Loading: show progress — fast, quiet indicator."
-   *
-   * The mark beside a run's state turns only while the run is moving, which is
-   * what `data-motion="active"` says. It is a `rotate` on a 12px line symbol
-   * and nothing else on the page moves with it. Three drawer-enters is a
-   * complete turn: slow enough to read as progress rather than as a spinner
-   * demanding attention, and still a motion token rather than a number.
-   *
-   * The word beside it is what carries the meaning, so reduced motion drops
-   * the turn and loses nothing.
+   * Rotate the state mark only while active. The text carries the state, so
+   * reduced motion can stop it. This indicates activity, not measured progress.
    */
   [data-slot="state-mark"][data-motion="active"] {
     transform-origin: center;
@@ -1046,17 +746,8 @@
   }
 
   /*
-   * The same rule for the screen that stands in while a session is unresolved.
-   *
-   * The Egma mark above this never moves — `DESIGN.md` forbids animating the
-   * logo — so one segment crossing a hairline track is the whole of the quiet
-   * indicator. Four drawer-enters for a crossing: a token rather than a number,
-   * and slow enough to read as work rather than as alarm.
-   *
-   * Reduced motion is answered once, in `globals.css`, which holds every
-   * animation to a single frame. What is left is a segment standing in its
-   * track — the same trade the skeleton bars make — and the sentence this
-   * screen announces carries the meaning either way.
+   * Animate a segment in the session-loading track; the logo stays still.
+   * The global reduced-motion rule shortens the animation and limits it to one iteration.
    */
   [data-slot="session-progress"] > * {
     animation: egma-session-progress calc(var(--duration-drawer-in) * 4)
@@ -1064,32 +755,10 @@
   }
 
   /*
-   * The same rule's other half: a page, or a whole route, that is still
-   * waiting.
-   *
-   * **One appearance assembled out of three elements.** A route fallback wraps
-   * a whole page composition, that composition holds a state card, and the
-   * card holds the bars. Only a rule that can see all three can say "one
-   * entrance, not three", which is why this is here rather than in three class
-   * lists that cannot see each other.
-   *
-   * **The entrance waits before it draws anything.** `--duration-popover-in`
-   * of nothing, held there by `both`, and then a `--duration-hover` fade. A
-   * route that answers inside that wait — a prefetched one, a warm cache, a
-   * second visit — is drawn without this ever having been on screen, and a box
-   * that appears and vanishes inside a fifth of a second reads as a fault
-   * rather than as speed.
-   *
-   * **A fallback owns the entrance; the card inside it does not.** Otherwise
-   * the header would fade as one thing and the card as another, and the two
-   * opacities would multiply for as long as they overlapped.
-   *
-   * **Reduced motion is deliberately not given a rule of its own here.** This
-   * is already opacity and nothing else, and `globals.css` caps every
-   * animation at a single frame under that query while leaving
-   * `animation-delay` alone — so what survives is the wait, and what goes is
-   * the fade. Writing `animation: none` here would throw away the half worth
-   * keeping.
+   * Delay the loading entrance to avoid flashes for quick responses. A route
+   * fallback owns the fade; suppress the nested card's fade to avoid multiplying
+   * opacities. The global reduced-motion rule keeps the delay while shortening
+   * the animation.
    */
   [data-slot="route-loading"],
   [data-slot="page-state"]:has([data-slot="loading-indicator"]) {
@@ -1103,22 +772,8 @@
   }
 
   /*
-   * The bars themselves.
-   *
-   * One full breath is `--duration-drawer-in` twice over — 560ms, so each half
-   * of it is one drawer-enter — against the 2s a stock shadcn skeleton
-   * carries. Quicker, and still slow enough to read as waiting rather than as
-   * alarm.
-   *
-   * The stagger is `--duration-hover` per bar and **negative**, so all three
-   * are already moving on the first frame and merely out of phase. A positive
-   * delay would hold the second and third still while the first breathed,
-   * which reads as two bars that failed to start. It is a separate
-   * `animation-delay` and it is safe to be one: both declarations are in this
-   * file, in this order, and the offsets are the more specific of the two.
-   *
-   * The word above them carries the meaning, so reduced motion stops the
-   * breath and leaves the bar — the same trade the state mark makes.
+   * Offset skeleton pulses with negative delays so all bars start immediately
+   * at different phases. Reduced motion leaves static bars.
    */
   [data-slot="skeleton"] {
     animation: egma-skeleton-pulse calc(var(--duration-drawer-in) * 2)
@@ -1212,21 +867,9 @@
   }
 
   /*
-   * The tooltip.
-   *
-   * Radix says how it was opened and the two answers want different things.
-   * `delayed-open` is a pointer that waited, so it arrives about its trigger
-   * on opacity and `transform`. `instant-open` is keyboard focus, or a pointer
-   * inside the grouping window, and neither of those gets a rule at all: "do
-   * not animate actions used many times each day, especially keyboard
-   * navigation", and a delay repeated across a row of controls is the tooltip
-   * behaviour everybody complains about.
-   *
-   * The exit is scoped by `data-input`, which the shared `Tooltip` sets on the
-   * way in, because Radix reports "closed" the same way whichever opened it.
-   * An animation is what Radix waits for before unmounting, so the pointer
-   * exit runs to completion and the keyboard one is not made to wait for
-   * anything.
+   * Animate delayed pointer tooltips. Instant-open states have no entrance
+   * animation. data-input selects pointer exits because closed state alone does
+   * not identify how the tooltip opened.
    */
   [data-slot="tooltip-content"][data-state="delayed-open"] {
     animation: egma-anchored-in var(--duration-popover-in) var(--ease-out);
@@ -1237,17 +880,8 @@
   }
 
   /*
-   * The toast.
-   *
-   * Position and motion are on separate properties on purpose, which is the
-   * same rule the dialog above follows and for the same reason: a toast
-   * arrives by moving, so its motion is on `translate` and nothing else writes
-   * that property.
-   *
-   * These stay transitions rather than animations, unlike everything else in
-   * this section. `DESIGN.md` asks this one surface for an *interruptible*
-   * exit, and the component keeps itself mounted until the `transitionend`
-   * rather than handing the decision to Radix.
+   * Keep toast movement on translate. The controlled component handles exit
+   * presence, with transition events and a timeout fallback.
    */
   [data-slot="toast"][data-input="pointer"] {
     transition:
@@ -1269,17 +903,8 @@
   }
 
   /*
-   * The development proof can show the same contract without changing the OS.
-   * Deliberately outside the media query below: this is how the reduced-motion
-   * form is inspected, not a second definition of it.
-   *
-   * **This is why `components/ui/tooltip.tsx` does not portal its panel.** A
-   * portalled tooltip is a child of `body`, and no descendant selector written
-   * here can reach it from the frame it belongs to — the panel would go on
-   * demonstrating full motion while the words above it said the opposite,
-   * which is worse than not demonstrating it. Radix positions the panel
-   * `fixed` either way, so staying in place costs none of the collision
-   * handling; `tooltip.tsx` records the whole trade.
+   * Allow reduced-motion previews without changing the OS setting. Tooltips
+   * stay under their preview frame so these descendant selectors can reach them.
    */
   [data-preview="reduced-motion"]
     [data-slot="tooltip-content"][data-state="delayed-open"] {
@@ -1292,18 +917,8 @@
   }
 
   /*
-   * A page that drew its own toolbar row does not pay the top gutter twice.
-   *
-   * `PageHeader` opens the block under the title bar when a page hands it a
-   * purpose statement, an action or a filter, and `PageBody` opens one when
-   * the page did not — so whichever comes first carries the 24px, and the
-   * second one starts where the first left off. It is a sibling rule because
-   * that is the question: *is there already a block above me*, which no class
-   * on either element can answer about the other.
-   *
-   * The header between them is `display: contents`, which changes what is
-   * drawn and not what is a sibling of what — so the match is on the header
-   * that holds a toolbar rather than on the toolbar itself.
+   * Remove the body's top gutter when the preceding header already has a
+   * toolbar. display: contents changes layout, not the DOM sibling relationship.
    */
   [data-slot="page-header"]:has([data-slot="page-toolbar"])
     + [data-slot="page-body"] {
@@ -1311,19 +926,8 @@
   }
 
   /*
-   * A link inside a table cell.
-   *
-   * The boards underline it in the text colour and turn it Ember under the
-   * pointer (`71C-0`): an underline is what says "this is a link" without
-   * spending the brand colour on every row of a list, and the colour arrives
-   * when somebody is actually pointing at one. It is here rather than in
-   * `ui/data-table.tsx` because the cell's contents are written by the page —
-   * the component never sees the link — and because every list in the product
-   * has to answer this the same way.
-   *
-   * Underline offset and thickness are the board's. Both are properties of the
-   * text rather than values a component chose, and neither has a token because
-   * `DESIGN.md` names no scale for them.
+   * Style links in table cells consistently, including links supplied by pages.
+   * Use an underline at rest and action feedback for fine-pointer hover.
    */
   [data-slot="table-cell"] a {
     color: inherit;
@@ -1372,17 +976,9 @@
   }
 
   /*
-   * A list row whose primary link is stretched across the whole row.
-   *
-   * Keyed on `data-stretch-primary-link`, and in the theme for the same reason
-   * the placement above is: the attribute has to be what does the work. Written
-   * as a class list on the row it was ten arbitrary variants that a test could
-   * only check by re-reading the prop that produced them.
-   *
-   * The `::after` covers the row, so every kind of control a cell may hold is
-   * lifted back above it — otherwise the press meant for an Edit button four
-   * columns along opens the row instead. There is still exactly one link in the
-   * accessibility tree; this adds a pointer target, not a second link.
+   * Stretch the primary link over the row with a pseudo-element. Raise other
+   * controls above it so their clicks remain independent. This enlarges the
+   * pointer target without adding another accessible link.
    */
   [data-slot="data-table-row"][data-stretch-primary-link="true"] {
     position: relative;


### PR DESCRIPTION
Web comments frequently repeat the component name, describe retired layouts, or promise behavior the component does not enforce. This replaces that prose with concise notes about current behavior, accessibility, request state, and CSS constraints.

This is the web portion of the repository comment cleanup, based on #310. It changes 158 files and keeps the newer inline persona settings and shared-select behavior from main. Component logic, user-facing text, and CSS declarations are unchanged. The split keeps each PR below Greptile's 400-file review limit.

Validation:
- Syntax-tree comparison verifies unchanged TypeScript/JSX behavior; CSS comparison verifies unchanged declarations.
- Local validation passed: workspace build, generated API check, lint, type checks, web production build, and 721 web/tooling tests.
- All required CI checks passed for 23c8e1d1, including the preview build. Greptile review passed at 5/5; the sole review thread is fixed and resolved.

Merge #310 first, then retarget this PR to main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791405770&installation_model_id=431960&pr_number=311&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F311&signature=37fc1204689607a46e9a4a0ec960e45dfb7f30447e62cf6ab6f61579fbcfba59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces verbose or stale web comments with concise explanations of current behavior, accessibility, request state, and CSS constraints without changing executable behavior or CSS declarations.
- The latest change corrects “A Egma-provided persona” to “An Egma-provided persona.”
- The previously reported grammar issue is fully fixed and its thread is resolved.
- No new actionable issues were identified.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the previous comment issue fully corrected and no new actionable findings.

The only change since the previous review is a grammatically correct article replacement in a test comment; it does not alter runtime behavior, and the previous finding is fully fixed.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/test/personas.test.tsx | Corrects the article in the Egma-provided persona test comment, fully addressing the previous finding. |

<sub>Reviews (2): Last reviewed commit: ["Fix article in persona test comment"](https://github.com/egma-ai/egma/commit/23c8e1d120cedf97803fcff29e6c597cbf03ba30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61356465)</sub>

<!-- /greptile_comment -->