### PR TITLE
Wait for final Retell and LiveKit evidence before grading

### DIFF
--- a/apps/api/src/retell-simulation-ingestion.ts
+++ b/apps/api/src/retell-simulation-ingestion.ts
@@ -4,55 +4,30 @@ import type { FastifyBaseLogger } from "fastify";
 import { IngestionUnavailableError } from "./ingestion/accept.ts";
 import { fileSimulationEvidence } from "./ingestion/simulation-ingestion.ts";
 import { platformEvent, safeExceptionType } from "./platform-log.ts";
-import { getRetellCall, type RetellReach } from "./retell/api.ts";
+import type { RetellReach, RetrievedCall } from "./retell/api.ts";
+import {
+  pollRetellSimulationCall,
+  type RetellSimulationPollOptions,
+} from "./retell/poll.ts";
 import {
   normaliseRetellCall,
-  retellCallDocumentIsComplete,
+  retellCallHasFinalTranscript,
   type RetellCall,
 } from "./retell/normalise.ts";
 
 /**
- * Fetch the agent POV of a completed Retell simulation using its connection
- * credential. Reuse production normalization, then file with simulation
- * attribution and the simulation trace ID.
- *
- * Await the first fetch. Retry missing or incomplete documents in the
- * background with bounded, unreferenced timers. Do not wait for call_analysis.
- * File once per invocation, using the latest fetched document after retries;
- * filing thin and then fuller evidence would conflict under stable span IDs.
- * Log fetch and filing failures without failing the simulation report.
+ * Fetch a completed simulation's Retell transcript through its connection key.
+ * Await the first request, then poll in the background for up to four minutes.
+ * File only the final usable record, once; incomplete records would prevent a
+ * later recovery from using the same stable span IDs. Do not wait for analysis.
  * Background retries are not durable across process shutdown.
  */
 
-/** Where the pull asks, and what does the asking — the deployment's own reach. */
 export type RetellSimulationPullReach = RetellReach;
 
