### PR TITLE
Verify published SOCI manifests from ECR

### DIFF
--- a/.github/fixtures/api-ecr-response.json
+++ b/.github/fixtures/api-ecr-response.json
@@ -1,0 +1,15 @@
+{
+    "images": [
+        {
+            "registryId": "599151709955",
+            "repositoryName": "egma/api",
+            "imageId": {
+                "imageDigest": "sha256:87d66f96b319dfbcfaae2c2d4cff5a39fff58f466340872c5fa18578ea054a08",
+                "imageTag": "29f06a444d3e6fe89c371977cfa15c719025816c"
+            },
+            "imageManifest": "{\n  \"schemaVersion\": 2,\n  \"mediaType\": \"application/vnd.docker.distribution.manifest.list.v2+json\",\n  \"manifests\": [\n    {\n      \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\n      \"digest\": \"sha256:8cee161977f3909da918a045d0efb918af7e98a0f4208f1be9ca6e1ff038cb07\",\n      \"size\": 6990,\n      \"platform\": {\n        \"architecture\": \"amd64\",\n        \"os\": \"linux\"\n      }\n    },\n    {\n      \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\n      \"digest\": \"sha256:dd08e526f322d8b46ea41b4d784bc2985f22f336cace5aa9b2f1a943cb0692c5\",\n      \"size\": 6990,\n      \"platform\": {\n        \"architecture\": \"arm64\",\n        \"os\": \"linux\"\n      }\n    }\n  ]\n}",
+            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.list.v2+json"
+        }
+    ],
+    "failures": []
+}

--- a/.github/fixtures/grader-ecr-response.json
+++ b/.github/fixtures/grader-ecr-response.json
@@ -1,0 +1,15 @@
+{
+    "images": [
+        {
+            "registryId": "599151709955",
+            "repositoryName": "egma/grader",
+            "imageId": {
+                "imageDigest": "sha256:34e31ac2b70460d00c1bfea4cbc91c8b30af864c92499603e59014674ff06aa5",
+                "imageTag": "29f06a444d3e6fe89c371977cfa15c719025816c"
+            },
+            "imageManifest": "{\n  \"schemaVersion\": 2,\n  \"mediaType\": \"application/vnd.docker.distribution.manifest.list.v2+json\",\n  \"manifests\": [\n    {\n      \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\n      \"digest\": \"sha256:58ffea7fcca61dcbf28cc4a3d5a273f0505ce43348cf5c7831a47b78136d6f75\",\n      \"size\": 5949,\n      \"platform\": {\n        \"architecture\": \"amd64\",\n        \"os\": \"linux\"\n      }\n    },\n    {\n      \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\n      \"digest\": \"sha256:ddb6ca07ee9887dd81db16d5bee0113f9e628b6f6ce1d50a9a7c9030110a5519\",\n      \"size\": 5949,\n      \"platform\": {\n        \"architecture\": \"arm64\",\n        \"os\": \"linux\"\n      }\n    }\n  ]\n}",
+            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.list.v2+json"
+        }
+    ],
+    "failures": []
+}

--- a/.github/fixtures/simulator-image-children-response.json
+++ b/.github/fixtures/simulator-image-children-response.json
@@ -1,0 +1,23 @@
+{
+    "images": [
+        {
+            "registryId": "599151709955",
+            "repositoryName": "egma/simulator",
+            "imageId": {
+                "imageDigest": "sha256:757810721cb41e65575969d35e88a86d3fb594f1daabd93e1c9ed3edfbc66e03"
+            },
+            "imageManifest": "{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\",\"config\":{\"mediaType\":\"application/vnd.oci.image.config.v1+json\",\"digest\":\"sha256:94137ffcb4864c3883d561ae6abbe5a1372fc24f439b53f5196ffd77cb043779\",\"size\":7076},\"layers\":[{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:dbaa5c62f0ed2acebf15ba5fc565cb938c8495c0b77e1acfab05f5a7354ab1a9\",\"size\":29148336},{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:c60e66565e0f0a275587aff19e0564e3e98c0414ce0c29a131ffd679651bb09e\",\"size\":3533328},{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:a4a2a2ab8a7b722a68b5089d8af948fdd24e2918c4638155d7fea408b50273a7\",\"size\":12592330},{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:45756fac4d8f5ec720e3c75c92e198d239d50101bb24911985b6282b1699fda8\",\"size\":250},{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:299b973aa5528f320b370c9a2f9434942c0533fe029541bd69dd069cf45faf20\",\"size\":92},{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:9569d5937f554eebadb16bb7d9e17f0bfad4c06efdb5efc60c67ad58f8b02a9d\",\"size\":252815387},{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:c8ea1b9f33f50f2244b3759e70c9d1698c28be64d8395481890000648812c199\",\"size\":99729},{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:2348dd199458d41618817e4f7baf601dbfababc9df791a78939a1d843bfe84d6\",\"size\":40075}],\"annotations\":{\"com.amazon.soci.index-digest\":\"sha256:a11f26ed5b28230f14e57ae6be6d2c1817a531af96df1283aa84afe449f9efc1\"}}",
+            "imageManifestMediaType": "application/vnd.oci.image.manifest.v1+json"
+        },
+        {
+            "registryId": "599151709955",
+            "repositoryName": "egma/simulator",
+            "imageId": {
+                "imageDigest": "sha256:23caa07746e3c293b30583670839e517fb62c03714361560e2b82f8e8505a880"
+            },
+            "imageManifest": "{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\",\"config\":{\"mediaType\":\"application/vnd.oci.image.config.v1+json\",\"digest\":\"sha256:24de7d0f3e1cb19cb257f83ed52d8d9668781c408ab5c19ae8880111822b408d\",\"size\":7069},\"layers\":[{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:b6c63e8a8451a81a14dfc5be8ad9d1ab4e084a09df04dd753bb979d286c277cd\",\"size\":29223190},{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:574d89de9063bf87c3336f6e5ecb1282c6f201986d35ced50fd3d5f229f653e8\",\"size\":3368466},{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:49cb2453f7328741066594f24b99c7e55a693f728614638a27197977b7a1c8f6\",\"size\":12490287},{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:1d9af84f35e323df65d86c4637cf40431591ccf51ade123023e20b535353b9a2\",\"size\":250},{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:0aafe3c914a0d4dcb0c6238246177f7d4002588ecf33003972a2433cfd3c80f0\",\"size\":92},{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:5c4593ed16685f67e959a6f5346d435d85f9bb5ae00146eb9698719ccfe210a0\",\"size\":246275321},{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:1d547ff2aa47df034315f37054d2fec2351fa3b874bfbd55189953fd59558174\",\"size\":99731},{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:02d046b9202972fb878410dcd78862c3ec4a2183f4218c0ecc22d6d76d080749\",\"size\":40073}],\"annotations\":{\"com.amazon.soci.index-digest\":\"sha256:acc0c1aa4594cb2d78a6153c2e0f93c83d29c67e95eb5421650b95025019fde2\"}}",
+            "imageManifestMediaType": "application/vnd.oci.image.manifest.v1+json"
+        }
+    ],
+    "failures": []
+}

