### PR TITLE
Automatically release CLI and SDK version bumps on merge

### DIFF
--- a/.github/package_release.py
+++ b/.github/package_release.py
@@ -1,0 +1,221 @@
+"""Release a package when a main push increases its committed version."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import tomllib
+from pathlib import Path
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import urlopen
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGES = {
+    "cli": {
+        "manifest": "apps/cli/package.json",
+        "name": "egma-cli",
+        "prefix": "cli-v",
+    },
+    "livekit-js": {
+        "manifest": "sdks/livekit-js/package.json",
+        "name": "@egma/livekit",
+        "prefix": "livekit-js-sdk-v",
+    },
+    "python": {
+        "manifest": "sdks/python/package.json",
+        "name": "@egma/sdk-python",
+        "prefix": "python-sdk-v",
+    },
+}
+
+
+def git(*arguments: str, root: Path = ROOT) -> str:
+    return subprocess.check_output(
+        ["git", *arguments], cwd=root, text=True, timeout=60
+    ).strip()
+
+
+def stable_version(version: str) -> tuple[int, int, int]:
+    if not re.fullmatch(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)", version):
+        raise ValueError(f"Release version must be major.minor.patch: {version!r}")
+    major, minor, patch = map(int, version.split("."))
+    return major, minor, patch
+
+
+def version_at(package_id: str, revision: str, root: Path = ROOT) -> str:
+    package = PACKAGES[package_id]
+    manifest = json.loads(git("show", f"{revision}:{package['manifest']}", root=root))
+    if manifest["name"] != package["name"]:
+        raise ValueError(f"Unexpected package name in {package['manifest']}")
+    version = manifest["version"]
+    stable_version(version)
+    if package_id == "python":
+        project = tomllib.loads(
+            git("show", f"{revision}:sdks/python/pyproject.toml", root=root)
+        )["project"]
+        if project["name"] != "egma" or project["version"] != version:
+            raise ValueError("Python package.json and pyproject.toml must agree")
+    return version
+
+
+def commit_sha(value: str) -> str:
+    if not re.fullmatch(r"[0-9a-f]{40}", value) or value == "0" * 40:
+        raise ValueError("Release comparison requires an existing commit SHA")
+    return value
+
+
+def planned_version(package_id: str, event: dict, root: Path = ROOT) -> str | None:
+    after = commit_sha(event["after"])
+    current = version_at(package_id, after, root)
+    ref = event["ref"]
+    if ref.startswith("refs/tags/"):
+        expected = f"refs/tags/{PACKAGES[package_id]['prefix']}{current}"
+        if ref != expected:
+            raise ValueError(f"Tag {ref} does not match package version {current}")
+        return current
+    if ref != "refs/heads/main":
+        raise ValueError("Automatic package releases only run from main")
+    before = commit_sha(event["before"])
+    git("merge-base", "--is-ancestor", before, after, root=root)
+    previous = version_at(package_id, before, root)
+    if stable_version(current) < stable_version(previous):
+        raise ValueError(f"{package_id} version decreased from {previous} to {current}")
+    return current if current != previous else None
+
+
+def ensure_tag(tag: str, sha: str, root: Path = ROOT) -> None:
+    """Keep a release tag on its original commit, including annotated tags."""
+    reference = f"refs/tags/{tag}"
+
+    def remote_commit() -> str | None:
+        rows = git("ls-remote", "origin", reference, f"{reference}^{{}}", root=root)
+        refs = dict(line.split()[::-1] for line in rows.splitlines())
+        return refs.get(f"{reference}^{{}}", refs.get(reference))
+
+    existing = remote_commit()
+    if existing is None:
+        try:
+            git("push", "origin", f"{sha}:{reference}", root=root)
+        except subprocess.CalledProcessError:
+            # A simultaneous manual tag is acceptable only on this same commit.
+            if remote_commit() != sha:
+                raise
+    elif existing != sha:
+        raise ValueError(f"Release tag {tag} already points to {existing}, not {sha}")
+
+
+def read_json(url: str) -> dict | None:
+    try:
+        with urlopen(url, timeout=30) as response:
+            value = json.load(response)
+    except HTTPError as error:
+        if error.code == 404:
+            return None
+        raise
+    if not isinstance(value, dict):
+        raise ValueError(f"Registry returned invalid metadata: {url}")
+    return value
+
+
+def npm_url(package_id: str, version: str) -> str:
+    name = quote(PACKAGES[package_id]["name"], safe="")
+    return f"https://registry.npmjs.org/{name}/{quote(version, safe='')}"
+
+
+def published(package_id: str, version: str) -> bool:
+    if package_id == "python":
+        metadata = read_json(f"https://pypi.org/pypi/egma/{version}/json")
+        if metadata is None:
+            return False
+        filenames = {entry["filename"] for entry in metadata["urls"]}
+        return {
+            f"egma-{version}-py3-none-any.whl",
+            f"egma-{version}.tar.gz",
+        }.issubset(filenames)
+    metadata = read_json(npm_url(package_id, version))
+    if metadata is None:
+        return False
+    if (
+        metadata["name"] != PACKAGES[package_id]["name"]
+        or metadata["version"] != version
+    ):
+        raise ValueError("Registry returned a different package or version")
+    return True
+
+
+def npm_tag(package_id: str, version: str) -> str:
+    """A delayed older release must not move npm's latest tag backwards."""
+    latest = read_json(npm_url(package_id, "latest"))
+    if (
+        latest is not None
+        and stable_version(latest["version"]) > stable_version(version)
+    ):
+        return "previous"
+    return "latest"
+
+
+def prepare(package_id: str, root: Path = ROOT) -> None:
+    event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+    version = planned_version(package_id, event, root)
+    outputs = {"should_publish": "false", "version": version or "", "npm_tag": ""}
+    if version is None:
+        summary = f"{package_id}: version unchanged; no release."
+    else:
+        sha = git("rev-parse", "HEAD", root=root)
+        event_commit = git(
+            "rev-parse", f"{commit_sha(event['after'])}^{{commit}}", root=root
+        )
+        if sha != event_commit:
+            raise ValueError("Checkout does not match the release event commit")
+        tag = f"{PACKAGES[package_id]['prefix']}{version}"
+        ensure_tag(tag, sha, root)
+        complete = published(package_id, version)
+        outputs["should_publish"] = str(not complete).lower()
+        if package_id != "python" and not complete:
+            outputs["npm_tag"] = npm_tag(package_id, version)
+        summary = (
+            f"{tag} at {sha}: already published; no duplicate upload."
+            if complete
+            else f"{tag} at {sha}: package checks and publication will run."
+        )
+    with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+        for key, value in outputs.items():
+            print(f"{key}={value}", file=output)
+    print(summary)
+    if "GITHUB_STEP_SUMMARY" in os.environ:
+        with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a") as output:
+            print(summary, file=output)
+
+
+def publish_npm(package_id: str, tarball: Path, root: Path = ROOT) -> None:
+    """Refresh registry state even when GitHub reruns only the failed publish job."""
+    if package_id == "python":
+        raise ValueError("The Python SDK is published to PyPI")
+    version = version_at(package_id, "HEAD", root)
+    if published(package_id, version):
+        print(f"{PACKAGES[package_id]['name']}@{version} is already published")
+        return
+    subprocess.run(
+        ["npm", "publish", "--tag", npm_tag(package_id, version), str(tarball)],
+        cwd=root,
+        check=True,
+        timeout=300,
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["prepare", "publish-npm"])
+    parser.add_argument("package", choices=PACKAGES)
+    parser.add_argument("tarball", nargs="?", type=Path)
+    args = parser.parse_args()
+    if args.command == "prepare":
+        prepare(args.package)
+    elif args.tarball is None:
+        parser.error("publish-npm requires a tarball")
+    else:
+        publish_npm(args.package, args.tarball)