-/**
- * How long the pull waits before each retry of a thin record, in order.
- *
- * Three attempts over about twenty seconds, which sits inside the thirty-second
- * bound ADR-0024 §6 puts on how long grading waits for an agent's POV. Past that
- * bound the record says the POV is incomplete and Regrade is what a late arrival
- * is picked up by, so a fourth attempt would be spending a request on a record
- * nothing is waiting for any more.
- */
-const RETRY_WAITS_MILLISECONDS = [5_000, 15_000] as const;
-
-/** Everything about the pull a test needs to move rather than wait out. */
-export type RetellSimulationPullOptions = {
+export type RetellSimulationPullOptions = RetellSimulationPollOptions & {
   readonly now?: number | undefined;
-  /** The waits between attempts. Empty makes the one immediate attempt final. */
-  readonly retryWaitsMilliseconds?: readonly number[] | undefined;
-  /** How the wait itself happens. The default is an `unref`'d timer. */
-  readonly sleep?: ((milliseconds: number) => Promise<void>) | undefined;
 };
-
-/** A wait that never holds the process open on its own account. */
-function waiting(milliseconds: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, milliseconds).unref();
-  });
-}
 
 function providerText(value: unknown): string {
   return typeof value === "string" || typeof value === "number"
@@ -93,9 +68,6 @@ export async function pullRetellSimulationRecord(
   log: FastifyBaseLogger,
   options: RetellSimulationPullOptions = {},
 ): Promise<void> {
-  const waits = options.retryWaitsMilliseconds ?? RETRY_WAITS_MILLISECONDS;
-  const sleep = options.sleep ?? waiting;
-
   let pull;
   try {
     pull = await resolveRetellSimulationPull(auth, simulationId);
@@ -104,21 +76,15 @@ export async function pullRetellSimulationRecord(
   }
   if (pull === undefined) return;
 
-  const ask = async (): Promise<RetellCall | undefined> => {
-    const answered = await getRetellCall(pull.apiKey, pull.providerReference, {
+  const calls = pollRetellSimulationCall(
+    pull.apiKey,
+    pull.providerReference,
+    {
       ...reach,
       ...(pull.baseUrl === null ? {} : { url: pull.baseUrl }),
-    });
-    if (answered.kind === "call") return answered.call;
-    log.warn(
-      platformEvent(
-        "egma.simulation.retell.pull.unavailable",
-        "Retell did not answer with the call record of a simulation that ended",
-        { simulation_id: simulationId, outcome: answered.kind },
-      ),
-    );
-    return undefined;
-  };
+    },
+    options,
+  );
 
   const file = async (call: RetellCall): Promise<void> => {
     const projectId = pull.standing.auth.projectId;
@@ -145,69 +111,51 @@ export async function pullRetellSimulationRecord(
     ]);
   };
 
-  let held: RetellCall | undefined;
-  try {
-    held = await ask();
-  } catch (cause) {
-    // **A throw here is the transport, not Retell's answer.** A blip on the
-    // first attempt is the exact thing the retries below exist for, so it is
-    // said and then carried past — returning here would spend the whole
-    // bound on one bad socket, and a terminal report resend deliberately starts no
-    // second pull, so this simulation would lose its agent POV for good.
-    said(log, simulationId, "the first attempt failed", cause);
-  }
-
-  if (held !== undefined && retellCallDocumentIsComplete(held)) {
-    // Complete on the first ask: filed once, and never asked again. Evidence
-    // is filed once and it is the fetch that retries (ADR-0014's identity
-    // rule), so a filing that fails is reported rather than re-attempted.
-    try {
-      await file(held);
-    } catch (cause) {
-      said(log, simulationId, "the record could not be filed", cause);
-    }
-    return;
-  }
-
-  if (waits.length === 0) {
-    // Nothing more to try. Whatever the one attempt held is what there is, and
-    // a document that is merely thin is still evidence.
-    if (held === undefined) return;
-    try {
-      await file(held);
-    } catch (cause) {
-      said(log, simulationId, "the record could not be filed", cause);
-    }
-    return;
-  }
-
-  // The record was thin, or Retell did not answer. Everything from here runs
-  // after the door has answered, and nothing after this point can reach it.
-  void (async () => {
-    for (const wait of waits) {
-      await sleep(wait);
+  const accept = async (answer: RetrievedCall): Promise<boolean> => {
+    if (answer.kind === "call" && retellCallHasFinalTranscript(answer.call)) {
       try {
-        const again = await ask();
-        if (again !== undefined) held = again;
-        if (again !== undefined && retellCallDocumentIsComplete(again)) break;
+        await file(answer.call);
       } catch (cause) {
-        said(log, simulationId, "a retry failed", cause);
+        said(log, simulationId, "the record could not be filed", cause);
       }
+      return true;
     }
-    if (held === undefined) {
+    if (answer.kind !== "call") {
+      log.warn(
+        platformEvent(
+          "egma.simulation.retell.pull.unavailable",
+          "Retell did not answer with the call record of a simulation that ended",
+          { simulation_id: simulationId, outcome: answer.kind },
+        ),
+      );
+    }
+    return false;
+  };
+
+  try {
+    const first = await calls.next();
+    if (!first.done && await accept(first.value)) {
+      await calls.return();
+      return;
+    }
+  } catch (cause) {
+    return said(log, simulationId, "the first attempt failed", cause);
+  }
+
+  void (async () => {
+    try {
+      for await (const answer of calls) {
+        if (await accept(answer)) return;
+      }
       log.warn(
         platformEvent(
           "egma.simulation.retell.pull.incomplete",
-          "Retell never answered with this simulation's call record; the agent POV is incomplete",
+          "Retell's final transcript is not available yet; the agent POV is incomplete",
           { simulation_id: simulationId },
         ),
       );
-      return;
-    }
-    try {
-      await file(held);
     } catch (cause) {
-      said(log, simulationId, "the record could not be filed", cause);
+      said(log, simulationId, "a retry failed", cause);
     }
   })();
 }

--- a/apps/api/src/retell-simulation-ingestion.ts
+++ b/apps/api/src/retell-simulation-ingestion.ts
@@ -25,7 +25,10 @@ import {
 
 export type RetellSimulationPullReach = RetellReach;
 
-export type RetellSimulationPullOptions = RetellSimulationPollOptions & {
+export type RetellSimulationPullOptions = Omit<
+  RetellSimulationPollOptions,
+  "completionReceivedAtMilliseconds"
+> & {
   readonly now?: number | undefined;
 };
 
@@ -83,7 +86,10 @@ export async function pullRetellSimulationRecord(
       ...reach,
       ...(pull.baseUrl === null ? {} : { url: pull.baseUrl }),
     },
-    options,
+    {
+      ...options,
+      completionReceivedAtMilliseconds: pull.completionReceivedAt.getTime(),
+    },
   );
 
   const file = async (call: RetellCall): Promise<void> => {

--- a/apps/api/src/retell/normalise.ts
+++ b/apps/api/src/retell/normalise.ts
@@ -131,7 +131,7 @@ function extent(call: RetellCall, now: number): {
   return {
     startedAt: started,
     endedAt: end.at,
-    whole: true,
+    whole: end.reported,
     reported: end.reported,
   };
 }
@@ -430,12 +430,22 @@ function turnsIn(call: RetellCall): Transcript {
   return { turns, toolCalls, whole };
 }
 
-/** Whether a full Get Call document can be normalized without inventing facts. */
+/** Whether Retell reported a terminal record that can be read without fallbacks. */
 export function retellCallDocumentIsComplete(call: RetellCall): boolean {
+  const status = call["call_status"];
   return (
-    text(call["call_id"]) !== "" &&
+    text(call["call_id"]).trim() !== "" &&
+    (status === "ended" || status === "error" || status === "not_connected") &&
     extent(call, 0).whole &&
     turnsIn(call).whole
+  );
+}
+
+/** Simulation grading needs spoken evidence in addition to a finished record. */
+export function retellCallHasFinalTranscript(call: RetellCall): boolean {
+  return (
+    retellCallDocumentIsComplete(call) &&
+    turnsIn(call).turns.some((turn) => turn.text.trim() !== "")
   );
 }
 

--- a/apps/api/src/retell/poll.ts
+++ b/apps/api/src/retell/poll.ts
@@ -13,6 +13,8 @@ const RETRY_WAITS_MILLISECONDS = [
 const REQUEST_TIMEOUT_MILLISECONDS = 5_000;
 
 export type RetellSimulationPollOptions = {
+  /** Stored completion receipt; shared with the grading evidence deadline. */
+  readonly completionReceivedAtMilliseconds: number;
   /** Gaps between planned attempts. Empty makes the immediate attempt final. */
   readonly retryWaitsMilliseconds?: readonly number[] | undefined;
   /** The default wait uses an unreferenced timer. */
@@ -46,32 +48,40 @@ async function askWithin(
 }
 
 /**
- * Read at fixed offsets from the first request; request time does not extend
- * the schedule. Yield each result so the report can await just the first read.
- * Only a final transcript stops polling successfully. Never overlap requests.
+ * Read immediately within the stored completion deadline, then at fixed offsets
+ * from that receipt. Skip elapsed slots after delayed starts or timers; never
+ * extend the deadline or overlap requests. Yield the first read to the report.
  */
 export async function* pollRetellSimulationCall(
   apiKey: string,
   callId: string,
   reach: RetellReach,
-  options: RetellSimulationPollOptions = {},
+  options: RetellSimulationPollOptions,
 ): AsyncGenerator<RetrievedCall, void> {
   const waits = options.retryWaitsMilliseconds ?? RETRY_WAITS_MILLISECONDS;
   const sleep = options.sleep ?? waiting;
   const canceled = (): boolean => reach.signal?.aborted === true;
-  const startedAt = Date.now();
-  const deadline = startedAt + AGENT_POV_BOUND_SECONDS * 1_000;
-  let plannedAt = startedAt;
-  let retryAfter = startedAt;
+  const receivedAt = options.completionReceivedAtMilliseconds;
+  if (!Number.isFinite(receivedAt)) return;
+  const deadline = receivedAt + AGENT_POV_BOUND_SECONDS * 1_000;
+  let plannedAt = receivedAt;
+  let retryAfter = receivedAt;
+  let lastAttemptAt = Number.NEGATIVE_INFINITY;
 
-  for (const gap of [0, ...waits]) {
+  for (const [attempt, gap] of [0, ...waits].entries()) {
     plannedAt += gap;
     if (canceled() || plannedAt >= deadline) return;
+    if (
+      attempt > 0 &&
+      (plannedAt < Date.now() || plannedAt <= lastAttemptAt)
+    ) continue;
     if (plannedAt < retryAfter) continue;
-    const wait = plannedAt - Date.now();
+    const wait = attempt === 0 ? 0 : plannedAt - Date.now();
     if (wait > 0) await sleep(wait);
-    const remaining = deadline - Date.now();
+    const requestedAt = Date.now();
+    const remaining = deadline - requestedAt;
     if (canceled() || remaining <= 0) return;
+    lastAttemptAt = requestedAt;
 
     const answer = await askWithin(
       apiKey,

--- a/apps/api/src/retell/poll.ts
+++ b/apps/api/src/retell/poll.ts
@@ -1,0 +1,91 @@
+import { AGENT_POV_BOUND_SECONDS } from "@egma/db";
+
+import { getRetellCall, type RetellReach, type RetrievedCall } from "./api.ts";
+import { retellCallHasFinalTranscript } from "./normalise.ts";
+
+/** Planned gaps: every five seconds for one minute, then bounded backoff. */
+const RETRY_WAITS_MILLISECONDS = [
+  5_000, 5_000, 5_000, 5_000, 5_000, 5_000,
+  5_000, 5_000, 5_000, 5_000, 5_000, 5_000,
+  10_000, 20_000, 40_000, 60_000, 50_000,
+] as const;
+
+const REQUEST_TIMEOUT_MILLISECONDS = 5_000;
+
+export type RetellSimulationPollOptions = {
+  /** Gaps between planned attempts. Empty makes the immediate attempt final. */
+  readonly retryWaitsMilliseconds?: readonly number[] | undefined;
+  /** The default wait uses an unreferenced timer. */
+  readonly sleep?: ((milliseconds: number) => Promise<void>) | undefined;
+};
+
+function waiting(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds).unref());
+}
+
+/** Bound both the request and its response body with the same abort signal. */
+async function askWithin(
+  apiKey: string,
+  callId: string,
+  reach: RetellReach,
+  timeoutMilliseconds: number,
+): Promise<RetrievedCall> {
+  const controller = new AbortController();
+  const upstream = reach.signal;
+  const abortFromUpstream = (): void => controller.abort(upstream?.reason);
+  if (upstream?.aborted === true) abortFromUpstream();
+  else upstream?.addEventListener("abort", abortFromUpstream, { once: true });
+  const timer = setTimeout(() => controller.abort(), timeoutMilliseconds);
+  timer.unref();
+  try {
+    return await getRetellCall(apiKey, callId, { ...reach, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+    upstream?.removeEventListener("abort", abortFromUpstream);
+  }
+}
+
+/**
+ * Read at fixed offsets from the first request; request time does not extend
+ * the schedule. Yield each result so the report can await just the first read.
+ * Only a final transcript stops polling successfully. Never overlap requests.
+ */
+export async function* pollRetellSimulationCall(
+  apiKey: string,
+  callId: string,
+  reach: RetellReach,
+  options: RetellSimulationPollOptions = {},
+): AsyncGenerator<RetrievedCall, void> {
+  const waits = options.retryWaitsMilliseconds ?? RETRY_WAITS_MILLISECONDS;
+  const sleep = options.sleep ?? waiting;
+  const canceled = (): boolean => reach.signal?.aborted === true;
+  const startedAt = Date.now();
+  const deadline = startedAt + AGENT_POV_BOUND_SECONDS * 1_000;
+  let plannedAt = startedAt;
+  let retryAfter = startedAt;
+
+  for (const gap of [0, ...waits]) {
+    plannedAt += gap;
+    if (canceled() || plannedAt >= deadline) return;
+    if (plannedAt < retryAfter) continue;
+    const wait = plannedAt - Date.now();
+    if (wait > 0) await sleep(wait);
+    const remaining = deadline - Date.now();
+    if (canceled() || remaining <= 0) return;
+
+    const answer = await askWithin(
+      apiKey,
+      callId,
+      reach,
+      Math.min(REQUEST_TIMEOUT_MILLISECONDS, remaining),
+    );
+    if (answer.kind === "refused" && answer.retryAfterMilliseconds !== undefined) {
+      retryAfter = Date.now() + answer.retryAfterMilliseconds;
+    }
+    yield answer;
+    if (
+      answer.kind === "invalid-key" ||
+      (answer.kind === "call" && retellCallHasFinalTranscript(answer.call))
+    ) return;
+  }
+}

--- a/apps/api/src/routes/simulations.ts
+++ b/apps/api/src/routes/simulations.ts
@@ -201,18 +201,9 @@ function agentPovIncomplete(
   }
   if (transcript?.agentEvidenceIncomplete === true) return true;
   if (transcript?.agentEvidenceComplete === true) return false;
-  // The wait began when the conversation ended, on the earlier of the two
-  // clocks that answer for that — the same reading grading itself takes, so a
-  // report from a machine running ahead cannot make this say "still waiting"
-  // forever.
-  const reported = simulation.endedAt;
-  const stamped = simulation.heartbeatAt;
-  const began =
-    reported === null
-      ? stamped
-      : stamped === null || reported < stamped
-        ? reported
-        : stamped;
+  // Use Egma's completion receipt so provider clock skew cannot shorten or
+  // extend the evidence wait. Historical rows may have only a reported end.
+  const began = simulation.heartbeatAt ?? simulation.endedAt;
   if (began === null) return false;
   return Date.now() - began.getTime() >= AGENT_POV_BOUND_SECONDS * 1_000;
 }
@@ -310,13 +301,8 @@ export async function simulationRoutes(
         // A result is read here, so it answers here — never by fetching the
         // run to find out.
         hasRecording: simulation.recordingReference !== null,
-        // **That grading stopped waiting for the agent's own account of this
-        // conversation.** The wait is bounded at thirty seconds so a broken
-        // exporter or a failed pull cannot hold a simulation open forever
-        // (ADR-0024 §6), and past the bound the record has to say so: a reader
-        // showing the agent's POV would otherwise show whatever fragment
-        // arrived as if it were the conversation. False is the ordinary answer
-        // — the account landed, or the lane files none.
+        // Use the grading wait bound to distinguish evidence still arriving
+        // from evidence missing after the deadline.
         agentPovComplete: transcript?.agentEvidenceComplete === true,
         agentPovIncomplete: agentPovIncomplete(simulation, run, transcript),
         measures: describedMeasures(simulation, transcript),
@@ -424,6 +410,12 @@ export async function simulationRoutes(
         traceId,
         runId: simulation.runId,
       });
+      if (requested.kind === "waiting") {
+        return unprocessable(
+          reply,
+          "the final platform transcript is still arriving. Grading will start when it is ready.",
+        );
+      }
       if (requested.kind === "not_requested") {
         return unprocessable(
           reply,

--- a/apps/api/test/otlp-agent-pov-ingest.test.ts
+++ b/apps/api/test/otlp-agent-pov-ingest.test.ts
@@ -1,4 +1,5 @@
 import {
+  AGENT_POV_BOUND_SECONDS,
   claimSimulations,
   cancelRun,
   completeSimulation,
@@ -16,7 +17,7 @@ import {
   startSimulation,
 } from "@egma/db";
 import { traceIdOfSimulation } from "@egma/simulation-contract";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { OTLP_TRACES_PATH } from "../src/routes/traces.ts";
 import { reportPathFor } from "../src/routes/reports.ts";
@@ -78,6 +79,13 @@ let acme: Customer;
 let globex: Customer;
 let acmeKey: string;
 let globexKey: string;
+
+afterEach(() => vi.useRealTimers());
+
+function advancePastEvidenceWait(): void {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(Date.now() + AGENT_POV_BOUND_SECONDS * 1_000 + 1);
+}
 
 /** Every captured request, already decoded, so a resource can be stamped. */
 let captured: OtlpExport[] = [];
@@ -528,9 +536,18 @@ describe.skipIf(!storage.available)("LiveKit evidence while the call is running"
     }
     await api.drainEvidence();
     expect(await getGradingJobForTrace(auth, landed.traceId)).toBeUndefined();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(endedAt.getTime() + 60_000);
     const pending = await api.app.inject({ method: "GET", url: `/v1/simulations/${landed.simulationId}`,
       headers: { authorization: `Bearer ${acmeKey}` } });
-    expect(pending.json()).toMatchObject({ agentPovComplete: false, agentPovIncomplete: false });
+    expect(pending.json()).toMatchObject({ gradingState: "pending", agentPovComplete: false, agentPovIncomplete: false });
+    const prematureRegrade = await api.app.inject({ method: "POST", url: `/v1/simulations/${landed.simulationId}/regrade`,
+      headers: { authorization: `Bearer ${acmeKey}` } });
+    expect(prematureRegrade.statusCode, prematureRegrade.body).toBe(422);
+    expect(prematureRegrade.body).toContain("final platform transcript is still arriving");
+    expect(await getGradingJobForTrace(auth, landed.traceId)).toBeUndefined();
+    // The ingestion publisher rotates segments on the real clock.
+    vi.useRealTimers();
     for (const exported of current) expect((await post(naming(exported, room), acmeKey)).statusCode).toBe(200);
     await api.drainEvidence();
     expect(await getGradingJobForTrace(auth, landed.traceId)).toMatchObject({ traceId: landed.traceId });
@@ -548,7 +565,10 @@ describe.skipIf(!storage.available)("LiveKit evidence while the call is running"
     await api.drainEvidence();
     const read = () => api.app.inject({ method: "GET", url: `/v1/simulations/${landed.simulationId}`,
       headers: { authorization: `Bearer ${acmeKey}` } });
+    expect((await read()).json()).toMatchObject({ agentPovComplete: false, agentPovIncomplete: false });
+    advancePastEvidenceWait();
     expect((await read()).json()).toMatchObject({ agentPovComplete: false, agentPovIncomplete: true });
+    vi.useRealTimers();
     await exportTheCapture(acmeKey, room);
     expect((await read()).json()).toMatchObject({ agentPovComplete: true, agentPovIncomplete: false });
   });
@@ -1120,6 +1140,7 @@ describe.skipIf(!storage.available)("when a simulation's grading is asked for", 
     const auth = contextFor(acme, "member");
     expect(await getGradingJobForTrace(auth, landed.traceId)).toBeUndefined();
 
+    advancePastEvidenceWait();
     const settled = await settleSimulationsPastTheAgentPovBound();
     expect(settled.map((one) => one.id)).toContain(landed.simulationId);
     expect(
@@ -1167,8 +1188,9 @@ describe.skipIf(!storage.available)("when a simulation's grading is asked for", 
     const auth = contextFor(acme, "member");
     expect(await getGradingJobForTrace(auth, landed.traceId)).toBeUndefined();
 
-    // The standing window, unwidened: six hours outside it by the report's own
-    // clock, and inside it by the stamp egma wrote when the landing arrived.
+    // A clock behind Egma does not spend the wait before the report arrives.
+    expect((await settleSimulationsPastTheAgentPovBound()).map((one) => one.id)).not.toContain(landed.simulationId);
+    advancePastEvidenceWait();
     const settled = await settleSimulationsPastTheAgentPovBound();
     expect(settled.map((one) => one.id)).toContain(landed.simulationId);
     expect(
@@ -1942,6 +1964,7 @@ describe.skipIf(!storage.available)("a Retell simulation that ends", () => {
       payload: terminalReport(running.simulationId, status, `missing_${running.simulationId}`),
     });
     expect(landed.statusCode, landed.body).toBe(200);
+    advancePastEvidenceWait();
     const read = await api.app.inject({ method: "GET", url: `/v1/simulations/${running.simulationId}`,
       headers: { authorization: `Bearer ${acmeKey}` } });
     expect(read.statusCode, read.body).toBe(200);

--- a/apps/api/test/otlp-agent-pov-ingest.test.ts
+++ b/apps/api/test/otlp-agent-pov-ingest.test.ts
@@ -1982,6 +1982,24 @@ describe.skipIf(!storage.available)("a Retell simulation that ends", () => {
     expect(askedOfRetell).toHaveLength(asksBefore);
   });
 
+  it("does not give a delayed pull a new request budget after the stored deadline", async () => {
+    const running = await runningCall("expired-pull");
+    const landed = await api.app.inject({
+      method: "POST",
+      url: reportPathFor(running.simulationId),
+      headers: { authorization: `Bearer ${api.config.simulatorServiceToken}` },
+      payload: terminalReport(running.simulationId, "completed", `missing_${running.simulationId}`),
+    });
+    expect(landed.statusCode, landed.body).toBe(200);
+    const standing = await resolveSimulationStanding(running.simulationId);
+    if (standing === undefined) throw new Error("the simulation has no standing");
+    advancePastEvidenceWait();
+    const fetchImpl = vi.fn(async () => new Response("", { status: 404 })) as unknown as typeof fetch;
+    await pullRetellSimulationRecord(standing.auth, running.simulationId,
+      { fetchImpl }, api.app.log, { retryWaitsMilliseconds: [] });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it("keeps an explicitly incomplete provider record marked incomplete after it arrives", async () => {
     const running = await runningCall("partial-provider-record");
     const callId = `missing_${running.simulationId}`;
@@ -2123,7 +2141,7 @@ describe.skipIf(!storage.available)("a Retell simulation that ends", () => {
       simulation.id,
       blippedReach,
       api.app.log,
-      { retryWaitsMilliseconds: [1], sleep: async () => {} },
+      { retryWaitsMilliseconds: [1_000], sleep: async () => {} },
     );
 
     // The retry runs after the door has answered, so the record arrives a

--- a/apps/api/test/retell-normalise.test.ts
+++ b/apps/api/test/retell-normalise.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   normaliseRetellCall,
+  retellCallDocumentIsComplete,
   traceIdFor,
   type RetellCall,
 } from "../src/retell/normalise.ts";
@@ -779,5 +780,24 @@ describe("a payload the normalizer cannot fully read", () => {
         callStatus,
       ).toBe(false);
     }
+  });
+});
+
+
+describe("Retell final call records", () => {
+  it("does not accept an ongoing call with only a start time as complete", () => {
+    const ongoing = capturedCall({
+      call_status: "ongoing",
+      end_timestamp: undefined,
+      transcript: undefined,
+      transcript_object: undefined,
+      transcript_with_tool_calls: undefined,
+    });
+
+    expect(retellCallDocumentIsComplete(ongoing)).toBe(false);
+    const retained = normaliseRetellCall(ongoing, FILED_INTO, NOW);
+    expect(retained.endReported).toBe(false);
+    expect(retained.degraded).toBe(true);
+    expect(retained.spans).toHaveLength(1);
   });
 });

--- a/apps/api/test/retell-provider.test.ts
+++ b/apps/api/test/retell-provider.test.ts
@@ -215,6 +215,35 @@ describe("Retell production call reads", () => {
     });
   });
 
+  it("rejects a still-running record even when it has transcript turns", async () => {
+    const answer = await getRetellCall("retell-api-key", "call_ongoing", {
+      fetchImpl: (async () => new Response(JSON.stringify({
+        call_id: "call_ongoing",
+        call_status: "ongoing",
+        start_timestamp: 1_786_000_000_000,
+        transcript_object: [{ role: "agent", content: "Hello." }],
+      }))) as typeof fetch,
+    });
+
+    expect(answer).toEqual({ kind: "refused", reason: "invalid-response" });
+  });
+
+  it("keeps transcript-free terminal production calls readable", async () => {
+    for (const status of ["ended", "error", "not_connected"]) {
+      const call = {
+        call_id: `call_${status}`,
+        call_status: status,
+        start_timestamp: 1_786_000_000_000,
+        end_timestamp: 1_786_000_001_000,
+      };
+      const answer = await getRetellCall("retell-api-key", call.call_id, {
+        fetchImpl: (async () => new Response(JSON.stringify(call))) as typeof fetch,
+      });
+
+      expect(answer).toEqual({ kind: "call", call });
+    }
+  });
+
   it("returns a safe rate-limit fact without Retell's raw error body", async () => {
     const providerSecret = "SENTINEL-provider-error-access-token";
     const fetchImpl = (async () =>

--- a/apps/api/test/retell-simulation-poll.test.ts
+++ b/apps/api/test/retell-simulation-poll.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { pollRetellSimulationCall } from "../src/retell/poll.ts";
+import type { RetrievedCall } from "../src/retell/api.ts";
+
+const PENDING_CALL = {
+  call_id: "call_waiting",
+  call_status: "ongoing",
+  start_timestamp: 1_786_000_000_000,
+};
+const FINAL_CALL = {
+  ...PENDING_CALL,
+  call_status: "ended",
+  end_timestamp: 1_786_000_074_000,
+  transcript_object: [{ role: "agent", content: "Goodbye." }],
+};
+
+afterEach(() => vi.useRealTimers());
+
+async function collect(
+  results: AsyncIterable<RetrievedCall>,
+): Promise<readonly RetrievedCall[]> {
+  const collected: RetrievedCall[] = [];
+  for await (const result of results) collected.push(result);
+  return collected;
+}
+
+describe("waiting for Retell's final simulation record", () => {
+  it("polls every five seconds for a minute, then backs off through four minutes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const requestedAt: number[] = [];
+    const fetchImpl = (async () => {
+      requestedAt.push(Date.now());
+      return new Response(JSON.stringify(PENDING_CALL));
+    }) as typeof fetch;
+
+    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }));
+    await vi.advanceTimersByTimeAsync(245_000);
+    await done;
+
+    expect(requestedAt).toEqual([
+      0, 5_000, 10_000, 15_000, 20_000, 25_000, 30_000,
+      35_000, 40_000, 45_000, 50_000, 55_000, 60_000,
+      70_000, 90_000, 130_000, 190_000, 240_000,
+    ]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("waits for both the final status and readable transcript, then stops", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const requestedAt: number[] = [];
+    const documents = [
+      { ...FINAL_CALL, transcript_object: undefined },
+      { ...FINAL_CALL, call_status: "ongoing" },
+      { ...FINAL_CALL, transcript_object: [{ role: "agent", content: " " }] },
+      FINAL_CALL,
+    ];
+    const fetchImpl = (async () => {
+      requestedAt.push(Date.now());
+      return new Response(JSON.stringify(documents.shift()));
+    }) as typeof fetch;
+
+    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }));
+    await vi.advanceTimersByTimeAsync(245_000);
+    const results = await done;
+
+    expect(requestedAt).toEqual([0, 5_000, 10_000, 15_000]);
+    expect(results.at(-1)).toEqual({ kind: "call", call: FINAL_CALL });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("ends a stalled request after five seconds without overlapping requests", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let active = 0;
+    let maximumActive = 0;
+    let requests = 0;
+    const fetchImpl = ((_input: unknown, init?: RequestInit) => {
+      requests += 1;
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          active -= 1;
+          reject(new DOMException("request aborted", "AbortError"));
+        }, { once: true });
+      });
+    }) as typeof fetch;
+
+    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }))
+      .then((results) => ({ results, finishedAt: Date.now() }));
+    await vi.advanceTimersByTimeAsync(245_000);
+    const result = await done;
+
+    expect(requests).toBe(18);
+    expect(maximumActive).toBe(1);
+    expect(active).toBe(0);
+    expect(result.finishedAt).toBe(245_000);
+    expect(result.results).toHaveLength(18);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("keeps the planned schedule when each response takes three seconds", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const requestedAt: number[] = [];
+    const fetchImpl = (async () => {
+      requestedAt.push(Date.now());
+      await new Promise((resolve) => setTimeout(resolve, 3_000));
+      return new Response(JSON.stringify(requestedAt.length === 3 ? FINAL_CALL : PENDING_CALL));
+    }) as typeof fetch;
+
+    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }));
+    await vi.advanceTimersByTimeAsync(13_000);
+    await done;
+
+    expect(requestedAt).toEqual([0, 5_000, 10_000]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("bounds response-body reads and does not expose the provider's error", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const fetchImpl = (async (_input: unknown, init?: RequestInit) => {
+      const response = new Response("");
+      Object.defineProperty(response, "text", {
+        value: () => new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new Error("SENTINEL-provider-secret")), { once: true });
+        }),
+      });
+      return response;
+    }) as typeof fetch;
+
+    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }, { retryWaitsMilliseconds: [] }));
+    await vi.advanceTimersByTimeAsync(5_000);
+    const results = await done;
+
+    expect(results).toEqual([{ kind: "unreachable", reason: "Retell at https://api.retellai.com did not answer" }]);
+    expect(JSON.stringify(results)).not.toContain("SENTINEL");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not retry a refused credential", async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi.fn(async () => new Response("", { status: 401 })) as unknown as typeof fetch;
+
+    const results = await collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }));
+
+    expect(results).toEqual([{ kind: "invalid-key" }]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not ask again before Retell's rate-limit retry time", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const requestedAt: number[] = [];
+    const fetchImpl = (async () => {
+      requestedAt.push(Date.now());
+      return requestedAt.length === 1
+        ? new Response("", { status: 429, headers: { "retry-after": "60" } })
+        : new Response(JSON.stringify(FINAL_CALL));
+    }) as typeof fetch;
+
+    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }));
+    await vi.advanceTimersByTimeAsync(245_000);
+    await done;
+
+    expect(requestedAt).toEqual([0, 60_000]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("stops after cancellation while waiting for the next request", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const controller = new AbortController();
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify(PENDING_CALL))) as unknown as typeof fetch;
+    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", {
+      fetchImpl,
+      signal: controller.signal,
+    }));
+    await vi.advanceTimersByTimeAsync(0);
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(5_000);
+    await done;
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+});