--- a/.github/fixtures/simulator-soci-children-response.json
+++ b/.github/fixtures/simulator-soci-children-response.json
@@ -1,0 +1,23 @@
+{
+    "images": [
+        {
+            "registryId": "599151709955",
+            "repositoryName": "egma/simulator",
+            "imageId": {
+                "imageDigest": "sha256:acc0c1aa4594cb2d78a6153c2e0f93c83d29c67e95eb5421650b95025019fde2"
+            },
+            "imageManifest": "{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\",\"config\":{\"mediaType\":\"application/vnd.amazon.soci.index.v2+json\",\"digest\":\"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a\",\"size\":2},\"layers\":[{\"mediaType\":\"application/octet-stream\",\"digest\":\"sha256:7456591ba062cc1841eda7b68796fe33428bc9ec48e76164d2e8b284be2517a3\",\"size\":1522296,\"annotations\":{\"com.amazon.soci.image-layer-digest\":\"sha256:b6c63e8a8451a81a14dfc5be8ad9d1ab4e084a09df04dd753bb979d286c277cd\",\"com.amazon.soci.image-layer-mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"com.amazon.soci.span-size\":\"4194304\"}},{\"mediaType\":\"application/octet-stream\",\"digest\":\"sha256:a6974bc50cf53281af43f93daa034d71d112c5c936ef8839043ac20fbf9436a8\",\"size\":681440,\"annotations\":{\"com.amazon.soci.image-layer-digest\":\"sha256:49cb2453f7328741066594f24b99c7e55a693f728614638a27197977b7a1c8f6\",\"com.amazon.soci.image-layer-mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"com.amazon.soci.span-size\":\"4194304\"}},{\"mediaType\":\"application/octet-stream\",\"digest\":\"sha256:93786c4c0aa324a1e3efd6a1387ad959d9fbfa8776df8020ce7dcd30210a0ec5\",\"size\":11397816,\"annotations\":{\"com.amazon.soci.image-layer-digest\":\"sha256:5c4593ed16685f67e959a6f5346d435d85f9bb5ae00146eb9698719ccfe210a0\",\"com.amazon.soci.image-layer-mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"com.amazon.soci.span-size\":\"4194304\"}}],\"annotations\":{\"com.amazon.soci.build-tool-identifier\":\"AWS SOCI CLI v0.2\"}}",
+            "imageManifestMediaType": "application/vnd.oci.image.manifest.v1+json"
+        },
+        {
+            "registryId": "599151709955",
+            "repositoryName": "egma/simulator",
+            "imageId": {
+                "imageDigest": "sha256:a11f26ed5b28230f14e57ae6be6d2c1817a531af96df1283aa84afe449f9efc1"
+            },
+            "imageManifest": "{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\",\"config\":{\"mediaType\":\"application/vnd.amazon.soci.index.v2+json\",\"digest\":\"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a\",\"size\":2},\"layers\":[{\"mediaType\":\"application/octet-stream\",\"digest\":\"sha256:3de4fa02365896f974e87a4d114219c3034671770ae0ee6d19bef422853663ce\",\"size\":1356968,\"annotations\":{\"com.amazon.soci.image-layer-digest\":\"sha256:dbaa5c62f0ed2acebf15ba5fc565cb938c8495c0b77e1acfab05f5a7354ab1a9\",\"com.amazon.soci.image-layer-mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"com.amazon.soci.span-size\":\"4194304\"}},{\"mediaType\":\"application/octet-stream\",\"digest\":\"sha256:262dde1f334d564a5156ad5d8173eaec7c7e21ec7df898b1d483263a87ef27b8\",\"size\":681392,\"annotations\":{\"com.amazon.soci.image-layer-digest\":\"sha256:a4a2a2ab8a7b722a68b5089d8af948fdd24e2918c4638155d7fea408b50273a7\",\"com.amazon.soci.image-layer-mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"com.amazon.soci.span-size\":\"4194304\"}},{\"mediaType\":\"application/octet-stream\",\"digest\":\"sha256:d5aa7293b6bfe8f7c26241f86c5d683a329a11e48c1de871a27cc41cc4e4a346\",\"size\":11431424,\"annotations\":{\"com.amazon.soci.image-layer-digest\":\"sha256:9569d5937f554eebadb16bb7d9e17f0bfad4c06efdb5efc60c67ad58f8b02a9d\",\"com.amazon.soci.image-layer-mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"com.amazon.soci.span-size\":\"4194304\"}}],\"annotations\":{\"com.amazon.soci.build-tool-identifier\":\"AWS SOCI CLI v0.2\"}}",
+            "imageManifestMediaType": "application/vnd.oci.image.manifest.v1+json"
+        }
+    ],
+    "failures": []
+}

