### PR TITLE
Patch vulnerable Fastify, fast-uri, and NLTK dependencies

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,7 +25,7 @@
     "@opentelemetry/instrumentation-undici": "^0.31.0",
     "@opentelemetry/sdk-node": "^0.221.0",
     "better-auth": "^1.6.25",
-    "fastify": "^5.6.1",
+    "fastify": "^5.12.1",
     "nodemailer": "^9.0.3",
     "posthog-node": "^5.49.1",
     "protobufjs": "^8.7.1"

--- a/apps/simulator/pyproject.toml
+++ b/apps/simulator/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "boto3>=1.42.0",
     "jsonschema>=4.25.1",
     "loguru>=0.7.3",
-    "nltk>=3.10.2",
+    "nltk>=3.10.3",
     "livekit==1.1.14",
     "opentelemetry-exporter-otlp-proto-common==1.44.0",
     "opentelemetry-sdk==1.44.0",

--- a/apps/simulator/uv.lock
+++ b/apps/simulator/uv.lock
@@ -383,7 +383,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.25.1" },
     { name = "livekit", specifier = "==1.1.14" },
     { name = "loguru", specifier = ">=0.7.3" },
-    { name = "nltk", specifier = ">=3.10.2" },
+    { name = "nltk", specifier = ">=3.10.3" },
     { name = "opentelemetry-exporter-otlp-proto-common", specifier = "==1.44.0" },
     { name = "opentelemetry-sdk", specifier = "==1.44.0" },
     { name = "pipecat-ai", extras = ["deepgram", "livekit", "tracing"], specifier = "==1.7.0" },
@@ -924,7 +924,7 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.10.2"
+version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -933,9 +933,9 @@ dependencies = [
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/16/24d639531e73cbc6884fb251d116dfe469df9c595e0dcf24668c54d0e8d3/nltk-3.10.2.tar.gz", hash = "sha256:fcfd80fb77931868cea8357573c79838b8abc609942ef9914d1c9f6070d4645c", size = 3101716, upload-time = "2026-08-05T09:56:20.657Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/2b/bf677eb32ca6684b270c0d19ab133c2271e9f3375997e5a8dd2b08e3152d/nltk-3.10.2-py3-none-any.whl", hash = "sha256:2c7ccacb765c5e26b0cb60fb1b57080af522c6924d12a714a243305ba3637412", size = 1725815, upload-time = "2026-08-05T09:56:09.657Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z" },
 ]
 
 [[package]]
@@ -2042,7 +2042,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -2117,7 +2117,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: ^1.6.25
         version: 1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.3)(kysely@0.29.4)(pg@8.22.0))(next@16.3.3(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@3.2.7(@types/node@24.13.3)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
       fastify:
-        specifier: ^5.6.1
-        version: 5.11.0
+        specifier: ^5.12.1
+        version: 5.12.3
       nodemailer:
         specifier: ^9.0.3
         version: 9.0.3
@@ -3248,14 +3248,14 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
-  fast-uri@4.1.2:
-    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
+  fast-uri@4.1.4:
+    resolution: {integrity: sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==}
 
-  fastify@5.11.0:
-    resolution: {integrity: sha512-Y/Ecx1yt0hYzrQR+QVLbxaUN8wCX+MQzMevh29r5RRvlOIArmi4+WAXXaGl5Hw5gBr2wduZpZaT3gRCnXoyVgA==}
+  fastify@5.12.3:
+    resolution: {integrity: sha512-reZ8wce5VNCcufIt9AVtzZa3L4u1j8esikn7OEgHWLVpRpL5R7Y2+Xzj70OUkv5zDfzUAxXZT6cu4Rt0zr3EKA==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4995,7 +4995,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
 
   '@fastify/error@4.2.0': {}
 
@@ -6866,7 +6866,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7258,7 +7258,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 4.1.2
+      fast-uri: 4.1.4
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -7270,11 +7270,11 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
-  fast-uri@4.1.2: {}
+  fast-uri@4.1.4: {}
 
-  fastify@5.11.0:
+  fastify@5.12.3:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
       '@fastify/error': 4.2.0


### PR DESCRIPTION
Updates the API and simulator dependency locks to address 19 of the 20 open Dependabot alerts: Fastify 5.12.3, fast-uri 3.1.7/4.1.4, and NLTK 3.10.3. Fastify and NLTK minimum versions now require the security releases. The fast-uri patches stay within the parent packages' supported ranges; no dependency overrides are added.

No normal product behavior change was found. Egma disables Fastify type coercion and uses a boolean proxy setting, so the two Fastify advisory scenarios do not match its configuration. Seven sentence-tokenization comparisons match NLTK 3.10.2, and a fresh tokenizer-data download and read passed.

Alert [#15](https://github.com/egma-ai/egma/security/dependabot/15), GHSA-8mgp-746c-j5xp, remains unpatched upstream. Egma and its Pipecat sentence-tokenization path do not call the affected model import/export functions. Pipecat stays at 1.7.0: 1.8.1 still depends on NLTK and its broader speech and metrics changes need separate review.

Validation:
- pnpm typecheck (includes build and lint): passed.
- pnpm audit: zero vulnerabilities.
- Fast lane: 3,381 tests passed initially; one suite lost its test database during concurrent cleanup, then all 45 tests in that suite passed alone.
- Browser lane: all 60 tests passed on a sequential retry after the database cleanup conflict.
- Simulator suite: 935 passed, 8 skipped.
- Frozen installs, uv lock check, and git diff --check: passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791408952&installation_model_id=431960&pr_number=313&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F313&signature=ff628524adbfda48e13f1f61504fc73bc4c33cec7afd19e56f8fd20e2d01d519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates dependency constraints and lockfiles to select patched Fastify, fast-uri, and NLTK releases.
- Raises the API Fastify minimum and locks Fastify 5.12.3.
- Updates both transitive fast-uri release lines while remaining within their parent packages' supported ranges.
- Raises and locks NLTK 3.10.3 for the simulator.
- Regenerates consistent Python dependency markers for the simulator's universal lock.

<h3>Confidence Score: 5/5</h3>

The dependency-only patch appears safe to merge, with consistent constraints and lockfile resolutions and no concrete behavioral regression identified.

The patched versions satisfy their parent constraints, automated installations remain reproducible through frozen lockfiles, and the Python marker changes preserve required dependencies across supported environments.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/package.json | Raises the Fastify dependency floor to the patched 5.12 release line. |
| pnpm-lock.yaml | Resolves Fastify 5.12.3 and patched fast-uri versions with consistent package and snapshot references. |
| apps/simulator/pyproject.toml | Raises the simulator's minimum NLTK version to 3.10.3. |
| apps/simulator/uv.lock | Locks NLTK 3.10.3 and retains complete SciPy-to-NumPy dependency coverage across supported Python resolution branches. |

<sub>Reviews (1): Last reviewed commit: ["Update vulnerable Fastify, fast-uri, and..."](https://github.com/egma-ai/egma/commit/3a479029aa66849b0672eb11b9cc54cc7a5948f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61370680)</sub>

<!-- /greptile_comment -->