--- a/apps/api/test/retell-simulation-poll.test.ts
+++ b/apps/api/test/retell-simulation-poll.test.ts
@@ -35,7 +35,7 @@ describe("waiting for Retell's final simulation record", () => {
       return new Response(JSON.stringify(PENDING_CALL));
     }) as typeof fetch;
 
-    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }));
+    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }, { completionReceivedAtMilliseconds: 0 }));
     await vi.advanceTimersByTimeAsync(245_000);
     await done;
 
@@ -62,7 +62,7 @@ describe("waiting for Retell's final simulation record", () => {
       return new Response(JSON.stringify(documents.shift()));
     }) as typeof fetch;
 
-    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }));
+    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }, { completionReceivedAtMilliseconds: 0 }));
     await vi.advanceTimersByTimeAsync(245_000);
     const results = await done;
 
@@ -89,7 +89,7 @@ describe("waiting for Retell's final simulation record", () => {
       });
     }) as typeof fetch;
 
-    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }))
+    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }, { completionReceivedAtMilliseconds: 0 }))
       .then((results) => ({ results, finishedAt: Date.now() }));
     await vi.advanceTimersByTimeAsync(245_000);
     const result = await done;
@@ -112,7 +112,7 @@ describe("waiting for Retell's final simulation record", () => {
       return new Response(JSON.stringify(requestedAt.length === 3 ? FINAL_CALL : PENDING_CALL));
     }) as typeof fetch;
 
