### PR TITLE
Add a build-only deployment dispatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      deploy:
+        description: Replace production and ship the web after publishing the images
+        required: true
+        type: boolean
+        default: true
 
 concurrency:
   # A newer push makes an older pull-request run pointless. Main is different:
@@ -348,6 +354,7 @@ jobs:
       DEPLOY_ROLE: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
       REGISTRY: ${{ vars.ECR_REGISTRY }}
       INSTANCE: ${{ vars.PLATFORM_INSTANCE_ID }}
+      REPLACE_PRODUCTION: ${{ github.event_name != 'workflow_dispatch' || inputs.deploy }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -363,8 +370,13 @@ jobs:
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "platform=true" >> "$GITHUB_OUTPUT"
-            echo "web=true" >> "$GITHUB_OUTPUT"
-            echo "Dispatched by hand: the whole deployment runs."
+            if [ "$REPLACE_PRODUCTION" = "true" ]; then
+              echo "web=true" >> "$GITHUB_OUTPUT"
+              echo "Dispatched by hand: the whole deployment runs."
+            else
+              echo "web=false" >> "$GITHUB_OUTPUT"
+              echo "Dispatched by hand: build and publish the exact image tags only."
+            fi
             exit 0
           fi
           base=$(curl -fsS \
@@ -413,7 +425,11 @@ jobs:
         if: steps.decide.outputs.platform == 'true'
         run: |
           missing=""
-          for v in DEPLOY_ROLE REGISTRY INSTANCE; do
+          required="DEPLOY_ROLE REGISTRY"
+          if [ "$REPLACE_PRODUCTION" = "true" ]; then
+            required="$required INSTANCE"
+          fi
+          for v in $required; do
             [ -n "${!v}" ] || missing="$missing $v"
           done
           if [ -n "$missing" ]; then
@@ -456,16 +472,28 @@ jobs:
             | docker login --username AWS --password-stdin "$REGISTRY"
           for app in api simulator grader; do
             echo "::group::$app"
-            docker build -f "apps/$app/Dockerfile" \
-              -t "$REGISTRY/egma/$app:$GITHUB_SHA" \
-              -t "$REGISTRY/egma/$app:latest" .
-            docker push "$REGISTRY/egma/$app:$GITHUB_SHA"
-            docker push "$REGISTRY/egma/$app:latest"
+            image="$REGISTRY/egma/$app"
+            tags=(-t "$image:$GITHUB_SHA")
+            if [ "$REPLACE_PRODUCTION" = "true" ]; then
+              tags+=(-t "$image:latest")
+            fi
+            docker build -f "apps/$app/Dockerfile" "${tags[@]}" .
+            push_log="$RUNNER_TEMP/$app-push.log"
+            docker push "$image:$GITHUB_SHA" 2>&1 | tee "$push_log"
+            digest=$(sed -n 's/.*digest: \(sha256:[0-9a-f]\{64\}\).*/\1/p' "$push_log" | tail -1)
+            [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+              echo "Could not read the $app image digest from docker push." >&2
+              exit 1
+            }
+            printf -- '- `%s@%s`\n' "$image" "$digest" >> "$GITHUB_STEP_SUMMARY"
+            if [ "$REPLACE_PRODUCTION" = "true" ]; then
+              docker push "$image:latest"
+            fi
             echo "::endgroup::"
           done
 
       - name: Replace what is running, and wait for its health checks
-        if: steps.decide.outputs.platform == 'true'
+        if: steps.decide.outputs.platform == 'true' && env.REPLACE_PRODUCTION == 'true'
         run: |
           set -euo pipefail
           ACCOUNT="${REGISTRY%%.*}"
@@ -496,7 +524,9 @@ jobs:
 
       - name: Yield when a newer merge owns the web deployment
         id: yield
-        if: steps.decide.outputs.platform == 'true' || steps.decide.outputs.web == 'true'
+        if: >-
+          env.REPLACE_PRODUCTION == 'true' &&
+          (steps.decide.outputs.platform == 'true' || steps.decide.outputs.web == 'true')
         run: |
           set -euo pipefail
           git fetch --quiet origin main
@@ -525,6 +555,7 @@ jobs:
 
       - name: Tell Vercel to ship
         if: >-
+          env.REPLACE_PRODUCTION == 'true' &&
           (steps.decide.outputs.platform == 'true' || steps.decide.outputs.web == 'true') &&
           steps.yield.outputs.fire == 'true'
         env:


### PR DESCRIPTION
The production workflow currently moves directly from image publication to SSM replacement. This adds a manual `deploy` switch, defaulting to the current deployment behavior, so `deploy=false` can stage only the three exact-SHA images before a coordinated database cutover. Build-only runs never write `latest`, call SSM, or fire the Vercel hook, and the workflow records each pushed digest in its summary.

Validation: YAML syntax parse; `git diff --check`; digest parser sample; independent runtime review with zero findings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791446877&installation_model_id=431960&pr_number=322&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F322&signature=f4e9c26275a58f662d1494549d6d783e45b8ad7715d177ace65ba309cc8d4b74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a manual build-only production workflow mode while preserving full deployment as the default.
- Adds a required `deploy` workflow-dispatch input that defaults to `true`.
- Publishes only exact-commit image tags when `deploy=false`.
- Gates latest-tag publication, SSM replacement, deployment yielding, and the Vercel hook behind the deployment switch.
- Records each exact-SHA image digest in the workflow summary.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because build-only dispatches retain image publication while all production-changing operations remain consistently gated.

No actionable failures remain; the workflow preserves existing push and default manual-deployment behavior, and `deploy=false` reaches only credential acquisition and exact-SHA image publication.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/test.yml | Adds a default-on deployment switch, consistently gates production-changing operations, and reports exact-SHA image digests for build-only and full-deployment runs. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Push or manual dispatch] --> B{Manual dispatch?}
  B -- No --> C[Full deployment]
  B -- Yes --> D{deploy input}
  D -- true --> C
  D -- false --> E[Build-only publication]
  C --> F[Build and push exact-SHA images]
  F --> G[Record image digests]
  G --> H[Push latest tags]
  H --> I[Replace production through SSM]
  I --> J[Yield check and Vercel hook]
  E --> K[Build and push exact-SHA images]
  K --> L[Record image digests]
  L --> M[Stop without production replacement]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Add a build-only deployment dispatch"](https://github.com/egma-ai/egma/commit/ba70e9f4a50142bf881d0318a17b8a4aee9c46e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61506580)</sub>

<!-- /greptile_comment -->