--- a/.github/test_package_release.py
+++ b/.github/test_package_release.py
@@ -1,0 +1,422 @@
+"""Exercise release decisions against committed manifests and a real tag remote."""
+
+import contextlib
+import io
+import json
+import os
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+from urllib.error import HTTPError
+from urllib.parse import unquote, urlparse
+
+import package_release
+
+
+class RepositoryTests(unittest.TestCase):
+    def setUp(self):
+        temporary = TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name) / "checkout"
+        self.origin = Path(temporary.name) / "origin.git"
+        self.root.mkdir()
+        self.git("init", "--initial-branch=main")
+        self.git("config", "user.name", "Release test")
+        self.git("config", "user.email", "release-test@example.invalid")
+        subprocess.run(
+            ["git", "init", "--bare", str(self.origin)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.git("remote", "add", "origin", str(self.origin))
+        for package in ("cli", "livekit-js", "python"):
+            self.write_version(package, "0.3.9")
+        self.before = self.commit("Initial package versions")
+
+    def git(self, *arguments):
+        return subprocess.run(
+            ["git", *arguments],
+            cwd=self.root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def write_json(self, relative_path, contents):
+        target = self.root / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(contents) + "\n")
+
+    def write_version(self, package, version):
+        if package == "cli":
+            self.write_json(
+                "apps/cli/package.json", {"name": "egma-cli", "version": version}
+            )
+        elif package == "livekit-js":
+            self.write_json(
+                "sdks/livekit-js/package.json",
+                {"name": "@egma/livekit", "version": version},
+            )
+        else:
+            self.write_json(
+                "sdks/python/package.json",
+                {"name": "@egma/sdk-python", "version": version},
+            )
+            (self.root / "sdks/python/pyproject.toml").write_text(
+                f'[project]\nname = "egma"\nversion = "{version}"\n'
+            )
+
+    def commit(self, message):
+        self.git("add", ".")
+        self.git("commit", "--quiet", "-m", message)
+        return self.git("rev-parse", "HEAD")
+
+    def push_event(self, after):
+        return {
+            "ref": "refs/heads/main",
+            "before": self.before,
+            "after": after,
+        }
+
+    def remote_tag_target(self, tag):
+        return subprocess.run(
+            ["git", "--git-dir", str(self.origin), "rev-parse", f"{tag}^{{commit}}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def prepare(self, event):
+        event_path = self.root.parent / "event.json"
+        output_path = self.root.parent / "output"
+        event_path.write_text(json.dumps(event))
+        output_path.write_text("")
+        with patch.dict(
+            os.environ,
+            {"GITHUB_EVENT_PATH": str(event_path), "GITHUB_OUTPUT": str(output_path)},
+            clear=True,
+        ), contextlib.redirect_stdout(io.StringIO()):
+            package_release.prepare("cli", self.root)
+        return dict(line.split("=", 1) for line in output_path.read_text().splitlines())
+
+    def test_reads_requested_commit_instead_of_working_tree(self):
+        self.write_version("cli", "9.0.0")
+        self.assertEqual(
+            package_release.version_at("cli", self.before, self.root), "0.3.9"
+        )
+
+    def test_releases_each_package_when_numeric_version_increases(self):
+        for package in ("cli", "livekit-js", "python"):
+            self.write_version(package, "0.3.10")
+        after = self.commit("Bump all packages")
+        for package in ("cli", "livekit-js", "python"):
+            with self.subTest(package=package):
+                self.assertEqual(
+                    package_release.planned_version(
+                        package, self.push_event(after), self.root
+                    ),
+                    "0.3.10",
+                )
+
+    def test_compares_entire_push_when_final_commit_does_not_change_version(self):
+        self.write_version("cli", "0.3.10")
+        self.commit("Bump CLI")
+        (self.root / "README.md").write_text("Unrelated change after the bump.\n")
+        after = self.commit("Update README")
+        self.assertEqual(
+            package_release.planned_version("cli", self.push_event(after), self.root),
+            "0.3.10",
+        )
+        self.assertIsNone(
+            package_release.planned_version(
+                "livekit-js", self.push_event(after), self.root
+            )
+        )
+
+    def test_unchanged_versions_do_not_release(self):
+        (self.root / "README.md").write_text("No version change.\n")
+        after = self.commit("Update README")
+        for package in ("cli", "livekit-js", "python"):
+            with self.subTest(package=package):
+                self.assertIsNone(
+                    package_release.planned_version(
+                        package, self.push_event(after), self.root
+                    )
+                )
+
+    def test_lower_versions_fail_instead_of_publishing(self):
+        for package in ("cli", "livekit-js", "python"):
+            self.write_version(package, "0.3.8")
+        after = self.commit("Lower package versions")
+        for package in ("cli", "livekit-js", "python"):
+            with self.subTest(package=package), self.assertRaises(ValueError):
+                package_release.planned_version(
+                    package, self.push_event(after), self.root
+                )
+
+    def test_invalid_and_prerelease_versions_fail(self):
+        for version in ("0.3", "v0.3.10", "0.3.10-rc.1", "0.3.10+build", "0.03.10"):
+            with self.subTest(version=version):
+                self.write_version("cli", version)
+                after = self.commit(f"Version {version}")
+                with self.assertRaises(ValueError):
+                    package_release.planned_version(
+                        "cli", self.push_event(after), self.root
+                    )
+
+    def test_rejects_wrong_package_name(self):
+        self.write_json(
+            "apps/cli/package.json", {"name": "another-package", "version": "0.3.10"}
+        )
+        after = self.commit("Wrong package identity")
+        with self.assertRaises(ValueError):
+            package_release.version_at("cli", after, self.root)
+
+    def test_python_manifests_must_have_matching_versions(self):
+        self.write_json(
+            "sdks/python/package.json",
+            {"name": "@egma/sdk-python", "version": "0.3.10"},
+        )
+        after = self.commit("Bump only the Python workspace manifest")
+        with self.assertRaises(ValueError):
+            package_release.planned_version("python", self.push_event(after), self.root)
+
+    def test_matching_manual_tags_still_release_each_package(self):
+        for package, tag in (
+            ("cli", "cli-v0.3.9"),
+            ("livekit-js", "livekit-js-sdk-v0.3.9"),
+            ("python", "python-sdk-v0.3.9"),
+        ):
+            with self.subTest(package=package):
+                self.assertEqual(
+                    package_release.planned_version(
+                        package,
+                        {"ref": f"refs/tags/{tag}", "after": self.before},
+                        self.root,
+                    ),
+                    "0.3.9",
+                )
+
+    def test_manual_tag_must_match_the_committed_version(self):
+        with self.assertRaises(ValueError):
+            package_release.planned_version(
+                "cli",
+                {"ref": "refs/tags/cli-v0.3.10", "after": self.before},
+                self.root,
+            )
+
+    def test_creates_remote_tag_and_rerun_keeps_the_same_target(self):
+        package_release.ensure_tag("cli-v0.3.9", self.before, self.root)
+        self.assertEqual(self.remote_tag_target("cli-v0.3.9"), self.before)
+        package_release.ensure_tag("cli-v0.3.9", self.before, self.root)
+        self.assertEqual(self.remote_tag_target("cli-v0.3.9"), self.before)
+
+    def test_existing_annotated_tag_is_compared_by_commit(self):
+        self.git("tag", "-a", "cli-v0.3.9", self.before, "-m", "CLI release")
+        self.git("push", "origin", "refs/tags/cli-v0.3.9")
+        package_release.ensure_tag("cli-v0.3.9", self.before, self.root)
+        self.assertEqual(self.remote_tag_target("cli-v0.3.9"), self.before)
+
+    def test_tag_collision_never_moves_the_existing_release(self):
+        self.git("tag", "cli-v0.3.9", self.before)
+        self.git("push", "origin", "refs/tags/cli-v0.3.9")
+        self.write_version("cli", "0.3.10")
+        after = self.commit("A different release commit")
+        with self.assertRaises(ValueError):
+            package_release.ensure_tag("cli-v0.3.9", after, self.root)
+        self.assertEqual(self.remote_tag_target("cli-v0.3.9"), self.before)
+
+    def test_prepare_without_bump_does_not_access_registry_or_create_tags(self):
+        (self.root / "README.md").write_text("No version change.\n")
+        after = self.commit("Update README")
+        with patch.object(package_release, "read_json") as read_json:
+            outputs = self.prepare(self.push_event(after))
+        self.assertEqual(outputs["should_publish"], "false")
+        self.assertEqual(outputs["version"], "")
+        read_json.assert_not_called()
+        self.assertEqual(self.git("ls-remote", "--tags", "origin"), "")
+
+    def test_prepare_retry_skips_upload_after_same_release_is_published(self):
+        self.write_version("cli", "0.3.10")
+        after = self.commit("Bump CLI")
+        event = self.push_event(after)
+        with patch.object(
+            package_release,
+            "read_json",
+            side_effect=[None, None, {"name": "egma-cli", "version": "0.3.10"}],
+        ) as read_json:
+            first = self.prepare(event)
+            retry = self.prepare(event)
+        self.assertEqual(first["should_publish"], "true")
+        self.assertEqual(first["npm_tag"], "latest")
+        self.assertEqual(retry["should_publish"], "false")
+        self.assertEqual(retry["version"], "0.3.10")
+        self.assertEqual(read_json.call_count, 3)
+        self.assertEqual(self.remote_tag_target("cli-v0.3.10"), after)
+        self.assertEqual(len(self.git("ls-remote", "--tags", "origin").splitlines()), 1)
+
+    def test_prepare_accepts_annotated_tag_event_object_sha(self):
+        self.git("tag", "-a", "cli-v0.3.9", self.before, "-m", "CLI release")
+        self.git("push", "origin", "refs/tags/cli-v0.3.9")
+        event = {
+            "ref": "refs/tags/cli-v0.3.9",
+            "after": self.git("rev-parse", "refs/tags/cli-v0.3.9"),
+        }
+        with patch.object(
+            package_release,
+            "read_json",
+            return_value={"name": "egma-cli", "version": "0.3.9"},
+        ):
+            outputs = self.prepare(event)
+        self.assertEqual(outputs["should_publish"], "false")
+        self.assertEqual(self.remote_tag_target("cli-v0.3.9"), self.before)
+
+    def test_prepare_rejects_checkout_of_a_different_commit_before_creating_tag(self):
+        self.write_version("cli", "0.3.10")
+        after = self.commit("Bump CLI")
+        (self.root / "README.md").write_text("A later commit.\n")
+        self.commit("Advance checkout")
+        with self.assertRaises(ValueError):
+            self.prepare(self.push_event(after))
+        self.assertEqual(self.git("ls-remote", "--tags", "origin"), "")
+
+    def test_publish_job_retry_refreshes_latest_after_prepare_finished(self):
+        self.write_version("cli", "0.3.10")
+        after = self.commit("Bump CLI")
+        tarball = self.root.parent / "egma-cli-0.3.10.tgz"
+        with patch.object(
+            package_release,
+            "read_json",
+            side_effect=[None, {"version": "0.3.9"}, None, {"version": "0.3.11"}],
+        ):
+            prepared = self.prepare(self.push_event(after))
+            self.assertEqual(prepared["npm_tag"], "latest")
+            with patch.object(
+                package_release, "version_at", return_value="0.3.10"
+            ), patch.object(package_release.subprocess, "run") as run:
+                package_release.publish_npm("cli", tarball, self.root)
+        run.assert_called_once_with(
+            ["npm", "publish", "--tag", "previous", str(tarball)],
+            cwd=self.root,
+            check=True,
+            timeout=300,
+        )
+
+
+class RegistryTests(unittest.TestCase):
+    def test_publish_job_retry_skips_an_already_published_package(self):
+        for package, name in (("cli", "egma-cli"), ("livekit-js", "@egma/livekit")):
+            with self.subTest(package=package), patch.object(
+                package_release, "version_at", return_value="0.3.10"
+            ), patch.object(
+                package_release,
+                "read_json",
+                return_value={"name": name, "version": "0.3.10"},
+            ), patch.object(
+                package_release.subprocess, "run"
+            ) as run, contextlib.redirect_stdout(io.StringIO()):
+                package_release.publish_npm(package, Path("package.tgz"))
+            run.assert_not_called()
+
+    def test_publish_job_does_not_upload_when_either_registry_check_fails(self):
+        failure = HTTPError("https://registry.invalid", 503, "Unavailable", {}, None)
+        for responses in ([failure], [None, failure]):
+            with self.subTest(responses=responses), patch.object(
+                package_release, "version_at", return_value="0.3.10"
+            ), patch.object(
+                package_release, "read_json", side_effect=responses
+            ), patch.object(
+                package_release.subprocess, "run"
+            ) as run, self.assertRaises(HTTPError):
+                package_release.publish_npm("cli", Path("package.tgz"))
+            run.assert_not_called()
+
+    def test_npm_queries_the_exact_package_version(self):
+        for package, name in (("cli", "egma-cli"), ("livekit-js", "@egma/livekit")):
+            with self.subTest(package=package), patch.object(
+                package_release,
+                "read_json",
+                return_value={"name": name, "version": "0.3.10"},
+            ) as read_json:
+                self.assertTrue(package_release.published(package, "0.3.10"))
+                url = urlparse(read_json.call_args.args[0])
+                self.assertEqual(url.netloc, "registry.npmjs.org")
+                self.assertEqual(unquote(url.path), f"/{name}/0.3.10")
+
+    def test_absent_registry_version_is_not_published(self):
+        for package in ("cli", "livekit-js", "python"):
+            with self.subTest(package=package), patch.object(
+                package_release, "read_json", return_value=None
+            ):
+                self.assertFalse(package_release.published(package, "0.3.10"))
+
+    def test_python_is_complete_only_after_both_distributions_exist(self):
+        wheel = {"filename": "egma-0.3.10-py3-none-any.whl"}
+        source = {"filename": "egma-0.3.10.tar.gz"}
+        other = {"filename": "egma-0.3.9.tar.gz"}
+        for files, expected in (
+            ([], False),
+            ([wheel], False),
+            ([source], False),
+            ([wheel, other], False),
+            ([wheel, source], True),
+        ):
+            with self.subTest(files=files), patch.object(
+                package_release,
+                "read_json",
+                return_value={"info": {"version": "0.3.10"}, "urls": files},
+            ) as read_json:
+                self.assertEqual(
+                    package_release.published("python", "0.3.10"), expected
+                )
+                read_json.assert_called_once_with("https://pypi.org/pypi/egma/0.3.10/json")
+
+    def test_registry_failures_do_not_become_permission_to_publish(self):
+        for package in ("cli", "livekit-js", "python"):
+            failure = HTTPError(
+                "https://registry.invalid", 503, "Unavailable", {}, None
+            )
+            with self.subTest(package=package), patch.object(
+                package_release, "read_json", side_effect=failure
+            ), self.assertRaises(HTTPError):
+                package_release.published(package, "0.3.10")
+
+    def test_delayed_npm_release_does_not_replace_a_newer_latest_version(self):
+        for latest, expected in (
+            (None, "latest"),
+            ({"version": "0.3.9"}, "latest"),
+            ({"version": "0.3.10"}, "latest"),
+            ({"version": "0.3.11"}, "previous"),
+            ({"version": "0.4.0"}, "previous"),
+        ):
+            with self.subTest(latest=latest), patch.object(
+                package_release, "read_json", return_value=latest
+            ):
+                self.assertEqual(package_release.npm_tag("cli", "0.3.10"), expected)
+
+    def test_read_json_returns_none_only_for_missing_registry_metadata(self):
+        for status in (404, 401, 429, 500, 503):
+            failure = HTTPError("https://registry.invalid", status, "Failure", {}, None)
+            with self.subTest(status=status), patch.object(
+                package_release, "urlopen", side_effect=failure
+            ):
+                if status == 404:
+                    self.assertIsNone(
+                        package_release.read_json("https://registry.invalid")
+                    )
+                else:
+                    with self.assertRaises(HTTPError):
+                        package_release.read_json("https://registry.invalid")
+
+    def test_read_json_rejects_invalid_registry_response_shape(self):
+        with patch.object(
+            package_release, "urlopen", return_value=io.BytesIO(b"[]")
+        ), self.assertRaises(ValueError):
+            package_release.read_json("https://registry.invalid")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,27 +1,62 @@
 name: Release CLI
 
-# Publish CLI releases from a cli-v<version> tag matching apps/cli/package.json.
-# Update and commit the package version before pushing the tag.
-# Publishing uses npm trusted OIDC authentication configured for this workflow;
-# merging to main alone does not trigger this workflow.
+# A version increase on main creates its release tag and publishes the CLI.
+# Manual cli-v<version> tags use the same checks and npm trusted publisher.
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "cli-v*"
+
+concurrency:
+  group: release-cli
+  queue: max
 
 permissions:
   contents: read
   id-token: write
 
 jobs:
-  release:
+  prepare:
+    name: Prepare release
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    outputs:
+      should_publish: ${{ steps.release.outputs.should_publish }}
+      version: ${{ steps.release.outputs.version }}
+      npm_tag: ${{ steps.release.outputs.npm_tag }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Compare versions and prepare the release tag
+        id: release
+        run: python3 .github/package_release.py prepare cli
+
+  release:
+    needs: prepare
+    if: needs.prepare.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+      NPM_TAG: ${{ needs.prepare.outputs.npm_tag }}
     steps:
       # Actions are pinned to a commit, not a tag. A tag can be moved; this job
       # holds npm publishing authority, so what it runs must not change under
       # it. The trailing comment is the human-readable version each SHA is.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         # Version comes from "packageManager" in the root package.json.
@@ -38,18 +73,16 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Check the tag matches the version
-        # Catches the classic slip: tagged cli-v0.2.0, shipped 0.1.0.
+      - name: Check the release matches the package version
         run: |
-          tagged="${GITHUB_REF_NAME#cli-v}"
           package="$(node -p "require('./apps/cli/package.json').name")"
           packaged="$(node -p "require('./apps/cli/package.json').version")"
           if [ "$package" != "egma-cli" ]; then
             echo "apps/cli/package.json names $package, expected egma-cli." >&2
             exit 1
           fi
-          if [ "$tagged" != "$packaged" ]; then
-            echo "Tag says $tagged, apps/cli/package.json says $packaged." >&2
+          if [ "$RELEASE_VERSION" != "$packaged" ]; then
+            echo "Release says $RELEASE_VERSION, apps/cli/package.json says $packaged." >&2
             exit 1
           fi
           echo "Releasing egma-cli $packaged."
@@ -113,7 +146,7 @@ jobs:
         run: |
           set -e
           status=0
-          out="$(npm publish --dry-run "${{ steps.pack.outputs.tarball }}" 2>&1)" || status=$?
+          out="$(npm publish --dry-run --tag "$NPM_TAG" "${{ steps.pack.outputs.tarball }}" 2>&1)" || status=$?
           echo "$out"
           if echo "$out" | grep -qi "auto-corrected some errors"; then
             echo "::error::npm would rewrite the packed manifest before publishing. Fix it rather than shipping the rewrite." >&2
@@ -124,4 +157,4 @@ jobs:
       - name: Publish to npm
         # npm, not pnpm: OIDC trusted publishing lives in the npm CLI.
         # No NODE_AUTH_TOKEN — the OIDC exchange is the credential.
-        run: npm publish "${{ steps.pack.outputs.tarball }}"
+        run: python3 .github/package_release.py publish-npm cli "${{ steps.pack.outputs.tarball }}"

--- a/.github/workflows/release-livekit-js-sdk.yml
+++ b/.github/workflows/release-livekit-js-sdk.yml
@@ -1,9 +1,7 @@
 name: Release LiveKit JavaScript SDK
 
-# Publishing is one deliberate tag push. Merging does not publish.
-#
-#   git tag livekit-js-sdk-v0.3.0
-#   git push origin livekit-js-sdk-v0.3.0
+# A version increase on main creates its release tag and publishes the SDK.
+# Manual livekit-js-sdk-v<version> tags use the same release checks.
 #
 # npm must trust this repository, workflow, and @egma/livekit package. GitHub
 # then supplies one short-lived OIDC credential. No long-lived npm token is
@@ -11,20 +9,54 @@ name: Release LiveKit JavaScript SDK
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "livekit-js-sdk-v*"
+
+concurrency:
+  group: release-livekit-js-sdk
+  queue: max
 
 permissions:
   contents: read
   id-token: write
 
 jobs:
+  prepare:
+    name: Prepare release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    outputs:
+      should_publish: ${{ steps.release.outputs.should_publish }}
+      version: ${{ steps.release.outputs.version }}
+      npm_tag: ${{ steps.release.outputs.npm_tag }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Compare versions and prepare the release tag
+        id: release
+        run: python3 .github/package_release.py prepare livekit-js
+
   compatibility:
     name: LiveKit JS compatibility
+    needs: prepare
+    if: needs.prepare.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
@@ -52,12 +84,18 @@ jobs:
 
   release:
     name: Verify and publish
-    needs: compatibility
+    needs: [prepare, compatibility]
+    if: needs.prepare.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+      NPM_TAG: ${{ needs.prepare.outputs.npm_tag }}
     steps:
       # This workflow holds npm publishing authority, so every action is pinned
       # to the commit behind the human-readable version in its comment.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         # Version comes from "packageManager" in the root package.json.
@@ -73,12 +111,11 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Check the tag matches the package version
+      - name: Check the release matches the package version
         run: |
-          tagged="${GITHUB_REF_NAME#livekit-js-sdk-v}"
           packaged="$(node -p "require('./sdks/livekit-js/package.json').version")"
-          if [ "$tagged" != "$packaged" ]; then
-            echo "Tag says $tagged and sdks/livekit-js/package.json says $packaged." >&2
+          if [ "$RELEASE_VERSION" != "$packaged" ]; then
+            echo "Release says $RELEASE_VERSION and sdks/livekit-js/package.json says $packaged." >&2
             exit 1
           fi
           echo "Releasing @egma/livekit $packaged."
@@ -163,7 +200,7 @@ jobs:
         run: |
           set -e
           status=0
-          out="$(npm publish --dry-run "${{ steps.pack.outputs.tarball }}" 2>&1)" || status=$?
+          out="$(npm publish --dry-run --tag "$NPM_TAG" "${{ steps.pack.outputs.tarball }}" 2>&1)" || status=$?
           echo "$out"
           if echo "$out" | grep -qi "auto-corrected some errors"; then
             echo "::error::npm would rewrite the packed manifest before publishing." >&2
@@ -172,4 +209,4 @@ jobs:
           exit "$status"
 
       - name: Publish to npm
-        run: npm publish "${{ steps.pack.outputs.tarball }}"
+        run: python3 .github/package_release.py publish-npm livekit-js "${{ steps.pack.outputs.tarball }}"

--- a/.github/workflows/release-python-sdk.yml
+++ b/.github/workflows/release-python-sdk.yml
@@ -1,9 +1,7 @@
 name: Release Python SDK
 
-# Publishing is one deliberate tag push. Merging does not publish.
-#
-#   git tag python-sdk-v0.3.0
-#   git push origin python-sdk-v0.3.0
+# A version increase on main creates its release tag and publishes the SDK.
+# Manual python-sdk-v<version> tags use the same release checks.
 #
 # PyPI must trust this repository, workflow, and `pypi` environment. GitHub
 # then supplies one short-lived OIDC credential. No long-lived PyPI token is
@@ -11,16 +9,50 @@ name: Release Python SDK
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "python-sdk-v*"
+
+concurrency:
+  group: release-python-sdk
+  queue: max
 
 permissions:
   contents: read
 
 jobs:
+  prepare:
+    name: Prepare release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    outputs:
+      should_publish: ${{ steps.release.outputs.should_publish }}
+      version: ${{ steps.release.outputs.version }}
+      npm_tag: ${{ steps.release.outputs.npm_tag }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Compare versions and prepare the release tag
+        id: release
+        run: python3 .github/package_release.py prepare python
+
   release:
     name: Verify and publish
+    needs: prepare
+    if: needs.prepare.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
     environment:
       name: pypi
       url: https://pypi.org/p/egma
@@ -32,6 +64,8 @@ jobs:
       # Every action is pinned to the commit behind its release tag. This job
       # holds publication authority, so a moved tag must not change its code.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -43,15 +77,14 @@ jobs:
           # silently change build backends because the CLI moved forward.
           version: "0.11.33"
 
-      - name: Check the tag matches both package versions
+      - name: Check the release matches both package versions
         working-directory: sdks/python
         run: |
           set -e
-          tagged="${GITHUB_REF_NAME#python-sdk-v}"
           packaged="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
           workspace="$(python -c 'import json; print(json.load(open("package.json"))["version"])')"
-          if [ "$tagged" != "$packaged" ] || [ "$packaged" != "$workspace" ]; then
-            echo "Tag says $tagged, pyproject.toml says $packaged, and package.json says $workspace." >&2
+          if [ "$RELEASE_VERSION" != "$packaged" ] || [ "$packaged" != "$workspace" ]; then
+            echo "Release says $RELEASE_VERSION, pyproject.toml says $packaged, and package.json says $workspace." >&2
             exit 1
           fi
           echo "Releasing egma $packaged."
@@ -110,7 +143,7 @@ jobs:
               def add_shutdown_callback(self, callback):
                   self.callbacks.append(callback)
 
-          expected = os.environ["GITHUB_REF_NAME"].removeprefix("python-sdk-v")
+          expected = os.environ["RELEASE_VERSION"]
           assert version("egma") == expected
           assert version("openai").split(".", 1)[0] == "2"
           assert agents.JobContext is not None
@@ -182,3 +215,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: sdks/python/dist/
+          skip-existing: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
         # Builds the workspace, then the tests against it, then the web app.
         run: pnpm typecheck
 
-      - name: Check compatibility job failure handling
+      - name: Test CI and release helpers
         run: python3 -B -m unittest discover -s .github -p 'test_*.py'
 
   fast:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,8 @@ The first open-source platform purpose-built to help teams shipping voice agents
 
 1. whenever you are taking to the developer iterating on this project with you - speak in simple human language, no overcomplicated jargons. always talk in ASD-STE100 Simplified Technical English. 
 2. trace the full story (what is being worked on, why its important, what's the decsion in front and its consequences). be truthful. 
-3. for a batch of UI annotations, inventory every comment first, group the work by product surface with one owner per surface, finish each group before one independent review, then run one integrated test, build, and browser proof.
 4. whenever you raise or update a pull request, monitor every required CI check and the Greptile review after the latest push. Fix test failures and applicable Greptile comments on the same branch. Reply with a clear reason when a Greptile comment should not be applied. Do not report the pull request as ready until every required check passes and every Greptile thread is fixed or answered.
+5. If a set of changes require new release of CLI or any SDKs, clearly tell the developer after the PR is ready to merge and mention this in PR description. Bump the version as part of the same effort so that the release happens as soon as merge. 
 
 # design system
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egma-cli",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "description": "Promptless commands for integrating voice agents with Egma.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Merging a CLI or SDK version bump currently leaves npm and PyPI unchanged until a developer manually creates a release tag. The existing package workflows now compare the versions before and after a push to main, create the matching tag on the merged commit, and run their existing checks and trusted publication. Unchanged versions do not publish.

Release retries reuse the original tag, skip completed uploads, and recheck npm immediately before publication so an older failed job cannot move latest backwards. Python retries can finish a partial wheel/source upload. Package workflows queue without canceling pending releases. The existing publisher workflow names and PyPI environment remain unchanged.

**Release on merge: egma-cli 0.3.4.** This includes the current CLI request change needed by the deployed run API. Existing CLI installations must upgrade. SDK versions are unchanged, so this PR does not publish an SDK. Includes the requested AGENTS.md rule to bump required package versions and identify releases in PR descriptions.

Validation:
- `pnpm build` passed, including lint and generated API checks.
- All 28 CI helper tests passed, including real temporary Git histories/remotes, unchanged and increased versions, tag collisions, annotated tags, registry failures, partial PyPI uploads, and selective npm job retries.
- Ruff passed. Workflow YAML and embedded shell syntax passed. Actionlint passed with only its unsupported `concurrency.queue` key diagnostic excluded; `queue: max` is documented by GitHub: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791414620&installation_model_id=431960&pr_number=314&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F314&signature=61b0c04d51bc536c3d5ce25cf29757cb3ce682928c1f4ad1c2cc38dc8ab0ee39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes package releases from manual tag-driven publication to automatic publication when a package version increases on `main`.
- Adds a shared helper that compares committed versions, creates immutable release tags, checks registry state, and makes retries idempotent.
- Updates the CLI, LiveKit JavaScript SDK, and Python SDK workflows to use the helper while preserving their existing validation and trusted-publishing paths.
- Prevents delayed npm jobs from moving `latest` to an older version and supports partial PyPI upload retries.
- Adds release-helper tests and bumps `egma-cli` from 0.3.3 to 0.3.4.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no actionable release correctness or security issue remains.

Release decisions are tied to validated committed versions and immutable event SHAs, publication paths preserve existing checks, and retries avoid duplicate uploads or npm latest-tag regression.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/package_release.py | Adds validated version planning, immutable tag creation, registry completion checks, and retry-safe npm publication. |
| .github/test_package_release.py | Covers version comparisons, tag forms and collisions, registry failures, retries, and partial Python publication state. |
| .github/workflows/release-cli.yml | Publishes CLI version increases from main while retaining package build and installation checks. |
| .github/workflows/release-livekit-js-sdk.yml | Adds automatic LiveKit SDK release preparation and retry-safe npm publication around existing compatibility checks. |
| .github/workflows/release-python-sdk.yml | Adds automatic Python SDK release preparation and partial-upload recovery through skip-existing publication. |
| apps/cli/package.json | Bumps the CLI release version from 0.3.3 to 0.3.4. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Push[Push to main or matching release tag] --> Prepare[Read event and committed package versions]
  Prepare --> Changed{Version increased or valid manual tag?}
  Changed -->|No| Stop[Finish without publication]
  Changed -->|Yes| Tag[Verify or create immutable release tag]
  Tag --> Registry{Required artifacts already published?}
  Registry -->|Yes| Done[Finish without duplicate upload]
  Registry -->|No| Checks[Build, test, and inspect package]
  Checks --> Publish{Registry}
  Publish -->|npm| Npm[Recheck version and latest tag, then publish]
  Publish -->|PyPI| PyPI[Upload missing wheel or source distribution]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Release CLI and SDK version bumps automa..."](https://github.com/egma-ai/egma/commit/894f51abd421fbdb55f0497b6384bac88d978076) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61391647)</sub>

<!-- /greptile_comment -->