-    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }));
+    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }, { completionReceivedAtMilliseconds: 0 }));
     await vi.advanceTimersByTimeAsync(13_000);
     await done;
 
@@ -133,7 +133,7 @@ describe("waiting for Retell's final simulation record", () => {
       return response;
     }) as typeof fetch;
 
-    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }, { retryWaitsMilliseconds: [] }));
+    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }, { completionReceivedAtMilliseconds: 0, retryWaitsMilliseconds: [] }));
     await vi.advanceTimersByTimeAsync(5_000);
     const results = await done;
 
@@ -144,9 +144,10 @@ describe("waiting for Retell's final simulation record", () => {
 
   it("does not retry a refused credential", async () => {
     vi.useFakeTimers();
+    vi.setSystemTime(0);
     const fetchImpl = vi.fn(async () => new Response("", { status: 401 })) as unknown as typeof fetch;
 
-    const results = await collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }));
+    const results = await collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }, { completionReceivedAtMilliseconds: 0 }));
 
     expect(results).toEqual([{ kind: "invalid-key" }]);
     expect(fetchImpl).toHaveBeenCalledTimes(1);
@@ -164,7 +165,7 @@ describe("waiting for Retell's final simulation record", () => {
         : new Response(JSON.stringify(FINAL_CALL));
     }) as typeof fetch;
 
