### PR TITLE
Tests grid: remove a persona from a test where you can see it

### DIFF
--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -4,6 +4,7 @@ import {
   Fragment,
   useCallback,
   useEffect,
+  useId,
   useRef,
   useState,
   type ComponentProps,
@@ -63,8 +64,18 @@ import { ConfirmDialog } from "./parts.tsx";
  * Mock tools and env open JSON dialogs instead of inline text editors.
  */
 
-/** A persona as a cell needs it: an id to send and a name to show. */
-type Named = { readonly id: string; readonly name: string };
+/**
+ * A persona as a cell needs it: an id to send and a name to show.
+ *
+ * `archivedAt` travels with the personas a test names, so the picker can say
+ * that one of them is gone. A persona read from the project's own list is
+ * available by definition and carries nothing here.
+ */
+type Named = {
+  readonly id: string;
+  readonly name: string;
+  readonly archivedAt?: string | null;
+};
 
 /** What a cell is, which is also which field one save carries. */
 type Field =
@@ -413,7 +424,13 @@ function PersonaPicker({
           /* The cell owns its own caret; opening must not move it first. */
           onMouseDown={(event) => event.preventDefault()}
         >
-          + Add a persona
+          {/*
+           * A cell that already names somebody opens a panel that both adds and
+           * removes, so the trigger says editing rather than adding. An empty
+           * one — the entry row, before anybody has been named — keeps the
+           * grid's own add line, because adding is all it can do.
+           */}
+          {chosen.length === 0 ? "+ Add a persona" : "Edit personas"}
         </button>
       </PopoverTrigger>
       <PopoverContent
@@ -439,8 +456,12 @@ function PersonaPicker({
   );
 }
 
+/** Why the only persona a test names cannot be taken off it. */
+const LAST_PERSONA = "A test needs at least one persona";
+
 /**
- * What the open picker holds: the search, the people, and the way out.
+ * What the open picker holds: who is on the test, the search, the people, and
+ * the way out.
  *
  * It is its own component so that the read below runs when a panel opens
  * rather than when the grid draws, which is the difference between one request
@@ -464,6 +485,21 @@ function PersonaChoices({
   const [refused, setRefused] = useState<string | null>(null);
   /** Whether egma holds more than this picker read. Said out loud if so. */
   const [truncated, setTruncated] = useState(false);
+  const panel = useRef<HTMLDivElement>(null);
+  const said = useId();
+
+  /*
+   * **Who the test names now, built from the row rather than from the list
+   * below.** The list holds the project's available personas, and a test can
+   * name one the project has since deleted — which is exactly the test that
+   * cannot be saved again until that persona comes off it. Reading the row
+   * puts the deleted one on screen, with its own way out.
+   */
+  const onTest: readonly Named[] = chosen.map(
+    (id) => known.get(id) ?? { id, name: id },
+  );
+  /** The last persona standing stays: a test says who calls. */
+  const onlyOne = onTest.length === 1;
 
   /*
    * **Every persona the project holds, not the first page of them.**
@@ -534,87 +570,145 @@ function PersonaChoices({
     onChange(next, named);
   }
 
+  /**
+   * Take one persona off the test, and hold the caret inside the open panel.
+   *
+   * The row that was pressed is about to leave. Radix reads focus falling to
+   * the body as focus leaving the panel, so the caret goes to the search
+   * field, which outlives every row here.
+   */
+  function remove(one: Named): void {
+    toggle(one);
+    panel.current
+      ?.querySelector<HTMLInputElement>('[data-slot="command-input"]')
+      ?.focus();
+  }
+
   return (
-    /*
-     * **`label` names the search field, not the list, and that is `cmdk`'s
-     * doing rather than a choice made here.** It renders the prop into a hidden
-     * element and points the field's `aria-labelledby` at it — always, even
-     * with no label given, which is why an `aria-label` on the field is
-     * overridden and silently does nothing. So the words that describe the
-     * typing have to arrive through this prop. The panel around it is a dialog
-     * and carries "Choose personas" of its own, so nothing is left unnamed.
-     */
-    <Command label="Search personas">
-      <CommandInput
-        /*
-         * The caret starts here, and that is load-bearing rather than a
-         * courtesy. Radix puts focus on the panel itself when it opens, and the
-         * panel's own children then re-render as the persona pages arrive —
-         * which drops focus to the body, reads to Radix as focus leaving the
-         * panel, and shuts it. Landing the caret on the field holds it on
-         * something that outlives the list, and it is where somebody opening a
-         * search panel expects to be typing.
-         */
-        autoFocus
-        /* A placeholder is not a name: it leaves with the first keystroke. */
-        placeholder="Search personas"
-        value={search}
-        onValueChange={setSearch}
-      />
-      <CommandList>
-        {refused !== null ? (
-          <p className="m-0 px-2.5 py-2 text-sm text-failure">{refused}</p>
-        ) : people === null ? (
-          <p className="m-0 px-2.5 py-2 text-sm text-muted-foreground">
-            Loading personas…
+    <div className="flex flex-col" ref={panel}>
+      {onTest.length === 0 ? null : (
+        <div className="border-b border-border">
+          <p className="m-0 px-2.5 pt-2 pb-1 text-sm text-faint" id={said}>
+            On this test
           </p>
-        ) : listed.length === 0 ? (
-          <p className="m-0 px-2.5 py-2 text-sm text-muted-foreground">
-            {wanted === ""
-              ? "This project has no personas yet."
-              : `No personas match “${search.trim()}”.`}
-          </p>
-        ) : (
-          <CommandGroup>
-            {listed.map((one) => (
-              <CommandItem
+          {/* Bounded and scrolling, as the list below it is: a test may name
+              more callers than a panel can hold. */}
+          <ul
+            className="m-0 max-h-40 list-none overflow-y-auto p-0"
+            aria-labelledby={said}
+          >
+            {onTest.map((one) => (
+              <li
+                className="flex flex-wrap items-center gap-x-2 px-2.5 pb-1"
                 key={one.id}
-                value={one.id}
-                /*
-                 * The row is the control, so the row says whether it is ticked.
-                 * `cmdk` has already spent `aria-selected` on the arrow keys'
-                 * highlight, and the box below is a picture of this state
-                 * rather than a second control announcing it again.
-                 */
-                aria-checked={chosen.includes(one.id)}
-                onSelect={() => toggle(one)}
               >
-                <Checkbox
-                  checked={chosen.includes(one.id)}
-                  readOnly
-                  tabIndex={-1}
-                  aria-hidden="true"
-                />
-                <span className="min-w-0 truncate">{one.name}</span>
-              </CommandItem>
+                <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+                  {one.name}
+                  {one.archivedAt === null || one.archivedAt === undefined ? null : (
+                    // The test still names somebody the project has deleted.
+                    // Saying so is what makes the Remove beside it make sense.
+                    <span className="text-faint"> (deleted)</span>
+                  )}
+                </span>
+                <Button
+                  aria-label={`Remove ${one.name}`}
+                  className="px-0"
+                  disabled={onlyOne}
+                  onClick={() => remove(one)}
+                  size="sm"
+                  type="button"
+                  variant="link"
+                  {...(onlyOne ? { why: LAST_PERSONA } : {})}
+                >
+                  Remove
+                </Button>
+              </li>
             ))}
-          </CommandGroup>
-        )}
-      </CommandList>
-      {truncated ? (
-        // The search above runs in the browser, so it reaches what was read
-        // and nothing beyond it. The sentence says that rather than promising
-        // a search that would quietly come back empty.
-        <p className="m-0 border-t border-border px-2.5 py-1.5 text-sm text-muted-foreground">
-          Egma holds more personas than this list read.
-        </p>
-      ) : null}
-      <div className="flex justify-end border-t border-border px-2.5 py-1.5">
-        <button className={cn(ADD_LINE, "underline")} type="button" onClick={onDone}>
-          Done
-        </button>
-      </div>
-    </Command>
+          </ul>
+        </div>
+      )}
+      {/*
+       * **`label` names the search field, not the list, and that is `cmdk`'s
+       * doing rather than a choice made here.** It renders the prop into a
+       * hidden element and points the field's `aria-labelledby` at it — always,
+       * even with no label given, which is why an `aria-label` on the field is
+       * overridden and silently does nothing. So the words that describe the
+       * typing have to arrive through this prop. The panel around it is a
+       * dialog and carries "Choose personas" of its own, so nothing is left
+       * unnamed.
+       */}
+      <Command label="Search personas">
+        <CommandInput
+          /*
+           * The caret starts here, and that is load-bearing rather than a
+           * courtesy. Radix puts focus on the panel itself when it opens, and the
+           * panel's own children then re-render as the persona pages arrive —
+           * which drops focus to the body, reads to Radix as focus leaving the
+           * panel, and shuts it. Landing the caret on the field holds it on
+           * something that outlives the list, and it is where somebody opening a
+           * search panel expects to be typing.
+           */
+          autoFocus
+          /* A placeholder is not a name: it leaves with the first keystroke. */
+          placeholder="Search personas"
+          value={search}
+          onValueChange={setSearch}
+        />
+        <CommandList>
+          {refused !== null ? (
+            <p className="m-0 px-2.5 py-2 text-sm text-failure">{refused}</p>
+          ) : people === null ? (
+            <p className="m-0 px-2.5 py-2 text-sm text-muted-foreground">
+              Loading personas…
+            </p>
+          ) : listed.length === 0 ? (
+            <p className="m-0 px-2.5 py-2 text-sm text-muted-foreground">
+              {wanted === ""
+                ? "This project has no personas yet."
+                : `No personas match “${search.trim()}”.`}
+            </p>
+          ) : (
+            <CommandGroup>
+              {listed.map((one) => (
+                <CommandItem
+                  key={one.id}
+                  value={one.id}
+                  /*
+                   * The row is the control, so the row says whether it is ticked.
+                   * `cmdk` has already spent `aria-selected` on the arrow keys'
+                   * highlight, and the box below is a picture of this state
+                   * rather than a second control announcing it again.
+                   */
+                  aria-checked={chosen.includes(one.id)}
+                  onSelect={() => toggle(one)}
+                >
+                  <Checkbox
+                    checked={chosen.includes(one.id)}
+                    readOnly
+                    tabIndex={-1}
+                    aria-hidden="true"
+                  />
+                  <span className="min-w-0 truncate">{one.name}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+        </CommandList>
+        {truncated ? (
+          // The search above runs in the browser, so it reaches what was read
+          // and nothing beyond it. The sentence says that rather than promising
+          // a search that would quietly come back empty.
+          <p className="m-0 border-t border-border px-2.5 py-1.5 text-sm text-muted-foreground">
+            Egma holds more personas than this list read.
+          </p>
+        ) : null}
+        <div className="flex justify-end border-t border-border px-2.5 py-1.5">
+          <button className={cn(ADD_LINE, "underline")} type="button" onClick={onDone}>
+            Done
+          </button>
+        </div>
+      </Command>
+    </div>
   );
 }
 /**

--- a/apps/web/test/test-suites-pages.test.tsx
+++ b/apps/web/test/test-suites-pages.test.tsx
@@ -1884,7 +1884,7 @@ describe("the suite-first Tests route", () => {
     const written = screen.getByText("Books service").closest("tr");
     if (written === null) throw new Error("the test's row is not on screen");
     fireEvent.click(within(written).getByText("Impatient Rita"));
-    fireEvent.click(within(written).getByRole("button", { name: "+ Add a persona" }));
+    fireEvent.click(within(written).getByRole("button", { name: "Edit personas" }));
 
     await waitFor(() => {
       expect(screen.getAllByRole("dialog", { name: "Choose personas" })).toHaveLength(1);
@@ -1926,7 +1926,7 @@ describe("the suite-first Tests route", () => {
     const written = screen.getByText("Books service").closest("tr");
     if (written === null) throw new Error("the test's row is not on screen");
     fireEvent.click(within(written).getByText("Impatient Rita"));
-    fireEvent.click(within(written).getByRole("button", { name: "+ Add a persona" }));
+    fireEvent.click(within(written).getByRole("button", { name: "Edit personas" }));
     fireEvent.click(await screen.findByRole("option", { name: "Calm Ben" }));
     expect(sent.some((request) => request.method === "PATCH")).toBe(false);
 
@@ -1975,6 +1975,143 @@ describe("the suite-first Tests route", () => {
     fireEvent.click(entryTrigger);
     expect(screen.getAllByRole("dialog", { name: "Choose personas" })).toHaveLength(1);
     expect(entryTrigger.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("takes a persona off a woken cell and commits the rest in their order", async () => {
+    const BEN = { id: "prs_2", name: "Calm Ben", archivedAt: null };
+    const CHRIS = { id: "prs_3", name: "Careful Chris", archivedAt: null };
+    gridAnswers({
+      tests: [testBody({ personas: [PERSONA, BEN, CHRIS] })],
+      saved: {
+        status: 200,
+        body: testBody({
+          personas: [PERSONA, CHRIS],
+          version: 2,
+          versionId: "tstv_2",
+        }),
+      },
+    });
+
+    render(<TestSuitePage />);
+
+    expect(await screen.findByText("Books service")).toBeTruthy();
+    const written = screen.getByText("Books service").closest("tr");
+    if (written === null) throw new Error("the test's row is not on screen");
+    fireEvent.click(
+      within(written).getByText("Impatient Rita, Calm Ben, Careful Chris"),
+    );
+
+    // The way in says what the panel does. A cell that already names somebody
+    // is edited, not only added to.
+    expect(
+      within(written).queryByRole("button", { name: "+ Add a persona" }),
+    ).toBeNull();
+    fireEvent.click(within(written).getByRole("button", { name: "Edit personas" }));
+
+    // The panel opens on who is on the test, in the order the test names them.
+    const panel = await screen.findByRole("dialog", { name: "Choose personas" });
+    expect(
+      within(panel)
+        .getAllByRole("listitem")
+        .map((row) => row.textContent),
+    ).toEqual(["Impatient RitaRemove", "Calm BenRemove", "Careful ChrisRemove"]);
+
+    fireEvent.click(within(panel).getByRole("button", { name: "Remove Calm Ben" }));
+
+    // Taking somebody off a test is an edit, not a destruction: nothing is
+    // asked, and nothing is sent until the panel shuts, exactly as unticking.
+    expect(screen.queryAllByRole("dialog")).toHaveLength(1);
+    expect(sent.some((request) => request.method === "PATCH")).toBe(false);
+
+    fireEvent.click(within(panel).getByRole("button", { name: "Done" }));
+
+    await waitFor(() => {
+      expect(sent.filter((request) => request.method === "PATCH")).toEqual([
+        {
+          path: "/v1/tests/tst_1",
+          method: "PATCH",
+          body: { personas: ["prs_1", "prs_3"], expectedVersionId: "tstv_1" },
+        },
+      ]);
+    });
+  });
+
+  it("keeps the one persona a test has left, and says why on the row", async () => {
+    gridAnswers();
+
+    render(<TestSuitePage />);
+
+    expect(await screen.findByText("Books service")).toBeTruthy();
+    const written = screen.getByText("Books service").closest("tr");
+    if (written === null) throw new Error("the test's row is not on screen");
+    fireEvent.click(within(written).getByText("Impatient Rita"));
+    fireEvent.click(within(written).getByRole("button", { name: "Edit personas" }));
+
+    const panel = await screen.findByRole("dialog", { name: "Choose personas" });
+    const remove = within(panel).getByRole("button", {
+      name: "Remove Impatient Rita",
+    }) as HTMLButtonElement;
+    expect(remove.disabled).toBe(true);
+
+    // The reason is drawn on the row and named by the button, so a keyboard
+    // and a screen reader reach it rather than only a resting pointer.
+    const why = within(panel).getByText("A test needs at least one persona");
+    expect(remove.getAttribute("aria-describedby")).toBe(why.id);
+
+    fireEvent.click(remove);
+    fireEvent.click(within(panel).getByRole("button", { name: "Done" }));
+
+    await waitFor(() => {
+      expect(screen.queryAllByRole("dialog", { name: "Choose personas" })).toHaveLength(0);
+    });
+    expect(sent.some((request) => request.method === "PATCH")).toBe(false);
+  });
+
+  it("shows a deleted persona a test still names, and takes it off", async () => {
+    const GONE = {
+      id: "prs_9",
+      name: "Retired Rae",
+      archivedAt: "2026-09-01T10:00:00.000Z",
+    };
+    gridAnswers({
+      tests: [testBody({ personas: [PERSONA, GONE] })],
+      saved: {
+        status: 200,
+        body: testBody({ personas: [PERSONA], version: 2, versionId: "tstv_2" }),
+      },
+    });
+
+    render(<TestSuitePage />);
+
+    expect(await screen.findByText("Books service")).toBeTruthy();
+    const written = screen.getByText("Books service").closest("tr");
+    if (written === null) throw new Error("the test's row is not on screen");
+    fireEvent.click(within(written).getByText("Impatient Rita, Retired Rae"));
+    fireEvent.click(within(written).getByRole("button", { name: "Edit personas" }));
+
+    const panel = await screen.findByRole("dialog", { name: "Choose personas" });
+
+    // The add list holds the project's available personas and nothing else, so
+    // this one is reachable nowhere but the section that names the test's own.
+    expect(await within(panel).findByRole("option", { name: "Impatient Rita" }))
+      .toBeTruthy();
+    expect(within(panel).queryByRole("option", { name: "Retired Rae" })).toBeNull();
+    expect(within(panel).getByText("(deleted)")).toBeTruthy();
+
+    fireEvent.click(within(panel).getByRole("button", { name: "Remove Retired Rae" }));
+    fireEvent.click(within(panel).getByRole("button", { name: "Done" }));
+
+    // The deleted persona is what refuses every later edit of this test, and
+    // this is the one way it comes off.
+    await waitFor(() => {
+      expect(sent.filter((request) => request.method === "PATCH")).toEqual([
+        {
+          path: "/v1/tests/tst_1",
+          method: "PATCH",
+          body: { personas: ["prs_1"], expectedVersionId: "tstv_1" },
+        },
+      ]);
+    });
   });
 
   it("saves a name against the revision it read, not the version", async () => {


### PR DESCRIPTION
## What changes

A person can remove a persona from a test, and the action is easy to find.

- In the Personas cell of the tests grid, the woken trigger now reads "Edit personas" instead of "+ Add a persona", because it always did both.
- The picker opens with the personas currently on the test, one row each with a quiet "Remove" action at the end. The existing add list with search and checkboxes sits below, unchanged.
- The last remaining persona cannot be removed. Its Remove is disabled and the row says why: a test needs at least one persona. The server already refuses an empty list; the client now says so before the request.
- A persona that was deleted but is still named on the test appears as "(deleted)" and can be removed. Until now it could not, because the picker listed only active personas, and every later edit of that test was refused.
- Removing takes the same path as unticking a checkbox: closing the picker commits, the change mints a test version as before, and the order of the remaining personas is kept.

No API, contract or database change. The persona library is untouched.

## Proof

- Focused grid tests cover the trigger label, the chosen list, remove and commit body, the last-persona guard, and the deleted persona.
- Web typecheck passes. The rest of the suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791435220&installation_model_id=431960&pr_number=318&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F318&signature=434f70eab0fe316a95515d35d74ce801459348c66dcc53a5195c16848b56eb02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes persona membership editable directly from the tests grid while preserving the existing save and versioning path.
- Changes the populated-cell trigger to “Edit personas.”
- Lists currently selected personas with removal controls.
- Prevents removal of the final persona and explains the constraint.
- Allows archived personas to be identified and removed.
- Adds focused coverage for removal, ordering, commit payloads, final-persona protection, and archived personas.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no actionable correctness, accessibility, security, or repository-rule issues were identified.

Selected personas are sourced from complete test response objects, removal preserves order and uses the established close-to-commit path, and focused tests cover the principal new behaviors and edge cases.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/tests/tests-grid.tsx | Adds selected-persona rows, guarded removal, archived-persona labeling, and focus handling while retaining the existing commit lifecycle. |
| apps/web/test/test-suites-pages.test.tsx | Updates trigger expectations and covers ordered removal, commit behavior, final-persona protection, and archived-persona recovery. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Open populated personas cell] --> B[Show selected personas]
    B --> C{Remove persona}
    C -->|More than one remains| D[Update local ordered selection]
    C -->|Only one remains| E[Disable removal and explain constraint]
    D --> F[Close picker or select Done]
    F --> G[Commit personas through existing PATCH path]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Tests grid: remove a persona from a test..."](https://github.com/egma-ai/egma/commit/b78e79d7798daa691987b801cd99c8d50b72ba9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61464443)</sub>

<!-- /greptile_comment -->