--- a/.github/fixtures/simulator-soci-manifest.json
+++ b/.github/fixtures/simulator-soci-manifest.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:757810721cb41e65575969d35e88a86d3fb594f1daabd93e1c9ed3edfbc66e03",
+      "size": 1624,
+      "annotations": {
+        "com.amazon.soci.index-digest": "sha256:a11f26ed5b28230f14e57ae6be6d2c1817a531af96df1283aa84afe449f9efc1"
+      },
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:23caa07746e3c293b30583670839e517fb62c03714361560e2b82f8e8505a880",
+      "size": 1624,
+      "annotations": {
+        "com.amazon.soci.index-digest": "sha256:acc0c1aa4594cb2d78a6153c2e0f93c83d29c67e95eb5421650b95025019fde2"
+      },
+      "platform": {
+        "architecture": "arm64",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:a11f26ed5b28230f14e57ae6be6d2c1817a531af96df1283aa84afe449f9efc1",
+      "size": 1492,
+      "annotations": {
+        "com.amazon.soci.image-manifest-digest": "sha256:757810721cb41e65575969d35e88a86d3fb594f1daabd93e1c9ed3edfbc66e03"
+      },
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:acc0c1aa4594cb2d78a6153c2e0f93c83d29c67e95eb5421650b95025019fde2",
+      "size": 1492,
+      "annotations": {
+        "com.amazon.soci.image-manifest-digest": "sha256:23caa07746e3c293b30583670839e517fb62c03714361560e2b82f8e8505a880"
+      },
+      "platform": {
+        "architecture": "arm64",
+        "os": "linux"
+      }
+    }
+  ]
+}

--- a/.github/test_verify_platform_images.py
+++ b/.github/test_verify_platform_images.py
@@ -1,5 +1,5 @@
-import importlib.util
 import hashlib
+import importlib.util
 import json
 import pathlib
 import unittest
@@ -15,7 +15,9 @@ FIXTURES = pathlib.Path(__file__).with_name("fixtures")
 class PlatformImageVerifierTest(unittest.TestCase):
     def setUp(self) -> None:
         self.index = json.loads((FIXTURES / "simulator-soci-manifest.json").read_text())
-        responses = json.loads((FIXTURES / "simulator-soci-children-response.json").read_text())
+        responses = json.loads(
+            (FIXTURES / "simulator-soci-children-response.json").read_text()
+        )
         responses["images"] += json.loads(
             (FIXTURES / "simulator-image-children-response.json").read_text()
         )["images"]
@@ -48,7 +50,9 @@ class PlatformImageVerifierTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.verify(wrong_platform)
         wrong_link = json.loads(json.dumps(self.index))
-        wrong_link["manifests"][0]["annotations"][VERIFY.INDEX_DIGEST] = "sha256:" + "0" * 64
+        wrong_link["manifests"][0]["annotations"][VERIFY.INDEX_DIGEST] = (
+            "sha256:" + "0" * 64
+        )
         with self.assertRaises(ValueError):
             self.verify(wrong_link)
 

--- a/.github/test_verify_platform_images.py
+++ b/.github/test_verify_platform_images.py
@@ -74,6 +74,17 @@ class PlatformImageVerifierTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "manifest size mismatch"):
             self.verify(wrong_size)
 