-    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }));
+    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", { fetchImpl }, { completionReceivedAtMilliseconds: 0 }));
     await vi.advanceTimersByTimeAsync(245_000);
     await done;
 
@@ -180,13 +181,95 @@ describe("waiting for Retell's final simulation record", () => {
     const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", {
       fetchImpl,
       signal: controller.signal,
-    }));
+    }, { completionReceivedAtMilliseconds: 0 }));
     await vi.advanceTimersByTimeAsync(0);
     controller.abort();
     await vi.advanceTimersByTimeAsync(5_000);
     await done;
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("anchors a delayed start to the completion receipt and skips missed slots", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(16_000);
+    const requestedAt: number[] = [];
+    const fetchImpl = (async () => {
+      requestedAt.push(Date.now());
+      return new Response(JSON.stringify(PENDING_CALL));
+    }) as typeof fetch;
+
+    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", {
+      fetchImpl,
+    }, { completionReceivedAtMilliseconds: 0 }));
+    await vi.runAllTimersAsync();
+    await done;
+
+    expect(requestedAt).toEqual([
+      16_000, 20_000, 25_000, 30_000, 35_000, 40_000, 45_000,
+      50_000, 55_000, 60_000, 70_000, 90_000, 130_000, 190_000, 240_000,
+    ]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("shortens the last request to the completion receipt's remaining budget", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(244_000);
+    const requestedAt: number[] = [];
+    const fetchImpl = ((_input: unknown, init?: RequestInit) => {
+      requestedAt.push(Date.now());
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("request aborted", "AbortError"));
+        }, { once: true });
+      });
+    }) as typeof fetch;
+
+    const done = collect(pollRetellSimulationCall("retell-key", "call_waiting", {
+      fetchImpl,
+    }, { completionReceivedAtMilliseconds: 0 }))
+      .then(() => Date.now());
+    await vi.runAllTimersAsync();
+
+    expect(await done).toBe(245_000);
+    expect(requestedAt).toEqual([244_000]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not request a record after the stored completion deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(245_000);
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify(FINAL_CALL))) as unknown as typeof fetch;
+
+    const results = await collect(pollRetellSimulationCall("retell-key", "call_waiting", {
+      fetchImpl,
+    }, { completionReceivedAtMilliseconds: 0 }));
+
+    expect(results).toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not burst through missed slots when a retry timer wakes late", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const requestedAt: number[] = [];
+    const fetchImpl = (async () => {
+      requestedAt.push(Date.now());
+      return new Response(JSON.stringify(PENDING_CALL));
+    }) as typeof fetch;
+    let delayed = false;
+    const sleep = async (milliseconds: number): Promise<void> => {
+      vi.setSystemTime(Date.now() + milliseconds + (delayed ? 0 : 185_000));
+      delayed = true;
+    };
+
+    await collect(pollRetellSimulationCall("retell-key", "call_waiting", {
+      fetchImpl,
+    }, { completionReceivedAtMilliseconds: 0, sleep }));
+
+    expect(requestedAt).toEqual([0, 190_000, 240_000]);
     expect(vi.getTimerCount()).toBe(0);
   });
 

--- a/docs/api/runs.mdx
+++ b/docs/api/runs.mdx
@@ -205,13 +205,18 @@ grading fields:
 </ResponseField>
 
 <ResponseField name="agentPovIncomplete" type="boolean">
-  `true` when this simulation was graded without the agent's own account of the
-  conversation. A simulation stores two accounts, and grading waits for the
-  agent's — the SDK's export from inside the room, or the pull from the agent
-  platform — for 30 seconds and no longer. `true` says the wait ran out: what is
-  stored is Egma's own account, and the agent's is missing or partial, so a
-  reader that shows the agent's POV has to say so rather than show a fragment as
-  the whole. Regrade picks up a late arrival.
+  `true` when the final platform record is still missing after the evidence
+  wait, or the received record is explicitly incomplete. For LiveKit and
+  Retell simulations, grading waits up to 245 seconds from Egma receiving the
+  completion report. Grading starts as soon as the complete agent record is
+  available. Regrade can use evidence that arrives after the wait expires.
+
+  Retell call records are checked immediately, every five seconds through the
+  first minute, then at 70, 90, 130, 190, and 240 seconds. Each request has a
+  five-second timeout, with at most 18 requests per simulation. Polling stops
+  when the final call record has a usable transcript. After those attempts,
+  Egma does not fetch again automatically, and Regrade only uses stored
+  evidence. LiveKit sends its record through the SDK and needs no polling.
 
   It is `false` on every simulation whose agent POV landed, and on every lane
   that files none: a Retell phone call reaches nothing of Egma's, so nothing was

--- a/packages/db/src/access/grading.ts
+++ b/packages/db/src/access/grading.ts
@@ -91,6 +91,7 @@ export type GradingRequestResult =
 
 export type RegradeTraceResult =
   | { readonly kind: "not_requested" }
+  | { readonly kind: "waiting"; readonly for: "evidence" }
   | {
       readonly kind: "queued";
       readonly jobId: string;
@@ -556,11 +557,12 @@ export async function traceEvidenceStartedAt(
 }
 
 /**
- * Maximum wait for an expected agent POV after simulation completion (ADR-0024 §6).
- * Grade as soon as it is query-visible, or after this bound with available evidence.
+ * Maximum wait for a final platform record after simulation completion.
+ * Covers four minutes of Retell polling and its last five-second request.
+ * Grade as soon as the record is query-visible, or report missing evidence at the bound.
  * A later arrival requires regrading.
  */
-export const AGENT_POV_BOUND_SECONDS = 30;
+export const AGENT_POV_BOUND_SECONDS = 245;
 
 /**
  * Evidence readiness and agent POV availability. Without an expected agent POV,
@@ -749,18 +751,14 @@ function simulationExpectsAnAgentPov(row: {
 }
 
 /**
- * Start the agent POV wait at the earlier of reported end time and stored heartbeat.
- * A simulator clock ahead of the platform must not extend the wait.
+ * Start the agent POV wait when Egma received completion. The simulator's
+ * reported end time can use a different clock and must not shorten or extend it.
  */
 function theWaitBeganAt(row: {
   readonly endedAt: Date | null;
   readonly heartbeatAt: Date | null;
 }): Date {
-  const reported = row.endedAt;
-  const stamped = row.heartbeatAt;
-  if (reported === null) return stamped ?? new Date(0);
-  if (stamped === null) return reported;
-  return reported < stamped ? reported : stamped;
+  return row.heartbeatAt ?? row.endedAt ?? new Date(0);
 }
 
 /**
@@ -793,8 +791,8 @@ export type SimulationPastTheAgentPovBound = {
 
 /**
  * Check completed simulations without queued grading jobs across all organizations.
- * Use the platform heartbeat for the lookback window and the earlier reported end
- * or heartbeat for the wait bound. Request grading when evidence is ready.
+ * Use Egma's completion heartbeat for the lookback window and the wait bound.
+ * Request grading when evidence is ready.
  * Finished jobs may have been deleted; requestGradingIn returns terminal without
  * creating work when all graders already have results.
  */
@@ -895,7 +893,7 @@ export async function settleSimulationsPastTheAgentPovBound(options?: {
 
 /**
  * How far back one tick looks for a simulation nobody asked grading about, and
- * how many it settles at a time. An hour is far more than the thirty seconds a
+ * how many it settles at a time. An hour is far more than the four minutes a
  * healthy wait takes, and short enough that a deployment coming back after a
  * long outage does not grade a day of backlog in one tick.
  */
@@ -1607,15 +1605,50 @@ export async function regradeTrace(
     if (entries.length === 0) return { kind: "not_requested" };
 
     const existing = await jobForTrace(tx, auth, ref.traceId);
-    if (existing !== undefined) {
-      if (existing.status === "pending" || existing.status === "claimed") {
-        return {
-          kind: "queued",
-          jobId: existing.id,
-          reopened: false,
-          alreadyWaiting: true,
-        };
+    if (existing?.status === "pending" || existing?.status === "claimed") {
+      return {
+        kind: "queued",
+        jobId: existing.id,
+        reopened: false,
+        alreadyWaiting: true,
+      };
+    }
+    if (ref.source === "simulation") {
+      const simulationId = simulationIdOfTrace(ref.traceId);
+      if (simulationId === undefined || ref.runId === undefined) {
+        throw new Error(`trace ${ref.traceId} is not a simulation trace`);
       }
+      const [row] = await tx
+        .select({
+          startedAt: simulation.startedAt,
+          endedAt: simulation.endedAt,
+          heartbeatAt: simulation.heartbeatAt,
+          providerReference: simulation.providerReference,
+          connectionSnapshot: run.connectionSnapshot,
+        })
+        .from(simulation)
+        .innerJoin(run, eq(run.id, simulation.runId))
+        .where(within(auth, simulation, eq(simulation.id, simulationId)))
+        .limit(1);
+      if (row === undefined) throw new Error(`simulation ${simulationId} is not readable`);
+      if (simulationExpectsAnAgentPov(row)) {
+        const completedAt = theWaitBeganAt(row);
+        const now = new Date();
+        const readiness = await simulationEvidenceReadiness(auth, {
+          traceId: ref.traceId,
+          runId: ref.runId,
+          window: {
+            from: BigInt((row.startedAt ?? completedAt).getTime() - 5 * 60 * 1_000) * 1_000n,
+            to: BigInt(now.getTime() + 1_000) * 1_000n,
+          },
+          producesAnAgentPov: true,
+          completedAt,
+          now,
+        });
+        if (!readiness.ready) return { kind: "waiting", for: "evidence" };
+      }
+    }
+    if (existing !== undefined) {
       const prior = await readTraceGrades(auth, ref);
       const [row] = await tx
         .update(gradingJob)

--- a/packages/db/src/access/runs.ts
+++ b/packages/db/src/access/runs.ts
@@ -1932,6 +1932,8 @@ export type RetellSimulationPull = {
   readonly standing: SimulationStanding;
   /** Retell's own id for the conversation, off the simulation's own row. */
   readonly providerReference: string;
+  /** The completion receipt that starts grading's wait for final evidence. */
+  readonly completionReceivedAt: Date;
   /** The connection's Retell key, unsealed. */
   readonly apiKey: string;
   /** Where Retell answers for this connection, when the config names one. */
@@ -1953,6 +1955,8 @@ export async function resolveRetellSimulationPull(
   const [row] = await db()
     .select({
       providerReference: simulation.providerReference,
+      heartbeatAt: simulation.heartbeatAt,
+      endedAt: simulation.endedAt,
       runId: run.id,
       connectionSnapshot: run.connectionSnapshot,
       credentials: connection.credentials,
@@ -2012,6 +2016,7 @@ export async function resolveRetellSimulationPull(
   return {
     standing,
     providerReference,
+    completionReceivedAt: row.heartbeatAt ?? row.endedAt ?? new Date(0),
     apiKey,
     baseUrl: baseUrl === "" ? null : baseUrl,
   };

--- a/packages/db/test/grading-evidence.test.ts
+++ b/packages/db/test/grading-evidence.test.ts
@@ -1,0 +1,318 @@
+import { newId } from "@egma/ids";
+import { traceIdOfSimulation } from "@egma/simulation-contract";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+  appendGrades,
+  appendSpans,
+  claimGradingJobs,
+  claimSimulations,
+  completeSimulation,
+  connectClickHouse,
+  createAgent,
+  createPersona,
+  createTest,
+  createTestSuite,
+  disconnectClickHouse,
+  finishGradingJob,
+  getGradingJobForTrace,
+  readTraceGrading,
+  reconcileGraderCatalog,
+  recordSimulationTraces,
+  regradeTrace,
+  releaseGradingJob,
+  resolveRunStartReach,
+  settleSimulationsPastTheAgentPovBound,
+  startRun,
+  startSimulation,
+  type AuthContext,
+  type NewSpan,
+  type SimulationClaim,
+} from "../src/index.ts";
+import { simulationEvidenceReadiness } from "../src/access/grading.ts";
+import {
+  createMigratedTraceStore,
+  type MigratedTraceStore,
+} from "./support/clickhouse.ts";
+import {
+  createConnectedDatabase,
+  type MigratedDatabase,
+} from "./support/database.ts";
+import { seedOrganization, seedUser } from "./support/tenancy.ts";
+
+let database: MigratedDatabase;
+let store: MigratedTraceStore;
+let suiteId: string;
+
+const organizationId = newId("org");
+const projectId = newId("prj");
+const userId = newId("usr");
+const auth: AuthContext = {
+  organizationId,
+  projectId,
+  userId,
+  role: "member",
+  via: "session",
+};
+const SIMULATOR = "final-evidence-simulator";
+type Platform = "livekit" | "retell";
+
+type CompletedConversation = {
+  readonly claim: SimulationClaim;
+  readonly traceId: string;
+  readonly completedAt: Date;
+  readonly span: NewSpan;
+};
+
+async function completedConversation(
+  platform: Platform,
+  reportedEndOffsetMilliseconds = 0,
+): Promise<CompletedConversation> {
+  const name = `${platform}-${newId("agt")}`;
+  const created = await createAgent(auth, {
+    agentPlatform: platform,
+    name,
+    connection: platform === "livekit"
+      ? {
+          agentPlatform: "livekit",
+          connectionType: "livekit_room",
+          accessVariant: "livekit_room.project_credentials",
+          modality: "voice",
+          config: { url: "wss://evidence.livekit.cloud", agentName: name },
+          credentials: { apiKey: "livekit-key-A1B2C3D4", apiSecret: "livekit-secret-A1B2C3D4" },
+        }
+      : {
+          agentPlatform: "retell",
+          connectionType: "retell_web_call",
+          accessVariant: "retell_web_call.api_key",
+          modality: "voice",
+          config: { retellAgentId: name },
+          credentials: { apiKey: "retell-secret-A1B2C3D4" },
+        },
+  });
+  const connectionId = created.connection?.id ?? "";
+  const reach = platform === "retell"
+    ? await resolveRunStartReach(auth, created.id, connectionId)
+    : undefined;
+  const started = await startRun(auth, {
+    suiteId,
+    agentId: created.id,
+    connectionId,
+    ...(reach === undefined ? {} : {
+      agentVersion: 1,
+      conductedConnectionIdentity: reach.connectionIdentity,
+    }),
+  });
+  const claim = (await claimSimulations({ claimant: SIMULATOR, capacity: 50 }))
+    .find((one) => one.runId === started.id);
+  if (claim === undefined) throw new Error("the conversation was not claimed");
+  const traceId = traceIdOfSimulation(claim.id);
+  if (traceId === undefined) throw new Error("the conversation has no trace id");
+  await startSimulation(auth, claim.id, SIMULATOR);
+  const completedAt = new Date();
+  const span: NewSpan = {
+    traceId,
+    spanId: "1111111111111111",
+    parentSpanId: "",
+    source: "simulation",
+    emitter: "egma-runtime",
+    environment: "default",
+    startedAtMicroseconds: BigInt(completedAt.getTime()) * 1_000n,
+    durationNanoseconds: 1_000_000_000n,
+    name: "agent_turn",
+    kind: "turn:agent",
+    status: "ok",
+    text: "Your booking is confirmed.",
+    audioUrl: "",
+    toolName: "",
+    toolArguments: "",
+    toolResult: "",
+    providerCallId: name,
+    agentPlatform: platform,
+    platformAgentId: name,
+    platformAgentName: name,
+    platformAgentVersion: "1",
+    connectionType: platform === "livekit" ? "livekit_room" : "retell_web_call",
+    runId: claim.runId,
+    agentId: claim.agentId,
+    agentVersionId: "",
+    testVersionId: claim.testVersionId,
+    personaVersionId: claim.personaVersionId,
+    payload: "{}",
+    endsTrace: false,
+  };
+  await appendSpans(auth, [span]);
+  await completeSimulation(auth, claim.id, SIMULATOR, {
+    endingReason: "agent_ended",
+    providerReference: name,
+    endedAt: new Date(completedAt.getTime() + reportedEndOffsetMilliseconds),
+    ...(reportedEndOffsetMilliseconds >= 0 ? {} : {
+      startedAt: new Date(completedAt.getTime() + reportedEndOffsetMilliseconds - 1_000),
+    }),
+  });
+  return { claim, traceId, completedAt, span };
+}
+
+function finalEvidence(conversation: CompletedConversation): NewSpan {
+  return {
+    ...conversation.span,
+    spanId: "2222222222222222",
+    emitter: "agent",
+    kind: conversation.span.agentPlatform === "livekit" ? "root" : "conversation",
+    name: conversation.span.agentPlatform === "livekit" ? "agent_session" : "retell_call",
+    payload: JSON.stringify({
+      call_status: "ended",
+      end_timestamp: conversation.completedAt.getTime(),
+      egma_normalised: { degraded: false },
+    }),
+  };
+}
+
+function afterCompletion(conversation: CompletedConversation, milliseconds: number): void {
+  vi.setSystemTime(new Date(conversation.completedAt.getTime() + milliseconds));
+}
+
+async function readiness(conversation: CompletedConversation) {
+  return simulationEvidenceReadiness(auth, {
+    traceId: conversation.traceId,
+    runId: conversation.claim.runId,
+    window: {
+      from: BigInt(conversation.completedAt.getTime() - 1_000) * 1_000n,
+      to: BigInt(Date.now() + 1_000) * 1_000n,
+    },
+    producesAnAgentPov: true,
+    completedAt: conversation.completedAt,
+  });
+}
+
+beforeAll(async () => {
+  database = await createConnectedDatabase("grading_evidence");
+  store = await createMigratedTraceStore("grading_evidence");
+  connectClickHouse({ clickhouseUrl: store.url, maxOpenConnections: 3 });
+  await seedOrganization(database, organizationId, [{ id: projectId, slug: "default" }]);
+  await seedUser(database, userId, "grading-evidence@example.com");
+  await reconcileGraderCatalog();
+  const persona = await createPersona(auth, {
+    name: "Rita",
+    identityName: "Rita Alvarez",
+    personality: "Patient",
+    language: "en-US",
+  });
+  suiteId = (await createTestSuite(auth, { name: "Final evidence" })).id;
+  await createTest(auth, {
+    suiteId,
+    name: "Confirm booking",
+    scenario: "Confirm a booking.",
+    expectedBehaviors: ["confirms the booking"],
+    personaIds: [persona.id],
+  });
+});
+
+afterEach(() => vi.useRealTimers());
+afterAll(async () => {
+  await disconnectClickHouse();
+  await store.drop();
+  await database.drop();
+});
+
+describe.each<Platform>(["livekit", "retell"])("%s final evidence", (platform) => {
+  it("keeps grading pending past thirty seconds and queues when the final record arrives", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const conversation = await completedConversation(platform);
+    const ref = { source: "simulation" as const, traceId: conversation.traceId, runId: conversation.claim.runId };
+    const partial: NewSpan = {
+      ...finalEvidence(conversation),
+      spanId: "3333333333333333",
+      name: platform === "livekit" ? "agent_turn" : "retell_call",
+      kind: platform === "livekit" ? "turn:agent" : "conversation",
+      payload: JSON.stringify({ call_status: "ongoing", egma_normalised: { degraded: true } }),
+    };
+    await appendSpans(auth, [partial]);
+    for (const milliseconds of [30_000, 60_000, 180_000, 240_000, 244_999]) {
+      afterCompletion(conversation, milliseconds);
+      await expect(readiness(conversation)).resolves.toMatchObject({ ready: false, agentPovFiled: false });
+      await recordSimulationTraces(auth, [conversation.span]);
+      await settleSimulationsPastTheAgentPovBound();
+      expect(await getGradingJobForTrace(auth, conversation.traceId)).toBeUndefined();
+      await expect(readTraceGrading(auth, ref)).resolves.toMatchObject({ state: "pending", current: [] });
+      await expect(regradeTrace(auth, ref)).resolves.toEqual({ kind: "waiting", for: "evidence" });
+      expect(await getGradingJobForTrace(auth, conversation.traceId)).toBeUndefined();
+    }
+
+    const final = finalEvidence(conversation);
+    await appendSpans(auth, [final]);
+    await recordSimulationTraces(auth, [final]);
+    await expect(readiness(conversation)).resolves.toMatchObject({ ready: true, agentPovFiled: true });
+    const job = await getGradingJobForTrace(auth, conversation.traceId);
+    expect(job).toMatchObject({ status: "pending", attempts: 0 });
+    await recordSimulationTraces(auth, [final]);
+    expect((await getGradingJobForTrace(auth, conversation.traceId))?.id).toBe(job?.id);
+  });
+
+  it("ends the wait at 245 seconds and allows regrading after late final evidence arrives", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const conversation = await completedConversation(platform);
+    const ref = { source: "simulation" as const, traceId: conversation.traceId, runId: conversation.claim.runId };
+    afterCompletion(conversation, 245_000);
+    const settled = await settleSimulationsPastTheAgentPovBound();
+    expect(settled).toContainEqual({ id: conversation.claim.id, runId: conversation.claim.runId, agentPovFiled: false });
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      const claimed = (await claimGradingJobs({ claimant: "final-evidence-grader", capacity: 50 }))
+        .find((one) => one.traceId === conversation.traceId);
+      if (claimed === undefined) throw new Error("the missing-evidence job was not claimed");
+      expect(claimed.attempts).toBe(attempt);
+      if (attempt < 3) {
+        await releaseGradingJob(claimed.auth, claimed.id, claimed.claimedBy, "The final transcript is not available yet.");
+        continue;
+      }
+      await appendGrades(claimed.auth, claimed.entries.map((entry) => ({
+        source: claimed.source,
+        traceId: claimed.traceId,
+        traceStartedAtMicroseconds: BigInt(claimed.traceStartedAt.getTime()) * 1_000n,
+        runId: claimed.runId ?? "",
+        projectGraderId: entry.projectGraderId,
+        graderDefinitionId: entry.graderDefinitionId,
+        graderDefinitionVersion: entry.graderDefinitionVersion,
+        parameterValues: entry.parameterValues,
+        graderPassThreshold: entry.graderPassThreshold,
+        gradingSequence: claimed.sequenceBase + claimed.attempts,
+        gradedAtMicroseconds: BigInt(Date.now()) * 1_000n,
+        score: null,
+        details: { error: "The final transcript is not available yet." },
+      })));
+      await finishGradingJob(claimed.auth, claimed.id, claimed.claimedBy);
+    }
+    await expect(readTraceGrading(auth, ref)).resolves.toMatchObject({ state: "error" });
+
+    afterCompletion(conversation, 300_000);
+    const final = finalEvidence(conversation);
+    await appendSpans(auth, [final]);
+    await recordSimulationTraces(auth, [final]);
+    await expect(readiness(conversation)).resolves.toMatchObject({ ready: true, agentPovFiled: true });
+    expect(await getGradingJobForTrace(auth, conversation.traceId)).toBeUndefined();
+    await expect(readTraceGrading(auth, ref)).resolves.toMatchObject({ state: "error" });
+    await expect(regradeTrace(auth, ref)).resolves.toMatchObject({ kind: "queued", reopened: true, alreadyWaiting: false });
+    expect(await getGradingJobForTrace(auth, conversation.traceId)).toMatchObject({ status: "pending", attempts: 0, lastError: null });
+    expect((await readTraceGrading(auth, ref))?.history[0]?.score).toBeNull();
+  });
+
+  it.each([-3_600_000, 3_600_000])("uses the full server wait when the reported end is offset by %i ms", async (offset) => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const conversation = await completedConversation(platform, offset);
+    afterCompletion(conversation, 244_999);
+    await recordSimulationTraces(auth, [conversation.span]);
+    await settleSimulationsPastTheAgentPovBound();
+    expect(await getGradingJobForTrace(auth, conversation.traceId)).toBeUndefined();
+    await expect(regradeTrace(auth, {
+      source: "simulation",
+      traceId: conversation.traceId,
+      runId: conversation.claim.runId,
+    })).resolves.toEqual({ kind: "waiting", for: "evidence" });
+    afterCompletion(conversation, 245_000);
+    expect(await settleSimulationsPastTheAgentPovBound()).toContainEqual({
+      id: conversation.claim.id,
+      runId: conversation.claim.runId,
+      agentPovFiled: false,
+    });
+  });
+});


### PR DESCRIPTION
Retell could return an `ongoing` call without an end timestamp or transcript after the simulator disconnected. Egma treated that record as complete, stopped fetching, and later recorded grading errors. LiveKit exports could also arrive after the previous 30-second evidence wait.

Require a terminal Retell record with a reported end and usable transcript before filing simulation evidence. Poll immediately and every five seconds through the first minute, then at 70, 90, 130, 190, and 240 seconds: at most 18 requests, each limited to five seconds, with no overlap. Honor rate limits and stop early when the transcript is ready.

For both Retell and LiveKit, keep grading pending for up to 245 seconds from Egma receiving completion. Start immediately when final evidence is visible. Use the server clock so provider clock skew cannot shorten the wait, and prevent manual regrade from bypassing it. Preserve existing error history when late evidence is graded again.

The poll schedule and grading deadline both use the stored completion receipt. Delayed starts skip missed request times, and a request near the deadline gets only the remaining time.

Validation: 169 affected or newly added tests pass across Retell normalization/provider/polling/production ingestion, simulation evidence ingestion, grading readiness/jobs/progress, and grader evidence selection. Affected API/grader builds, test type checking, lint, and diff checks pass. The full suite was not run locally; CI runs it.

Polling remains process-local and stops after the bound. Regrade uses stored evidence; it does not start a new Retell fetch or repair previously stored incomplete records. No schema or SDK changes.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The latest commit aligns Retell polling with grading’s stored completion receipt and adds regressions for delayed starts, missed slots, shortened timeouts, and expired deadlines.
- Polling and grading now derive their 245-second deadline from the same server-stamped completion time.
- Delayed pollers make an immediate request when budget remains, skip obsolete scheduled slots, and never begin a request after the deadline.
- The final request timeout is limited to the remaining evidence budget.
- Tests cover the corrected deadline behavior and integration with simulation ingestion.

<h3>Confidence Score: 5/5</h3>

The latest changes appear safe to merge, with no new actionable failures found.

The stored server receipt is immutable after terminal completion and is now used identically by polling and grading. Requests are skipped after expiration and bounded to the remaining deadline, addressing the latest polling-deadline concern with focused regression coverage. The previous thread was manually resolved after thebhulawat described the implementation and tests.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/src/retell/poll.ts | Anchors polling slots and request timeouts to the stored completion receipt, preventing the poll from extending its request budget beyond grading’s deadline. |
| apps/api/src/retell-simulation-ingestion.ts | Supplies the persisted completion receipt to the Retell poller while preserving final-transcript-only filing. |
| packages/db/src/access/runs.ts | Exposes the immutable server-stamped completion receipt used by both polling and grading. |
| apps/api/test/retell-simulation-poll.test.ts | Adds deterministic coverage for delayed starts, skipped slots, remaining-budget timeouts, and expired deadlines. |
| apps/api/test/otlp-agent-pov-ingest.test.ts | Adds integration coverage proving an expired stored deadline does not create a fresh Retell request budget. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant S as Simulator report
    participant DB as Simulation record
    participant P as Retell poller
    participant R as Retell
    participant G as Grading readiness

    S->>DB: Store terminal report and server receipt
    DB-->>P: completionReceivedAt
    DB-->>G: same completion receipt
    P->>R: Immediate request if before deadline
    loop Remaining scheduled slots
        P->>P: Skip elapsed or rate-limited slots
        P->>R: Request with min(5s, remaining budget)
        alt Final usable transcript
            R-->>P: Terminal call and transcript
            P->>DB: File simulation evidence
        else Incomplete response
            R-->>P: Pending or unavailable
        end
    end
    G->>G: Grade when evidence is ready or 245s expires
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Use the stored completion deadline for R..."](https://github.com/egma-ai/egma/commit/21734b16c0e54b3ce790b0599082395fd624d0a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61395841)</sub>

**Context used:**

- Knowledge Base — [Provider ingestion and recordings](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/api-ingestion-and-recordings.md)
- Knowledge Base — [Grading and judgments](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/grading-and-judgments.md)

<!-- /greptile_comment -->