+    def test_rejects_soci_links_to_unrelated_image_layers(self) -> None:
+        soci_digest = self.index["manifests"][2]["digest"]
+        image_digest = self.index["manifests"][0]["digest"]
+        soci = json.loads(self.children[soci_digest])
+        image = json.loads(self.children[image_digest])
+        soci["layers"][0]["annotations"]["com.amazon.soci.image-layer-digest"] = (
+            "sha256:" + "0" * 64
+        )
+        with self.assertRaisesRegex(ValueError, "outside its paired image"):
+            VERIFY.verify_soci_layers(image, soci)
+
     def test_plain_images_require_exact_native_platforms(self) -> None:
         plain = {
             "schemaVersion": 2,

--- a/.github/test_verify_platform_images.py
+++ b/.github/test_verify_platform_images.py
@@ -63,10 +63,16 @@ class PlatformImageVerifierTest(unittest.TestCase):
         raw = json.dumps(wrong_type, separators=(",", ":"))
         digest = "sha256:" + hashlib.sha256(raw.encode()).hexdigest()
         with self.assertRaisesRegex(ValueError, "wrong config media type"):
-            VERIFY.verify_child(raw, digest, VERIFY.SOCI_V2, None)
+            VERIFY.verify_child(raw, digest, len(raw.encode()), VERIFY.SOCI_V2, None)
         children = {**self.children, soci_digest: self.children[soci_digest] + " "}
         with self.assertRaises(ValueError):
             self.verify(children=children)
+
+    def test_rejects_wrong_child_size(self) -> None:
+        wrong_size = json.loads(json.dumps(self.index))
+        wrong_size["manifests"][0]["size"] += 1
+        with self.assertRaisesRegex(ValueError, "manifest size mismatch"):
+            self.verify(wrong_size)
 
     def test_plain_images_require_exact_native_platforms(self) -> None:
         plain = {

--- a/.github/test_verify_platform_images.py
+++ b/.github/test_verify_platform_images.py
@@ -1,0 +1,89 @@
+import importlib.util
+import hashlib
+import json
+import pathlib
+import unittest
+
+MODULE_PATH = pathlib.Path(__file__).with_name("verify-platform-images.py")
+SPEC = importlib.util.spec_from_file_location("verify_platform_images", MODULE_PATH)
+assert SPEC and SPEC.loader
+VERIFY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VERIFY)
+FIXTURES = pathlib.Path(__file__).with_name("fixtures")
+
+
+class PlatformImageVerifierTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.index = json.loads((FIXTURES / "simulator-soci-manifest.json").read_text())
+        responses = json.loads((FIXTURES / "simulator-soci-children-response.json").read_text())
+        responses["images"] += json.loads(
+            (FIXTURES / "simulator-image-children-response.json").read_text()
+        )["images"]
+        self.children = {
+            image["imageId"]["imageDigest"]: image["imageManifest"]
+            for image in responses["images"]
+        }
+
+    def verify(self, index=None, children=None) -> None:
+        VERIFY.verify_simulator_index(
+            self.index if index is None else index,
+            (self.children if children is None else children).__getitem__,
+        )
+
+    def test_accepts_actual_soci_v2_manifest_shape(self) -> None:
+        self.verify()
+
+    def test_rejects_missing_extra_and_duplicate_descriptors(self) -> None:
+        for manifests in (
+            self.index["manifests"][:-1],
+            self.index["manifests"] + [self.index["manifests"][0]],
+            self.index["manifests"][:-1] + [self.index["manifests"][0]],
+        ):
+            with self.subTest(count=len(manifests)), self.assertRaises(ValueError):
+                self.verify({**self.index, "manifests": manifests})
+
+    def test_rejects_wrong_platform_and_cross_links(self) -> None:
+        wrong_platform = json.loads(json.dumps(self.index))
+        wrong_platform["manifests"][0]["platform"]["architecture"] = "s390x"
+        with self.assertRaises(ValueError):
+            self.verify(wrong_platform)
+        wrong_link = json.loads(json.dumps(self.index))
+        wrong_link["manifests"][0]["annotations"][VERIFY.INDEX_DIGEST] = "sha256:" + "0" * 64
+        with self.assertRaises(ValueError):
+            self.verify(wrong_link)
+
+    def test_rejects_wrong_child_type_and_digest(self) -> None:
+        soci_digest = self.index["manifests"][2]["digest"]
+        wrong_type = json.loads(self.children[soci_digest])
+        wrong_type["config"]["mediaType"] = VERIFY.OCI_CONFIG
+        raw = json.dumps(wrong_type, separators=(",", ":"))
+        digest = "sha256:" + hashlib.sha256(raw.encode()).hexdigest()
+        with self.assertRaisesRegex(ValueError, "wrong config media type"):
+            VERIFY.verify_child(raw, digest, VERIFY.SOCI_V2, None)
+        children = {**self.children, soci_digest: self.children[soci_digest] + " "}
+        with self.assertRaises(ValueError):
+            self.verify(children=children)
+
+    def test_plain_images_require_exact_native_platforms(self) -> None:
+        plain = {
+            "schemaVersion": 2,
+            "mediaType": VERIFY.OCI_INDEX,
+            "manifests": [
+                {"mediaType": VERIFY.OCI_MANIFEST, "digest": "sha256:" + str(i) * 64,
+                 "platform": {"os": "linux", "architecture": arch}}
+                for i, arch in ((1, "amd64"), (2, "arm64"))
+            ],
+        }
+        VERIFY.verify_native_index(plain)
+        plain["manifests"].append(plain["manifests"][0])
+        with self.assertRaises(ValueError):
+            VERIFY.verify_native_index(plain)
+
+    def test_accepts_actual_docker_manifest_lists(self) -> None:
+        for name in ("api-ecr-response.json", "grader-ecr-response.json"):
+            response = json.loads((FIXTURES / name).read_text())
+            VERIFY.verify_native_index(json.loads(response["images"][0]["imageManifest"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/verify-platform-images.py
+++ b/.github/verify-platform-images.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Verify published native images and the simulator's SOCI v2 indexes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import sys
+
+OCI_INDEX = "application/vnd.oci.image.index.v1+json"
+OCI_MANIFEST = "application/vnd.oci.image.manifest.v1+json"
+DOCKER_INDEX = "application/vnd.docker.distribution.manifest.list.v2+json"
+DOCKER_MANIFEST = "application/vnd.docker.distribution.manifest.v2+json"
+OCI_CONFIG = "application/vnd.oci.image.config.v1+json"
+SOCI_V2 = "application/vnd.amazon.soci.index.v2+json"
+INDEX_DIGEST = "com.amazon.soci.index-digest"
+IMAGE_DIGEST = "com.amazon.soci.image-manifest-digest"
+PLATFORMS = {"linux/amd64", "linux/arm64"}
+DIGEST = re.compile(r"sha256:[0-9a-f]{64}\Z")
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def platform(descriptor: dict) -> str:
+    value = descriptor.get("platform")
+    if not isinstance(value, dict):
+        fail("descriptor has no platform")
+    os_name = value.get("os")
+    architecture = value.get("architecture")
+    if not isinstance(os_name, str) or not isinstance(architecture, str):
+        fail("descriptor has an incomplete platform")
+    return f"{os_name}/{architecture}"
+
+
+def descriptor_digest(descriptor: dict) -> str:
+    value = descriptor.get("digest")
+    if not isinstance(value, str) or not DIGEST.fullmatch(value):
+        fail("descriptor has an invalid digest")
+    return value
+
+
+def parse_manifest(raw: str, expected_digest: str | None = None) -> dict:
+    if expected_digest is not None:
+        actual = "sha256:" + hashlib.sha256(raw.encode()).hexdigest()
+        if actual != expected_digest:
+            fail(f"manifest digest mismatch: expected {expected_digest}, got {actual}")
+    value = json.loads(raw)
+    if not isinstance(value, dict) or value.get("schemaVersion") != 2:
+        fail("manifest is not schema version 2")
+    return value
+
+
+def native_descriptors(index: dict) -> dict[str, dict]:
+    index_type = index.get("mediaType")
+    child_type = {OCI_INDEX: OCI_MANIFEST, DOCKER_INDEX: DOCKER_MANIFEST}.get(index_type)
+    if child_type is None:
+        fail("tag does not contain a supported multi-platform image index")
+    descriptors = index.get("manifests")
+    if not isinstance(descriptors, list):
+        fail("image index has no descriptor list")
+    result: dict[str, dict] = {}
+    for descriptor in descriptors:
+        if not isinstance(descriptor, dict):
+            fail("image index contains a non-object descriptor")
+        name = platform(descriptor)
+        if name in result:
+            fail(f"duplicate descriptor for {name}")
+        if descriptor.get("mediaType") != child_type:
+            fail(f"unexpected descriptor media type for {name}")
+        descriptor_digest(descriptor)
+        result[name] = descriptor
+    return result
+
+
+def verify_native_index(index: dict) -> None:
+    descriptors = native_descriptors(index)
+    if set(descriptors) != PLATFORMS:
+        fail("native image index must contain exactly linux/amd64 and linux/arm64")
+
+
+def verify_child(raw: str, digest: str, expected_config: str, index_digest: str | None) -> None:
+    child = parse_manifest(raw, digest)
+    if child.get("mediaType") != OCI_MANIFEST:
+        fail("child is not an OCI image manifest")
+    config = child.get("config")
+    if not isinstance(config, dict) or config.get("mediaType") != expected_config:
+        fail(f"child has the wrong config media type for {digest}")
+    annotations = child.get("annotations") or {}
+    if not isinstance(annotations, dict):
+        fail("child annotations are not an object")
+    if index_digest is not None and annotations.get(INDEX_DIGEST) != index_digest:
+        fail("native child does not point to its SOCI index")
+
+
+def verify_simulator_index(index: dict, fetch_child) -> None:
+    if index.get("mediaType") != OCI_INDEX:
+        fail("tag does not contain an OCI image index")
+    descriptors = index.get("manifests")
+    if not isinstance(descriptors, list) or len(descriptors) != 4:
+        fail("simulator index must contain exactly four descriptors")
+
+    images: dict[str, dict] = {}
+    soci: dict[str, dict] = {}
+    for descriptor in descriptors:
+        if not isinstance(descriptor, dict):
+            fail("simulator index contains a non-object descriptor")
+        name = platform(descriptor)
+        if descriptor.get("mediaType") != OCI_MANIFEST:
+            fail(f"unexpected descriptor media type for {name}")
+        descriptor_digest(descriptor)
+        annotations = descriptor.get("annotations")
+        if not isinstance(annotations, dict):
+            fail(f"simulator descriptor for {name} has invalid annotations")
+        has_index = INDEX_DIGEST in annotations
+        has_image = IMAGE_DIGEST in annotations
+        if has_index == has_image:
+            fail(f"simulator descriptor for {name} must have exactly one SOCI cross-link")
+        if has_index:
+            target = images
+            linked = annotations[INDEX_DIGEST]
+        elif IMAGE_DIGEST in annotations:
+            target = soci
+            linked = annotations[IMAGE_DIGEST]
+        else:
+            fail(f"simulator descriptor for {name} has no SOCI cross-link")
+        if name in target:
+            fail(f"duplicate simulator descriptor for {name}")
+        if not isinstance(linked, str) or not DIGEST.fullmatch(linked):
+            fail(f"simulator descriptor for {name} has an invalid cross-link")
+        target[name] = descriptor
+
+    if set(images) != PLATFORMS or set(soci) != PLATFORMS:
+        fail("simulator must contain one image and one SOCI index for each platform")
+    for name in PLATFORMS:
+        image_digest = descriptor_digest(images[name])
+        soci_digest = descriptor_digest(soci[name])
+        if images[name]["annotations"][INDEX_DIGEST] != soci_digest:
+            fail(f"image-to-SOCI cross-link is wrong for {name}")
+        if soci[name]["annotations"][IMAGE_DIGEST] != image_digest:
+            fail(f"SOCI-to-image cross-link is wrong for {name}")
+        verify_child(fetch_child(image_digest), image_digest, OCI_CONFIG, soci_digest)
+        verify_child(fetch_child(soci_digest), soci_digest, SOCI_V2, None)
+
+
+def ecr_manifest(repository: str, image_id: str) -> tuple[str, str]:
+    key = "imageDigest" if image_id.startswith("sha256:") else "imageTag"
+    command = [
+        "aws", "ecr", "batch-get-image", "--repository-name", repository,
+        "--image-ids", f"{key}={image_id}", "--output", "json",
+    ]
+    response = json.loads(subprocess.check_output(command, text=True))
+    images = response.get("images")
+    failures = response.get("failures")
+    if not isinstance(images, list) or len(images) != 1 or failures != []:
+        fail(f"ECR returned an ambiguous result for {repository}:{image_id}")
+    image = images[0]
+    raw = image.get("imageManifest")
+    digest = (image.get("imageId") or {}).get("imageDigest")
+    if not isinstance(raw, str) or not isinstance(digest, str):
+        fail(f"ECR omitted manifest data for {repository}:{image_id}")
+    return raw, digest
+
+
+def main() -> int:
+    if len(sys.argv) != 2 or not re.fullmatch(r"[0-9a-f]{40}", sys.argv[1]):
+        print("usage: verify-platform-images.py <40-character release SHA>", file=sys.stderr)
+        return 2
+    release_sha = sys.argv[1]
+    try:
+        for app in ("api", "grader", "simulator"):
+            repository = f"egma/{app}"
+            raw, digest = ecr_manifest(repository, release_sha)
+            index = parse_manifest(raw, digest)
+            if app == "simulator":
+                verify_simulator_index(index, lambda child: ecr_manifest(repository, child)[0])
+            else:
+                verify_native_index(index)
+            print(f"{app}:{release_sha} digest {digest} passed manifest verification.")
+        print(f"simulator:{release_sha} contains two cross-linked SOCI v2 indexes.")
+    except (json.JSONDecodeError, subprocess.CalledProcessError, ValueError) as error:
+        print(f"Platform image verification failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/verify-platform-images.py
+++ b/.github/verify-platform-images.py
@@ -56,7 +56,10 @@ def parse_manifest(raw: str, expected_digest: str | None = None) -> dict:
 
 def native_descriptors(index: dict) -> dict[str, dict]:
     index_type = index.get("mediaType")
-    child_type = {OCI_INDEX: OCI_MANIFEST, DOCKER_INDEX: DOCKER_MANIFEST}.get(index_type)
+    child_type = {
+        OCI_INDEX: OCI_MANIFEST,
+        DOCKER_INDEX: DOCKER_MANIFEST,
+    }.get(index_type)
     if child_type is None:
         fail("tag does not contain a supported multi-platform image index")
     descriptors = index.get("manifests")
@@ -82,7 +85,9 @@ def verify_native_index(index: dict) -> None:
         fail("native image index must contain exactly linux/amd64 and linux/arm64")
 
 
-def verify_child(raw: str, digest: str, expected_config: str, index_digest: str | None) -> None:
+def verify_child(
+    raw: str, digest: str, expected_config: str, index_digest: str | None
+) -> None:
     child = parse_manifest(raw, digest)
     if child.get("mediaType") != OCI_MANIFEST:
         fail("child is not an OCI image manifest")
@@ -118,7 +123,9 @@ def verify_simulator_index(index: dict, fetch_child) -> None:
         has_index = INDEX_DIGEST in annotations
         has_image = IMAGE_DIGEST in annotations
         if has_index == has_image:
-            fail(f"simulator descriptor for {name} must have exactly one SOCI cross-link")
+            fail(
+                f"simulator descriptor for {name} must have exactly one SOCI cross-link"
+            )
         if has_index:
             target = images
             linked = annotations[INDEX_DIGEST]
@@ -167,7 +174,10 @@ def ecr_manifest(repository: str, image_id: str) -> tuple[str, str]:
 
 def main() -> int:
     if len(sys.argv) != 2 or not re.fullmatch(r"[0-9a-f]{40}", sys.argv[1]):
-        print("usage: verify-platform-images.py <40-character release SHA>", file=sys.stderr)
+        print(
+            "usage: verify-platform-images.py <40-character release SHA>",
+            file=sys.stderr,
+        )
         return 2
     release_sha = sys.argv[1]
     try:
@@ -176,7 +186,12 @@ def main() -> int:
             raw, digest = ecr_manifest(repository, release_sha)
             index = parse_manifest(raw, digest)
             if app == "simulator":
-                verify_simulator_index(index, lambda child: ecr_manifest(repository, child)[0])
+                verify_simulator_index(
+                    index,
+                    lambda child, repository=repository: ecr_manifest(
+                        repository, child
+                    )[0],
+                )
             else:
                 verify_native_index(index)
             print(f"{app}:{release_sha} digest {digest} passed manifest verification.")

--- a/.github/verify-platform-images.py
+++ b/.github/verify-platform-images.py
@@ -86,8 +86,14 @@ def verify_native_index(index: dict) -> None:
 
 
 def verify_child(
-    raw: str, digest: str, expected_config: str, index_digest: str | None
+    raw: str,
+    digest: str,
+    expected_size: int,
+    expected_config: str,
+    index_digest: str | None,
 ) -> None:
+    if len(raw.encode()) != expected_size:
+        fail(f"manifest size mismatch for {digest}")
     child = parse_manifest(raw, digest)
     if child.get("mediaType") != OCI_MANIFEST:
         fail("child is not an OCI image manifest")
@@ -149,8 +155,20 @@ def verify_simulator_index(index: dict, fetch_child) -> None:
             fail(f"image-to-SOCI cross-link is wrong for {name}")
         if soci[name]["annotations"][IMAGE_DIGEST] != image_digest:
             fail(f"SOCI-to-image cross-link is wrong for {name}")
-        verify_child(fetch_child(image_digest), image_digest, OCI_CONFIG, soci_digest)
-        verify_child(fetch_child(soci_digest), soci_digest, SOCI_V2, None)
+        verify_child(
+            fetch_child(image_digest),
+            image_digest,
+            images[name].get("size"),
+            OCI_CONFIG,
+            soci_digest,
+        )
+        verify_child(
+            fetch_child(soci_digest),
+            soci_digest,
+            soci[name].get("size"),
+            SOCI_V2,
+            None,
+        )
 
 
 def ecr_manifest(repository: str, image_id: str) -> tuple[str, str]:

--- a/.github/verify-platform-images.py
+++ b/.github/verify-platform-images.py
@@ -91,7 +91,7 @@ def verify_child(
     expected_size: int,
     expected_config: str,
     index_digest: str | None,
-) -> None:
+) -> dict:
     if len(raw.encode()) != expected_size:
         fail(f"manifest size mismatch for {digest}")
     child = parse_manifest(raw, digest)
@@ -105,6 +105,30 @@ def verify_child(
         fail("child annotations are not an object")
     if index_digest is not None and annotations.get(INDEX_DIGEST) != index_digest:
         fail("native child does not point to its SOCI index")
+    return child
+
+
+def verify_soci_layers(image: dict, soci: dict) -> None:
+    image_layers = image.get("layers")
+    soci_layers = soci.get("layers")
+    if not isinstance(image_layers, list) or not isinstance(soci_layers, list):
+        fail("image or SOCI child has no layer list")
+    image_digests = {descriptor_digest(layer) for layer in image_layers}
+    indexed: list[str] = []
+    for layer in soci_layers:
+        annotations = layer.get("annotations") if isinstance(layer, dict) else None
+        digest = (
+            annotations.get("com.amazon.soci.image-layer-digest")
+            if isinstance(annotations, dict)
+            else None
+        )
+        if not isinstance(digest, str) or not DIGEST.fullmatch(digest):
+            fail("SOCI layer has no valid image-layer digest")
+        indexed.append(digest)
+    if not indexed or len(indexed) != len(set(indexed)):
+        fail("SOCI layer links must be present and unique")
+    if not set(indexed).issubset(image_digests):
+        fail("SOCI index refers to a layer outside its paired image")
 
 
 def verify_simulator_index(index: dict, fetch_child) -> None:
@@ -155,20 +179,21 @@ def verify_simulator_index(index: dict, fetch_child) -> None:
             fail(f"image-to-SOCI cross-link is wrong for {name}")
         if soci[name]["annotations"][IMAGE_DIGEST] != image_digest:
             fail(f"SOCI-to-image cross-link is wrong for {name}")
-        verify_child(
+        image_child = verify_child(
             fetch_child(image_digest),
             image_digest,
             images[name].get("size"),
             OCI_CONFIG,
             soci_digest,
         )
-        verify_child(
+        soci_child = verify_child(
             fetch_child(soci_digest),
             soci_digest,
             soci[name].get("size"),
             SOCI_V2,
             None,
         )
+        verify_soci_layers(image_child, soci_child)
 
 
 def ecr_manifest(repository: str, image_id: str) -> tuple[str, str]:

--- a/.github/workflows/build-platform-images.yml
+++ b/.github/workflows/build-platform-images.yml
@@ -9,6 +9,11 @@ on:
     paths:
       - .github/workflows/build-platform-images.yml
       - .github/ecr-image-exists.sh
+      - .github/verify-platform-images.py
+      - .github/test_verify_platform_images.py
+      - .github/fixtures/simulator-*-response.json
+      - .github/fixtures/simulator-soci-manifest.json
+      - .github/fixtures/*-ecr-response.json
       - apps/api/**
       - apps/grader/**
       - apps/simulator/**
@@ -37,6 +42,14 @@ permissions:
   contents: read
 
 jobs:
+  verify-publisher:
+    name: Verify publication manifest checks
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - run: python3 -B .github/test_verify_platform_images.py
+
   validate:
     name: Build ${{ matrix.app }} (${{ matrix.arch }})
     if: github.event_name == 'pull_request'
@@ -262,27 +275,4 @@ jobs:
           done
 
       - name: Verify platforms and simulator SOCI v2 manifests
-        run: |
-          set -euo pipefail
-          for app in api grader simulator; do
-            response="$(aws ecr batch-get-image \
-              --repository-name "egma/$app" \
-              --image-ids "imageTag=$RELEASE_SHA" \
-              --output json)"
-            manifest="$(jq -r '.images[0].imageManifest' <<<"$response")"
-            digest="$(jq -r '.images[0].imageId.imageDigest' <<<"$response")"
-            jq -e '
-              [.manifests[] | select(
-                .artifactType == null and .platform.os == "linux") |
-                (.platform.os + "/" + .platform.architecture)] | sort ==
-              ["linux/amd64", "linux/arm64"]' <<<"$manifest" >/dev/null
-            if [ "$app" = simulator ]; then
-              jq -e '
-                [.manifests[] | select(.artifactType ==
-                  "application/vnd.amazon.soci.index.v2+json") |
-                  (.platform.os + "/" + .platform.architecture)] | sort ==
-                ["linux/amd64", "linux/arm64"]' <<<"$manifest" >/dev/null
-            fi
-            echo "$app:$RELEASE_SHA digest $digest contains native linux/amd64 and linux/arm64 images."
-          done
-          echo "simulator:$RELEASE_SHA contains both SOCI index manifest v2 artifacts."
+        run: python3 .github/verify-platform-images.py "$RELEASE_SHA"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -404,7 +404,7 @@ jobs:
               apps/api/*|apps/grader/*|apps/simulator/*|packages/*|ee/*) platform=true ;;
               docker-compose.yml|docker-compose.managed.yml|.env.example) platform=true ;;
               pnpm-lock.yaml|pnpm-workspace.yaml|package.json|tsconfig.base.json) platform=true ;;
-              certificates/*|.github/ecr-image-exists.sh|.github/workflows/test.yml|.github/workflows/build-platform-images.yml) platform=true ;;
+              certificates/*|.github/ecr-image-exists.sh|.github/verify-platform-images.py|.github/workflows/test.yml|.github/workflows/build-platform-images.yml) platform=true ;;
               apps/web/*|tools/*) web=true ;;
             esac
           done <<< "$changed"
@@ -545,7 +545,7 @@ jobs:
               apps/api/*|apps/grader/*|apps/simulator/*|packages/*|ee/*) deployable=true ;;
               docker-compose.yml|docker-compose.managed.yml|.env.example) deployable=true ;;
               pnpm-lock.yaml|pnpm-workspace.yaml|package.json|tsconfig.base.json) deployable=true ;;
-              certificates/*|.github/ecr-image-exists.sh|.github/workflows/test.yml|.github/workflows/build-platform-images.yml) deployable=true ;;
+              certificates/*|.github/ecr-image-exists.sh|.github/verify-platform-images.py|.github/workflows/test.yml|.github/workflows/build-platform-images.yml) deployable=true ;;
               apps/web/*|tools/*) deployable=true ;;
             esac
           done <<< "$(git diff --name-only "${{ github.sha }}" "$head")"


### PR DESCRIPTION
The native image publication completed, but run 34275015269 then rejected the simulator tag because its inline verifier expected SOCI `artifactType` fields on the top-level descriptors. The pinned SOCI 0.15 standalone converter records SOCI v2 in each child manifest's `config.mediaType` and links image and SOCI descriptors through annotations.

Move verification into a focused script that accepts the actual Docker manifest lists used by API and grader, and strictly validates the simulator's four OCI descriptors, two platforms, reciprocal SOCI links, child types, and raw manifest digests. The workflow now runs focused verifier tests and treats verifier changes as platform deployment changes.

Validation:
- `python3 -B .github/test_verify_platform_images.py`
- `python3 -B .github/test_ecr_image_exists.py`
- `git diff --check`
- Read-only execution against the actual API, grader, and simulator ECR manifests for public SHA `29f06a444d3e6fe89c371977cfa15c719025816c`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791492773&installation_model_id=431960&pr_number=327&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F327&signature=a7112c65dea1af777deaea4da39819d23bc50ed31ecfa898ab37530057df9060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces inline ECR manifest checks with a focused Python verifier for API, grader, and simulator images.
- Accepts the Docker manifest-list format currently published for API and grader.
- Strictly validates the simulator’s two runnable image descriptors and two reciprocal SOCI v2 descriptors.
- Verifies fetched child manifest sizes, raw digests, config media types, and cross-links.
- The latest change fully addresses the resolved prior finding by requiring each SOCI image-layer digest to be valid, unique, and present in its paired runnable image manifest.
- Adds fixture-based tests and includes verifier changes in platform deployment-change detection.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the prior SOCI layer-link issue is fully fixed and no new actionable defects remain.

The verifier now validates every SOCI image-layer link against the exact paired runnable image manifest and rejects missing, duplicate, invalid, or unrelated layer digests. The focused corruption test covers the previously missed unrelated-layer case, and the resolved previous finding is fully addressed.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/verify-platform-images.py | Implements strict native-image and simulator SOCI verification, including the corrected per-layer linkage check. |
| .github/test_verify_platform_images.py | Exercises real manifest shapes and corruption cases, including a SOCI link to an unrelated image layer. |
| .github/workflows/build-platform-images.yml | Runs focused verifier tests for pull requests and invokes the verifier after publication. |
| .github/workflows/test.yml | Classifies verifier changes as platform and deployable changes. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Release SHA] --> B[Fetch API tag from ECR]
    A --> C[Fetch grader tag from ECR]
    A --> D[Fetch simulator tag from ECR]
    B --> E[Verify exact amd64 and arm64 descriptors]
    C --> E
    D --> F[Verify four OCI descriptors]
    F --> G[Pair image and SOCI descriptors by platform]
    G --> H[Validate reciprocal descriptor links]
    H --> I[Fetch child manifests by digest]
    I --> J[Validate raw digest, size, and config type]
    J --> K[Require SOCI layer links to be unique subsets of paired image layers]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Verify SOCI indexes reference image laye..."](https://github.com/egma-ai/egma/commit/f4f1dc82a57ba71f8f44b8b4c5dfac81d56db1cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61797178)</sub>

<!-- /greptile_comment -->