### PR TITLE
Add run details and per-run concurrency

### DIFF
--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -249,6 +249,7 @@ function describedHeader(
           mockMetadata: mockMetadataAsPublished(run.mockMetadata),
         }
       : {}),
+    concurrency: run.concurrency,
     expectedSimulationCount: run.expectedSimulationCount,
     completedCount: run.completedCount,
     failedCount: run.failedCount,
@@ -424,6 +425,7 @@ export async function runRoutes(
           "connectionId",
           "name",
           "expectedTestVersions",
+          "concurrency",
         ],
         "a run",
       );
@@ -452,10 +454,16 @@ export async function runRoutes(
       if ("name" in body && typeof body.name !== "string") {
         return unprocessable(reply, "name must be text");
       }
+      if (body.concurrency !== undefined &&
+          (typeof body.concurrency !== "number" || !Number.isInteger(body.concurrency) ||
+           body.concurrency < 1 || body.concurrency > 2147483647)) {
+        return unprocessable(reply, "concurrency must be a whole number between 1 and 2147483647");
+      }
       const expected = expectedVersions(body.expectedTestVersions);
       if (typeof expected === "string") return unprocessable(reply, expected);
 
       const input: NewRun = {
+        ...(body.concurrency === undefined ? {} : { concurrency: body.concurrency as number }),
         suiteId,
         agentId,
         connectionId,

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -5565,3 +5565,98 @@ it(
   },
   SETTLE * 2,
 );
+
+describe("run advanced settings", () => {
+  it("keeps concurrency optional and collapsed, and sends only a custom limit", async () => {
+    const key = await anotherCustomer("run-advanced@browser.example", "Run settings");
+    const walk = await signedInBrowser("run-advanced@browser.example");
+    const projectId = projectIn(walk);
+    async function create<T = unknown>(resource: string, body: unknown) {
+      const response = await fetch(`${origin}/v1/${resource}`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${key}`, "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      expect(response.status, await response.clone().text()).toBe(201);
+      return await response.json() as T;
+    }
+    try {
+      const suite = await create<{ id: string }>("test-suites", { name: "Appointment checks" });
+      await create("tests", {
+        suiteId: suite.id, name: "Book an appointment", scenario: "Ask for an appointment.",
+        expectedBehaviors: ["Confirms the time"], personas: ["Everyday caller"],
+      });
+      const targets = new Map<string, { agent: { id: string }; connection: { id: string } }>();
+      for (const modality of ["voice", "chat"]) {
+        targets.set(modality, await create<{ agent: { id: string }; connection: { id: string } }>("agents", {
+          name: `${modality === "voice" ? "Voice" : "Chat"} receptionist`, agentPlatform: "livekit",
+          connection: {
+            agentPlatform: "livekit", connectionType: "livekit_room",
+            accessVariant: "livekit_room.project_credentials", modality,
+            config: { url: "wss://example.livekit.cloud", agentName: `${modality}-receptionist` },
+            credentials: { apiKey: "local-test-key", apiSecret: "local-test-secret" },
+          },
+        }));
+      }
+      async function choose(modality: string) {
+        await walk.goto(`${origin}/projects/${projectId}/runs/new`);
+        await walk.selectOption("#run-suite", suite.id);
+        await walk.selectOption("#run-agent", targets.get(modality)!.agent.id);
+        await walk.selectOption("#run-connection", targets.get(modality)!.connection.id);
+        await expect.poll(() => walk.getByRole("button", { name: "Start run", exact: true }).isEnabled()).toBe(true);
+      }
+      async function submit(expected: number, custom: boolean) {
+        const response = walk.waitForResponse((one) => one.request().method() === "POST" && new URL(one.url()).pathname === "/v1/runs");
+        await walk.getByRole("button", { name: "Start run", exact: true }).click();
+        const written = await response;
+        expect(written.status(), await written.text()).toBe(201);
+        const payload = written.request().postDataJSON();
+        if (custom) expect(payload.concurrency).toBe(expected);
+        else expect(payload).not.toHaveProperty("concurrency");
+        const run = await written.json();
+        expect(run.concurrency).toBe(expected);
+        await walk.waitForURL(`**/runs/${run.id}`);
+      }
+      await walk.setViewportSize({ width: 1280, height: 900 });
+      await choose("voice");
+      const advanced = walk.getByRole("button", { name: "Advanced Settings", exact: true });
+      expect(await advanced.getAttribute("aria-expanded")).toBe("false");
+      expect(await walk.locator("#run-concurrency").count()).toBe(0);
+      await walk.screenshot({ animations: "disabled", path: "/tmp/egma-run-advanced-collapsed-desktop.png" });
+      await advanced.focus();
+      await walk.keyboard.press("Enter");
+      await walk.locator("#run-concurrency").waitFor();
+      expect(await walk.locator("#run-concurrency").getAttribute("placeholder")).toBe("4");
+      expect(await walk.locator("#run-concurrency").inputValue()).toBe("");
+      await walk.screenshot({ animations: "disabled", path: "/tmp/egma-run-advanced-open-desktop.png" });
+      await submit(4, false);
+
+      await choose("chat");
+      expect(await advanced.getAttribute("aria-expanded")).toBe("false");
+      await advanced.click();
+      expect(await walk.locator("#run-concurrency").getAttribute("placeholder")).toBe("10");
+      await walk.fill("#run-concurrency", "0");
+      expect(await walk.getByRole("button", { name: "Start run", exact: true }).isDisabled()).toBe(true);
+      await walk.getByRole("alert").waitFor();
+      await walk.fill("#run-concurrency", "2");
+      await walk.setViewportSize({ width: 390, height: 844 });
+      await walk.emulateMedia({ reducedMotion: "reduce" });
+      await walk.evaluate('document.documentElement.dataset.theme = "dark"');
+      await walk.locator("#run-concurrency").focus();
+      expect(await walk.evaluate("document.documentElement.scrollWidth <= window.innerWidth")).toBe(true);
+      await walk.screenshot({ animations: "disabled", path: "/tmp/egma-run-advanced-open-mobile-dark.png" });
+      await advanced.click();
+      await advanced.click();
+      expect(await walk.locator("#run-concurrency").inputValue()).toBe("2");
+      await submit(2, true);
+
+      await choose("chat");
+      await advanced.click();
+      await walk.fill("#run-concurrency", "3");
+      await walk.fill("#run-concurrency", "");
+      await submit(10, false);
+    } finally {
+      await walk.context().close();
+    }
+  }, SETTLE * 2);
+});

--- a/apps/api/test/runs-suite-contract.test.ts
+++ b/apps/api/test/runs-suite-contract.test.ts
@@ -4,6 +4,7 @@ import {
   startSimulation,
 } from "@egma/db";
 import { newId } from "@egma/ids";
+import { fetchRunDetails } from "../../cli/src/platform/runs.ts";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
@@ -278,5 +279,43 @@ describe("run authorization", () => {
       );
       expect(answer.statusCode, `${method} ${path}`).toBe(404);
     }
+  });
+});
+
+describe("run concurrency contract", () => {
+  it("defaults chat to ten, persists an override, and rejects invalid requests", async () => {
+    const ready = await readyToRun("run_concurrency");
+    const standard = await start(ready);
+    expect(standard.statusCode).toBe(201);
+    expect(standard.body.concurrency).toBe(10);
+    const body = { suiteId: ready.suiteId, agentId: ready.agentId, connectionId: ready.connectionId };
+    const custom = await request(api.app, "POST", "/v1/runs", ready.key, { ...body, concurrency: 100 });
+    expect(custom.statusCode).toBe(201);
+    expect(custom.body.concurrency).toBe(100);
+    const read = await request(api.app, "GET", `/v1/runs/${String(custom.body.id)}`, ready.key);
+    expect(read.body.concurrency).toBe(100);
+    const details = await fetchRunDetails(
+      { url: "https://egma.example", key: ready.key },
+      { runId: String(custom.body.id), projectId: ready.customer.projectId },
+      async (input, init) => {
+        const url = new URL(String(input));
+        const response = await api.app.inject({
+          method: "GET", url: `${url.pathname}${url.search}`,
+          headers: Object.fromEntries(new Headers(init?.headers)),
+        });
+        return new Response(response.body, { status: response.statusCode, headers: { "content-type": "application/json" } });
+      },
+    );
+    expect(details.run.concurrency).toBe(100);
+    expect(details.simulations).toHaveLength(Number(custom.body.expectedSimulationCount));
+    expect(details.simulations[0]?.test.scenario).toBe("Move Thursday's booking to next week.");
+    expect(details.simulations[0]).toHaveProperty("gradeHistory");
+    expect(details.simulations[0]).toHaveProperty("transcript");
+    for (const concurrency of [0, -1, 1.5, "4", null, 2147483648]) {
+      const refused = await request(api.app, "POST", "/v1/runs", ready.key, { ...body, concurrency });
+      expect(refused.statusCode, JSON.stringify(refused.body)).toBe(422);
+    }
+    const listed = await request(api.app, "GET", "/v1/runs", ready.key);
+    expect(listed.body.runs).toHaveLength(2);
   });
 });

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -57,6 +57,7 @@ egma suite create
 egma suite delete
 egma test delete
 egma run create
+egma run get
 egma run cancel
 egma self-host up
 ```
@@ -327,7 +328,7 @@ file only after the platform confirms deletion. A refused remote deletion keeps
 all local bytes. An unpushed local Test has no remote identity, so remove that
 draft directly instead of using `egma test delete`.
 
-## Create and cancel Runs
+## Create, read, and cancel Runs
 
 The first argument to `run create` is a local suite directory, not a Suite ID.
 The Egma Agent and Connection IDs are explicit:
@@ -341,7 +342,28 @@ egma run create receptionist-core \
 
 The command pushes the complete repository first. A failed push creates no Run.
 After a successful start it prints the Run ID and the web results URL, then
-returns. Follow progress on that web page.
+returns. Follow progress on that web page or fetch it with `egma run get`.
+
+Use `--concurrency 8` to allow up to eight active simulations in this Run.
+The default is 4 for voice and 10 for chat. The value must be a positive whole number.
+A limit of 100 with seven simulations allows all seven to run together, subject
+to worker capacity and deployment or provider limits. Each test and persona
+combination creates one simulation.
+
+Read the current Run and all of its simulation details as JSON:
+
+```bash
+egma run get run_... > run.json
+```
+
+The command follows every simulation and event page. It includes transcripts,
+tool calls, metrics, test and persona details, grades, grade history, and failure
+reasons. `readStartedAt` and `fetchedAt` mark the collection interval; an active
+Run can change during these reads. Run the command again to refresh the data.
+Recording availability is included; audio files are not downloaded. The API
+limits each transcript to 20,000 spans. Any truncation is preserved in
+`spansTruncated` and reported in `warnings`. A failed request exits nonzero
+without printing partial JSON.
 
 Before a real phone Run, the coding agent must state the Suite, target, and
 expected simulation count, warn that calls can cost money, and obtain fresh

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egma-cli",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "type": "module",
   "description": "Promptless commands for integrating voice agents with Egma.",
   "license": "MIT",

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -1,4 +1,4 @@
-/** `egma run create | cancel`: explicit Run resource commands. */
+/** `egma run create | get | cancel`: explicit Run resource commands. */
 
 import {
   RepositoryValidationError,
@@ -9,7 +9,7 @@ import {
 import { selectTarget, type RefusedTarget } from "../folder/target-selection.ts";
 import { PlatformUnreachableError } from "../platform/device-flow.ts";
 import { PlatformRefusedError } from "../platform/refused.ts";
-import { cancelRun, startRun } from "../platform/runs.ts";
+import { cancelRun, fetchRunDetails, startRun } from "../platform/runs.ts";
 import { notSignedInRefusal, signedInAt } from "../platform/signed-in.ts";
 import {
   RunSelectionError,
@@ -35,6 +35,7 @@ export type RunCreateCommandOptions = FolderCommandOptions & {
   readonly suiteDirectory: string;
   readonly agent: string;
   readonly connection: string;
+  readonly concurrency?: number;
   readonly name?: string;
   readonly signal: AbortSignal;
 };
@@ -183,12 +184,17 @@ async function pushBeforeRun(
 
 /**
  * Push the complete repository, create one Run, print its durable handles, and
- * return. Run progress belongs in the web product, not in this command.
+ * return. Use run get to read progress and evidence.
  */
 export async function runCreateCommand(
   options: RunCreateCommandOptions,
 ): Promise<number> {
   if (options.signal.aborted) return interrupted(options);
+  if (options.concurrency !== undefined &&
+      (!Number.isInteger(options.concurrency) || options.concurrency < 1 || options.concurrency > 2147483647)) {
+    options.fail("Concurrency must be a whole number between 1 and 2147483647.");
+    return RUN_EXIT.nothing;
+  }
 
   const paths = folderPathsIn(options.cwd);
   let config: FolderConfig;
@@ -266,6 +272,7 @@ export async function runCreateCommand(
           versionId: one.versionId,
         })),
         ...(options.name === undefined ? {} : { name: options.name }),
+        ...(options.concurrency === undefined ? {} : { concurrency: options.concurrency }),
       },
       options.fetchImpl,
       options.signal,
@@ -376,4 +383,55 @@ function unreachable(
     return RUN_EXIT.unreachable;
   }
   throw cause;
+}
+
+/** Print all public run details as one JSON document for tools and coding agents. */
+export async function runGetCommand(options: RunCancelCommandOptions): Promise<number> {
+  if (wasInterrupted(options.signal)) return RUN_EXIT.interrupted;
+  const runId = options.runId.trim();
+  if (runId === "") {
+    options.fail("Name one Run ID.");
+    return RUN_EXIT.nothing;
+  }
+  let config: FolderConfig;
+  try {
+    config = await readConfig(folderPathsIn(options.cwd).config);
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") {
+      options.fail(
+        `There is no egma/config.yaml in ${oneLineFactText(options.cwd, "this directory")}. Run egma init here first.`,
+      );
+    } else {
+      options.fail(
+        cause instanceof Error
+          ? cause.message
+          : "Egma could not read egma/config.yaml. Fix the file and run this again.",
+      );
+    }
+    return RUN_EXIT.nothing;
+  }
+  if (config.project === null) {
+    options.fail("egma/config.yaml does not name an Egma Project. Run egma init here first.");
+    return RUN_EXIT.nothing;
+  }
+
+  const signedIn = await signedInAt(options.access);
+  if (signedIn === null) {
+    options.fail(notSignedInRefusal(options.access.url));
+    return RUN_EXIT.notSignedIn;
+  }
+
+
+  try {
+    const details = await fetchRunDetails(signedIn, { runId, projectId: config.project.id }, options.fetchImpl, options.signal);
+    if (wasInterrupted(options.signal)) return RUN_EXIT.interrupted;
+    options.out(JSON.stringify(details, null, 2));
+    return RUN_EXIT.done;
+  } catch (cause) {
+    if (wasInterrupted(options.signal)) {
+      options.fail("Run detail retrieval was interrupted. Run egma run get again to fetch a fresh result.");
+      return RUN_EXIT.interrupted;
+    }
+    return unreachable(options, cause);
+  }
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -21,7 +21,7 @@ import { runPersonasCommand } from "./commands/personas.ts";
 import { runProjectApiKeyCreateCommand } from "./commands/project-api-key.ts";
 import { runPullCommand } from "./commands/pull.ts";
 import { runPushCommand } from "./commands/push.ts";
-import { runCancelCommand, runCreateCommand } from "./commands/run.ts";
+import { runCancelCommand, runCreateCommand, runGetCommand } from "./commands/run.ts";
 import { runSelfHostCommand } from "./commands/self-host.ts";
 import { runSuiteCreateCommand, runSuiteDeleteCommand } from "./commands/suite.ts";
 import { runTestDeleteCommand } from "./commands/test.ts";
@@ -72,6 +72,7 @@ export const COMMANDS = [
   "suite delete",
   "test delete",
   "run create",
+  "run get",
   "run cancel",
   "self-host up",
 ] as const;
@@ -179,9 +180,10 @@ const SCHEMAS: Readonly<Record<Command, OptionSchema>> = {
   "suite delete": { values: [REPOSITORY_OPTION], positionals: 1 },
   "test delete": { values: [REPOSITORY_OPTION], positionals: 1 },
   "run create": {
-    values: ["--agent", "--connection", "--name", REPOSITORY_OPTION],
+    values: ["--agent", "--connection", "--name", "--concurrency", REPOSITORY_OPTION],
     positionals: 1,
   },
+  "run get": { values: [REPOSITORY_OPTION], positionals: 1 },
   "run cancel": { values: [REPOSITORY_OPTION], positionals: 1 },
   "self-host up": { values: [REPOSITORY_OPTION], positionals: 0 },
 };
@@ -414,6 +416,7 @@ const HELP: Readonly<Record<HelpTopic, readonly string[]>> = {
   run: [
     "Usage:",
     "  egma run create <suite-directory> --agent <Agent ID> --connection <Connection ID> [options]",
+    "  egma run get <Run ID> [--cwd <path>]",
     "  egma run cancel <Run ID> [--cwd <path>]",
     "",
     "create pushes the complete repository first, starts the Run, prints its results URL, and returns.",
@@ -558,12 +561,14 @@ const HELP: Readonly<Record<HelpTopic, readonly string[]>> = {
   ],
   "run create": [
     "Usage:",
-    "  egma run create <suite-directory> --agent <Agent ID> --connection <Connection ID> [--name <name>] [--cwd <path>]",
+    "  egma run create <suite-directory> --agent <Agent ID> --connection <Connection ID> [--name <name>] [--concurrency <number>] [--cwd <path>]",
     "",
+    "Concurrency limits active simulations in this Run; the defaults are 4 for voice and 10 for chat.",
     "The suite directory is the direct child under egma/tests, not a Suite ID.",
     "Egma pushes first. It creates no Run if the push fails.",
     "On success it prints the Run ID and results URL, then returns.",
   ],
+  "run get": ["Usage:", "  egma run get <Run ID> [--cwd <path>]", "", "Prints JSON with run status, all simulation details, grades, transcripts, and events."],
   "run cancel": ["Usage:", "  egma run cancel <Run ID> [--cwd <path>]"],
   "self-host up": ["Usage:", "  egma self-host up [--cwd <platform-workspace>]"],
 };
@@ -743,10 +748,12 @@ async function dispatch(
         }),
       );
     case "run create": {
+      const concurrency = value(args, "--concurrency");
       const name = value(args, "--name");
       return withCommandSignal(async (signal) =>
         runCreateCommand({
           ...options,
+          ...(concurrency === null ? {} : { concurrency: /^\d+$/u.test(concurrency) ? Number(concurrency) : NaN }),
           suiteDirectory: args.positionals[0] as string,
           agent: value(args, "--agent") as string,
           connection: value(args, "--connection") as string,
@@ -755,6 +762,10 @@ async function dispatch(
         }),
       );
     }
+    case "run get":
+      return withCommandSignal(async (signal) =>
+        runGetCommand({ ...options, runId: args.positionals[0] as string, signal }),
+      );
     case "run cancel":
       return withCommandSignal(async (signal) =>
         runCancelCommand({

--- a/apps/cli/src/platform/runs.ts
+++ b/apps/cli/src/platform/runs.ts
@@ -1,13 +1,18 @@
 /**
- * Create complete-suite runs with an optional current-set precondition, or cancel by ID.
- * The web app shows progress. Return run-start refusals as values and preserve
- * the platform's explanation.
+ * Create, inspect, and cancel complete-suite runs through the public API.
+ * Preserve the platform's explanations and simulation evidence.
  */
 
 import {
+  getRun,
+  getSimulation,
+  listRunEvents,
   cancelRun as cancelRunRequest,
   createRun as createRunRequest,
   listRunSimulations as listRunSimulationsRequest,
+  type GetRunResponse,
+  type GetSimulationResponse,
+  type ListRunEventsResponse,
   type CancelRunResponse,
   type CreateRunResponse,
   type ListRunSimulationsResponse,
@@ -121,6 +126,8 @@ export type NewRun = {
     readonly testId: string;
     readonly versionId: string;
   }[];
+  /** Maximum active simulations in this run. Omission uses the modality default. */
+  readonly concurrency?: number;
   /** Optional run display name. */
   readonly name?: string;
 };
@@ -270,6 +277,7 @@ export async function startRun(
         versionId: version.versionId,
       })),
       ...(input.name === undefined ? {} : { name: input.name }),
+      ...(input.concurrency === undefined ? {} : { concurrency: input.concurrency }),
     },
     {
       client: platformClient(signedIn, fetchImpl),
@@ -359,4 +367,78 @@ export async function cancelRun(
   }
 
   return { kind: "canceled", run: runFrom(answer.data) };
+}
+
+/** A fresh collection of the public run resources, read over a stated interval. */
+export type RunDetails = {
+  readonly readStartedAt: string;
+  readonly fetchedAt: string;
+  readonly run: GetRunResponse;
+  readonly simulations: readonly GetSimulationResponse[];
+  readonly events: ListRunEventsResponse["events"];
+  readonly warnings: readonly string[];
+};
+
+/** Follow every page and retain simulation evidence without the summary projection. */
+export async function fetchRunDetails(
+  signedIn: SignedIn,
+  input: { readonly runId: string; readonly projectId: string },
+  fetchImpl?: Fetch,
+  signal?: AbortSignal,
+): Promise<RunDetails> {
+  const readStartedAt = new Date().toISOString();
+  const options = {
+    client: platformClient(signedIn, fetchImpl),
+    ...(signal === undefined ? {} : { signal }),
+  };
+  function dataOf<T>(answer: { data?: T; error?: unknown; response?: Response }): NonNullable<T> {
+    const response = platformResponse(answer, signedIn.url);
+    if (!response.ok || answer.data === undefined || answer.data === null) {
+      throw new PlatformRefusedError(response.status, platformRefusalMessage(answer.error, response.status));
+    }
+    return answer.data;
+  }
+  // Establish access before walking the child resources.
+  dataOf(await getRun(input, options));
+  const simulations: GetSimulationResponse[] = [];
+  let pageToken: string | undefined;
+  const seen = new Set<string>();
+  for (;;) {
+    const page = dataOf(await listRunSimulationsRequest({
+      ...input, pageSize: 200,
+      ...(pageToken === undefined ? {} : { pageToken }),
+    }, options));
+    for (const simulation of page.simulations) {
+      simulations.push(dataOf(await getSimulation({
+        simulationId: simulation.id, projectId: input.projectId,
+      }, options)));
+    }
+    if (page.nextPageToken === null) break;
+    if (seen.has(page.nextPageToken)) {
+      throw new PlatformRefusedError(502, "Egma repeated a simulation page token. Run details could not be fetched completely.");
+    }
+    pageToken = page.nextPageToken;
+    seen.add(pageToken);
+  }
+  const events: ListRunEventsResponse["events"] = [];
+  let after = 0;
+  for (;;) {
+    const page = dataOf(await listRunEvents({ ...input, after }, options));
+    events.push(...page.events);
+    if (page.caughtUp) break;
+    if (page.next <= after) {
+      throw new PlatformRefusedError(502, "Egma did not advance the run event cursor. Run details could not be fetched completely.");
+    }
+    after = page.next;
+  }
+  const run = dataOf(await getRun(input, options));
+  return {
+    readStartedAt,
+    fetchedAt: new Date().toISOString(),
+    run,
+    simulations,
+    events,
+    warnings: simulations.filter((simulation) => simulation.transcript?.spansTruncated)
+      .map((simulation) => `Simulation ${simulation.id}: the API truncated transcript spans; aggregate counts still cover the full trace.`),
+  };
 }

--- a/apps/cli/test/public-command-surface.test.ts
+++ b/apps/cli/test/public-command-surface.test.ts
@@ -97,8 +97,9 @@ const APPROVED_FLAGS = [
   { words: ["test", "delete"], flags: ["--cwd"] },
   {
     words: ["run", "create"],
-    flags: ["--agent", "--connection", "--cwd", "--name"],
+    flags: ["--agent", "--concurrency", "--connection", "--cwd", "--name"],
   },
+  { words: ["run", "get"], flags: ["--cwd"] },
   { words: ["run", "cancel"], flags: ["--cwd"] },
   { words: ["self-host", "up"], flags: ["--cwd"] },
 ] as const;

--- a/apps/cli/test/run-resource-command.test.ts
+++ b/apps/cli/test/run-resource-command.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  runGetCommand,
   runCancelCommand,
   runCreateCommand,
 } from "../src/commands/run.ts";
@@ -184,6 +185,7 @@ describe("Run resource commands", () => {
     const code = await runCreateCommand({
       access: { url: URL, credentialsFile: workspace.credentialsFile },
       cwd: workspace.dir,
+      concurrency: 100,
       suiteDirectory: "release",
       agent: "agt_one",
       connection: "con_one",
@@ -202,6 +204,7 @@ describe("Run resource commands", () => {
     ]);
     expect(runInputs).toHaveLength(1);
     expect(runInputs[0]).toMatchObject({
+      concurrency: 100,
       suiteId: SUITE_ID,
       agentId: "agt_one",
       connectionId: "con_one",
@@ -299,5 +302,92 @@ describe("Run resource commands", () => {
       "no run of yours has that id",
       `Egma has no Run ${RUN_ID} in this Project. Nothing was changed.`,
     ]);
+  });
+});
+
+describe("run get", () => {
+  it("collects every simulation and event page and preserves full evidence as JSON", async () => {
+    const out: string[] = [];
+    const failed: string[] = [];
+    const calls: string[] = [];
+    const code = await runGetCommand({
+      access: { url: URL, credentialsFile: workspace.credentialsFile },
+      cwd: workspace.dir, runId: RUN_ID,
+      out: (line) => out.push(line), fail: (line) => failed.push(line),
+      fetchImpl: async (input, init) => {
+        const url = new globalThis.URL(String(input));
+        calls.push(url.pathname);
+        expect(init?.method ?? "GET").toBe("GET");
+        expect(url.searchParams.get("projectId")).toBe(PROJECT_ID);
+        let body: unknown;
+        if (url.pathname.endsWith("/simulations")) {
+          const second = url.searchParams.has("pageToken");
+          body = { simulations: [{ id: second ? "sim_second" : "sim_first" }], nextPageToken: second ? null : "sim_first" };
+        } else if (url.pathname.startsWith("/v1/simulations/")) {
+          body = {
+            id: url.pathname.split("/").at(-1), status: "completed",
+            test: { scenario: "Preserve\nall text" },
+            grades: [{ score: 0.5, details: { rationale: "Full rationale", assertions: [{ citedSpanIds: ["span1"] }] } }],
+            transcript: { spansTruncated: url.pathname.endsWith("sim_second"), spans: [{ toolArguments: { name: "Alex" }, toolResult: "Booked" }] },
+            metrics: [{ key: "duration", value: 30 }],
+          };
+        } else if (url.pathname.endsWith("/events")) {
+          const second = url.searchParams.get("after") === "1";
+          body = { events: [{ seq: second ? 2 : 1 }], next: second ? 2 : 1, caughtUp: second, done: false };
+        } else {
+          body = runHeader("pending");
+        }
+        return new JsonResponse(JSON.stringify(body));
+      },
+    });
+    expect(code).toBe(0);
+    expect(failed).toEqual([]);
+    expect(out).toHaveLength(1);
+    const result = JSON.parse(out[0]!);
+    expect(result.simulations.map((simulation: { id: string }) => simulation.id)).toEqual(["sim_first", "sim_second"]);
+    expect(result.simulations[0].test.scenario).toBe("Preserve\nall text");
+    expect(result.simulations[0].grades[0].details.rationale).toBe("Full rationale");
+    expect(result.simulations[0].transcript.spans[0].toolResult).toBe("Booked");
+    expect(result.events).toEqual([{ seq: 1 }, { seq: 2 }]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("sim_second");
+    expect(Date.parse(result.fetchedAt)).toBeGreaterThanOrEqual(Date.parse(result.readStartedAt));
+    expect(calls.filter((call) => call.endsWith("/simulations"))).toHaveLength(2);
+  });
+
+  it("fails without partial JSON when a child resource cannot be read", async () => {
+    const out: string[] = [];
+    const failed: string[] = [];
+    const code = await runGetCommand({
+      access: { url: URL, credentialsFile: workspace.credentialsFile },
+      cwd: workspace.dir, runId: RUN_ID,
+      out: (line) => out.push(line), fail: (line) => failed.push(line),
+      fetchImpl: async (input) => {
+        if (String(input).includes("/simulations")) {
+          return new JsonResponse(JSON.stringify({ message: "Read refused" }), { status: 403 });
+        }
+        return new JsonResponse(JSON.stringify(runHeader("pending")));
+      },
+    });
+    expect(code).toBe(1);
+    expect(out).toEqual([]);
+    expect(failed).toEqual(["Read refused"]);
+  });
+});
+
+describe("run concurrency validation", () => {
+  it.each([0, -1, 1.5, NaN, Infinity, 2147483648])("rejects %s before pushing or starting a run", async (concurrency) => {
+    const failed: string[] = [];
+    let calls = 0;
+    const code = await runCreateCommand({
+      access: { url: URL, credentialsFile: workspace.credentialsFile },
+      cwd: workspace.dir, suiteDirectory: "release", agent: "agt_one", connection: "con_one",
+      concurrency, signal: new AbortController().signal,
+      out: () => {}, fail: (line) => failed.push(line),
+      fetchImpl: async () => { calls += 1; return new JsonResponse("{}"); },
+    });
+    expect(code).toBe(1);
+    expect(calls).toBe(0);
+    expect(failed[0]).toContain("Concurrency must be a whole number");
   });
 });

--- a/apps/web/app/projects/[projectId]/runs/create-run-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/runs/create-run-sheet.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { XIcon } from "lucide-react";
+import { ChevronRightIcon, XIcon } from "lucide-react";
 import {
   createRun,
   getAgent,
@@ -13,6 +13,7 @@ import {
 } from "@egma/platform-api/client";
 
 import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import {
@@ -44,7 +45,7 @@ import {
   type TestSuitePage,
 } from "../../../../lib/test-suites.ts";
 import type { TestPage } from "../../../../lib/tests.ts";
-import { Field, Refused } from "../../../../ui/form.tsx";
+import { Field, Problem, Refused } from "../../../../ui/form.tsx";
 import { WorkRefusalActions } from "../../../../ui/work-refusal-actions.tsx";
 import { RunNote, type RunNoteTest } from "../../../../ui/run-note.tsx";
 import { Empty, Failure, Loading } from "../../../../ui/page-state.tsx";
@@ -90,6 +91,8 @@ export function CreateRunSheet({
   const [agentId, setAgentId] = useState("");
   const [connectionId, setConnectionId] = useState("");
   const [name, setName] = useState("");
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [concurrency, setConcurrency] = useState("");
   const [moreSuites, setMoreSuites] = useState<readonly TestSuite[]>([]);
   const [suiteCursor, setSuiteCursor] = useState<string | null>(null);
   const [moreAgents, setMoreAgents] = useState<
@@ -141,6 +144,8 @@ export function CreateRunSheet({
     setAgentId(selected);
     setConnectionId("");
     setName("");
+    setConcurrency("");
+    setAdvancedOpen(false);
     setMoreSuites([]);
     setSuiteCursor(null);
     setMoreAgents([]);
@@ -240,7 +245,7 @@ export function CreateRunSheet({
   }, [suiteTests, suiteId, projectId]);
 
   useUnsavedChanges(
-    suiteId !== "" || agentId !== "" || connectionId !== "" || name !== "",
+    suiteId !== "" || agentId !== "" || connectionId !== "" || name !== "" || concurrency !== "",
     starting,
   );
 
@@ -318,11 +323,14 @@ export function CreateRunSheet({
     suiteTests?.status === "ready" &&
     (suiteTests.value.tests.length > 0 ||
       suiteTests.value.nextPageToken !== null);
+  const validConcurrency = concurrency === "" ||
+    (/^\d+$/u.test(concurrency) && Number(concurrency) >= 1 && Number(concurrency) <= 2147483647);
   const ready =
     suiteId !== "" &&
     suiteHasTests &&
     agentId !== "" &&
-    connectionId !== "";
+    connectionId !== "" &&
+    validConcurrency;
   /** The connection this run will be conducted over, once one is chosen. */
   const chosenConnection = connections.find((one) => one.id === connectionId);
   const whyNot = !mayStart
@@ -346,6 +354,7 @@ export function CreateRunSheet({
           agentId,
           connectionId,
           ...(trimmedName === "" ? {} : { name: trimmedName }),
+          ...(concurrency === "" ? {} : { concurrency: Number(concurrency) }),
         },
         { client: platformClient },
       ),
@@ -565,6 +574,42 @@ export function CreateRunSheet({
               />
             </Field>
           </div>
+        )}
+
+        {chosenConnection === undefined ? null : (
+          <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
+            <CollapsibleTrigger asChild>
+              <Button type="button" variant="ghost" className="justify-start px-0 text-muted-foreground" disabled={starting}>
+                <ChevronRightIcon aria-hidden="true" />
+                Advanced Settings
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="pt-3">
+              <Field
+                label="Concurrency [optional]"
+                htmlFor="run-concurrency"
+                hint={`Leave blank to use ${chosenConnection.modality === "chat" ? 10 : 4} simultaneous simulations.`}
+              >
+                <Input
+                  id="run-concurrency"
+                  inputMode="numeric"
+                  value={concurrency}
+                  placeholder={chosenConnection.modality === "chat" ? "10" : "4"}
+                  autoComplete="off"
+                  disabled={starting}
+                  aria-invalid={!validConcurrency}
+                  aria-describedby={validConcurrency ? undefined : "run-concurrency-error"}
+                  onChange={(event) => {
+                    setRefused(null);
+                    setConcurrency(event.target.value);
+                  }}
+                />
+              </Field>
+            </CollapsibleContent>
+            {validConcurrency ? null : (
+              <Problem id="run-concurrency-error">Concurrency must be a whole number between 1 and 2147483647.</Problem>
+            )}
+          </Collapsible>
         )}
 
         {moreRefused === null ? null : (

--- a/docs/docs/platform/runs/start-and-follow-a-run.mdx
+++ b/docs/docs/platform/runs/start-and-follow-a-run.mdx
@@ -17,6 +17,7 @@ to models, voices, or grading policy apply to future runs.
     1. Open **Runs** and select **Create a run**.
     2. Choose your test suite.
     3. Choose the agent and one of its connections. Review the run settings.
+       To change concurrency, open **Advanced Settings**.
     4. Select **Start run**.
     5. Open the run to follow its simulations. Starting successfully does not mean the tests passed.
 
@@ -40,8 +41,21 @@ to models, voices, or grading policy apply to future runs.
     ID and results URL, and returns. A zero exit code means the run started. It does not
     mean that simulation execution or grading passed.
 
+    Voice runs use concurrency 4 by default. Chat runs use 10. Add
+    `--concurrency <number>` when this run needs a different limit. Deployment
+    and provider limits still apply.
+
     If the pre-run push is refused, no run starts. Resolve the reported test change
     or invalid content first.
+
+    To read the full run as JSON:
+
+    ```bash
+    egma run get "$EGMA_RUN_ID" > run.json
+    ```
+
+    The result includes every simulation and run event. Run the command again to
+    refresh an active run. Recording files are not downloaded.
   </Tab>
 </Tabs>
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -16382,6 +16382,12 @@
                       "additionalProperties": false
                     },
                     "description": "Optional exact list of the suite's test IDs and current version IDs. Each test and version must appear once. The request is refused if the suite membership or any version changed. Omit this field to use the current suite."
+                  },
+                  "concurrency": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 2147483647,
+                    "description": "Maximum active simulations in this run. Defaults to 4 for voice and 10 for chat. Worker and provider limits still apply."
                   }
                 },
                 "required": [
@@ -16512,6 +16518,12 @@
                         }
                       ]
                     },
+                    "concurrency": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 2147483647,
+                      "description": "Maximum active simulations in this run, fixed when the run starts."
+                    },
                     "expectedSimulationCount": {
                       "type": "integer",
                       "description": "Number of test-and-persona combinations captured when the run started."
@@ -16639,6 +16651,7 @@
                     "productLabel",
                     "environment",
                     "agentVersion",
+                    "concurrency",
                     "expectedSimulationCount",
                     "completedCount",
                     "failedCount",
@@ -16976,6 +16989,12 @@
                               }
                             ]
                           },
+                          "concurrency": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 2147483647,
+                            "description": "Maximum active simulations in this run, fixed when the run starts."
+                          },
                           "expectedSimulationCount": {
                             "type": "integer",
                             "description": "Number of test-and-persona combinations captured when the run started."
@@ -17103,6 +17122,7 @@
                           "productLabel",
                           "environment",
                           "agentVersion",
+                          "concurrency",
                           "expectedSimulationCount",
                           "completedCount",
                           "failedCount",
@@ -17361,6 +17381,12 @@
                           "type": "null"
                         }
                       ]
+                    },
+                    "concurrency": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 2147483647,
+                      "description": "Maximum active simulations in this run, fixed when the run starts."
                     },
                     "expectedSimulationCount": {
                       "type": "integer",
@@ -17694,6 +17720,7 @@
                     "productLabel",
                     "environment",
                     "agentVersion",
+                    "concurrency",
                     "expectedSimulationCount",
                     "completedCount",
                     "failedCount",
@@ -18598,6 +18625,12 @@
                         }
                       ]
                     },
+                    "concurrency": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 2147483647,
+                      "description": "Maximum active simulations in this run, fixed when the run starts."
+                    },
                     "expectedSimulationCount": {
                       "type": "integer",
                       "description": "Number of test-and-persona combinations captured when the run started."
@@ -18725,6 +18758,7 @@
                     "productLabel",
                     "environment",
                     "agentVersion",
+                    "concurrency",
                     "expectedSimulationCount",
                     "completedCount",
                     "failedCount",

--- a/packages/db/migrations/0001_run_concurrency.sql
+++ b/packages/db/migrations/0001_run_concurrency.sql
@@ -1,0 +1,58 @@
+ALTER TABLE public.run
+  ADD COLUMN concurrency integer DEFAULT 4 NOT NULL;
+
+ALTER TABLE public.run DISABLE TRIGGER run_lifecycle_guard;
+
+UPDATE public.run
+SET concurrency = CASE
+  WHEN connection_snapshot->>'modality' = 'chat' THEN 10
+  ELSE 4
+END;
+
+CREATE OR REPLACE FUNCTION public.guard_run_lifecycle() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  -- The counts and finished_at land together, once; after that the header is
+  -- frozen and a retry is a new run. The one carve-out below is the cleanup
+  -- bookkeeping, which is about somebody's Retell account rather than about
+  -- this run's numbers.
+  IF OLD.finished_at IS NOT NULL THEN
+    IF (NEW.temp_mock_agent_version_cleanup IS DISTINCT FROM OLD.temp_mock_agent_version_cleanup
+        OR NEW.mock_metadata IS DISTINCT FROM OLD.mock_metadata)
+       AND (to_jsonb(NEW) - 'temp_mock_agent_version_cleanup' - 'mock_metadata')
+         = (to_jsonb(OLD) - 'temp_mock_agent_version_cleanup' - 'mock_metadata')
+    THEN
+      RETURN NEW;
+    END IF;
+    RAISE EXCEPTION 'run % is finished, and a finished run''s header is written once',
+      OLD.id;
+  END IF;
+
+  IF NEW.concurrency <> OLD.concurrency THEN
+    RAISE EXCEPTION 'run % concurrency is set once at start', OLD.id;
+  END IF;
+
+  IF NEW.expected_simulation_count <> OLD.expected_simulation_count THEN
+    RAISE EXCEPTION 'run % expected % simulations, and the expectation is set once at start',
+      OLD.id, OLD.expected_simulation_count;
+  END IF;
+
+  IF NEW.status = OLD.status THEN
+    RETURN NEW;
+  END IF;
+
+  IF (OLD.status = 'pending' AND NEW.status IN ('running', 'canceled'))
+  OR (OLD.status = 'running' AND NEW.status IN ('completed', 'canceled'))
+  THEN
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION 'run % may not move from % to %', OLD.id, OLD.status, NEW.status;
+END
+$$;
+
+ALTER TABLE public.run ENABLE TRIGGER run_lifecycle_guard;
+
+ALTER TABLE public.run
+  ADD CONSTRAINT run_concurrency_positive CHECK (concurrency > 0);

--- a/packages/db/migrations/README.md
+++ b/packages/db/migrations/README.md
@@ -1,14 +1,9 @@
 # Database migrations
 
-PostgreSQL and ClickHouse each have one `0000_baseline.sql` that creates the
-complete current schema in an empty database. They use different SQL dialects,
-so each store has its own file. PostgreSQL's Drizzle snapshot and journal describe
-that same baseline. New migrations start at `0001`.
-
-Egma is pre-launch. The baseline defines the final schema directly, without
-historical backfills, temporary columns or old-schema conversion paths. Rebuild
-disposable development databases when their baseline changes. The application
-does not convert or erase an existing database.
+PostgreSQL and ClickHouse each have one `0000_baseline.sql`. They use different
+SQL dialects, so each store has its own file. The PostgreSQL baseline is applied
+to production and is immutable. New migrations start at `0001`, and empty
+databases apply all files in order.
 
 ## Startup and history
 

--- a/packages/db/migrations/meta/0001_snapshot.json
+++ b/packages/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,6132 @@
+{
+  "id": "491f6fa0-2e56-4b4b-b9f4-1b6e808d1200",
+  "prevId": "1f21e52b-661d-4d1e-902a-59b57716f30e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_id_prefix": {
+          "name": "account_id_prefix",
+          "value": "\"account\".\"id\" ~ '^acc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_id_prefix": {
+          "name": "session_id_prefix",
+          "value": "\"session\".\"id\" ~ '^ses_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_external_identity_unique": {
+          "name": "user_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_id_prefix": {
+          "name": "user_id_prefix",
+          "value": "\"user\".\"id\" ~ '^usr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verification_id_prefix": {
+          "name": "verification_id_prefix",
+          "value": "\"verification\".\"id\" ~ '^vrf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_suffix": {
+          "name": "display_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_organization_id_idx": {
+          "name": "api_key_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_organization_id_organization_id_fk": {
+          "name": "api_key_organization_id_organization_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "api_key_project_organization_fk": {
+          "name": "api_key_project_organization_fk",
+          "tableFrom": "api_key",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_hash_unique": {
+          "name": "api_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "api_key_id_prefix": {
+          "name": "api_key_id_prefix",
+          "value": "\"api_key\".\"id\" ~ '^key_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "api_key_scope_allowed": {
+          "name": "api_key_scope_allowed",
+          "value": "\"api_key\".\"scope\" in ('organization', 'project')"
+        },
+        "api_key_project_scope_agrees": {
+          "name": "api_key_project_scope_agrees",
+          "value": "(\"api_key\".\"scope\" = 'project') = (\"api_key\".\"project_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_created_by_user_id_fk": {
+          "name": "invitation_created_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_hash_unique": {
+          "name": "invitation_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_id_prefix": {
+          "name": "invitation_id_prefix",
+          "value": "\"invitation\".\"id\" ~ '^inv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "invitation_role_allowed": {
+          "name": "invitation_role_allowed",
+          "value": "\"invitation\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.membership": {
+      "name": "membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_organization_id_idx": {
+          "name": "membership_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "membership_organization_id_organization_id_fk": {
+          "name": "membership_organization_id_organization_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_user_id_user_id_fk": {
+          "name": "membership_user_id_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_created_by_user_id_fk": {
+          "name": "membership_created_by_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "membership_user_id_unique": {
+          "name": "membership_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "membership_organization_id_user_id_unique": {
+          "name": "membership_organization_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "membership_id_prefix": {
+          "name": "membership_id_prefix",
+          "value": "\"membership\".\"id\" ~ '^mbr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "membership_role_allowed": {
+          "name": "membership_role_allowed",
+          "value": "\"membership\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_residency": {
+          "name": "data_residency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_updated_at": {
+          "name": "settings_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_external_identity_unique": {
+          "name": "organization_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_id_prefix": {
+          "name": "organization_id_prefix",
+          "value": "\"organization\".\"id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_organization_id_idx": {
+          "name": "project_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"project\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_created_by_user_id_fk": {
+          "name": "project_created_by_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_organization_id_slug_unique": {
+          "name": "project_organization_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "slug"
+          ]
+        },
+        "project_id_organization_id_unique": {
+          "name": "project_id_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_id_prefix": {
+          "name": "project_id_prefix",
+          "value": "\"project\".\"id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "project_revision_prefix": {
+          "name": "project_revision_prefix",
+          "value": "\"project\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_code_expires_at_idx": {
+          "name": "device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_organization_id_organization_id_fk": {
+          "name": "device_code_organization_id_organization_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_project_organization_fk": {
+          "name": "device_code_project_organization_fk",
+          "tableFrom": "device_code",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_code_device_code_unique": {
+          "name": "device_code_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_code_user_code_unique": {
+          "name": "device_code_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_code_id_prefix": {
+          "name": "device_code_id_prefix",
+          "value": "\"device_code\".\"id\" ~ '^dvc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "device_code_status_allowed": {
+          "name": "device_code_status_allowed",
+          "value": "\"device_code\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "device_code_authorized_for_agrees": {
+          "name": "device_code_authorized_for_agrees",
+          "value": "(\"device_code\".\"organization_id\" is null) = (\"device_code\".\"project_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona_definition": {
+      "name": "persona_definition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "persona_egma_provided_name_unique": {
+          "name": "persona_egma_provided_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"persona_definition\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "persona_organization_id_project_id_idx": {
+          "name": "persona_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"persona_definition\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "persona_definition_organization_id_organization_id_fk": {
+          "name": "persona_definition_organization_id_organization_id_fk",
+          "tableFrom": "persona_definition",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_definition_current_version_id_persona_definition_version_id_fk": {
+          "name": "persona_definition_current_version_id_persona_definition_version_id_fk",
+          "tableFrom": "persona_definition",
+          "tableTo": "persona_definition_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persona_definition_created_by_user_id_fk": {
+          "name": "persona_definition_created_by_user_id_fk",
+          "tableFrom": "persona_definition",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "persona_project_organization_fk": {
+          "name": "persona_project_organization_fk",
+          "tableFrom": "persona_definition",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "persona_id_prefix": {
+          "name": "persona_id_prefix",
+          "value": "\"persona_definition\".\"id\" ~ '^prs_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "persona_tenancy_is_whole_or_egmas": {
+          "name": "persona_tenancy_is_whole_or_egmas",
+          "value": "(\"persona_definition\".\"organization_id\" is null) = (\"persona_definition\".\"project_id\" is null)"
+        },
+        "persona_egma_provided_is_active": {
+          "name": "persona_egma_provided_is_active",
+          "value": "\"persona_definition\".\"organization_id\" is not null or \"persona_definition\".\"archived_at\" is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona_definition_version": {
+      "name": "persona_definition_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_name": {
+          "name": "identity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "personality": {
+          "name": "personality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parameter_contract": {
+          "name": "parameter_contract",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "persona_definition_version_persona_id_persona_definition_id_fk": {
+          "name": "persona_definition_version_persona_id_persona_definition_id_fk",
+          "tableFrom": "persona_definition_version",
+          "tableTo": "persona_definition",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_definition_version_created_by_user_id_fk": {
+          "name": "persona_definition_version_created_by_user_id_fk",
+          "tableFrom": "persona_definition_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_version_persona_id_version_unique": {
+          "name": "persona_version_persona_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "persona_id",
+            "version"
+          ]
+        },
+        "persona_version_id_persona_id_unique": {
+          "name": "persona_version_id_persona_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "persona_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_version_id_prefix": {
+          "name": "persona_version_id_prefix",
+          "value": "\"persona_definition_version\".\"id\" ~ '^prsv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "persona_version_identity_name_stated": {
+          "name": "persona_version_identity_name_stated",
+          "value": "btrim(\"persona_definition_version\".\"identity_name\") <> ''"
+        },
+        "persona_version_personality_stated": {
+          "name": "persona_version_personality_stated",
+          "value": "btrim(\"persona_definition_version\".\"personality\") <> ''"
+        },
+        "persona_version_language_stated": {
+          "name": "persona_version_language_stated",
+          "value": "btrim(\"persona_definition_version\".\"language\") <> ''"
+        },
+        "persona_definition_version_parameter_contract_is_array": {
+          "name": "persona_definition_version_parameter_contract_is_array",
+          "value": "jsonb_typeof(\"persona_definition_version\".\"parameter_contract\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_persona": {
+      "name": "project_persona",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_definition_id": {
+          "name": "persona_definition_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parameter_values": {
+          "name": "parameter_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_persona_organization_id_organization_id_fk": {
+          "name": "project_persona_organization_id_organization_id_fk",
+          "tableFrom": "project_persona",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_persona_persona_definition_id_persona_definition_id_fk": {
+          "name": "project_persona_persona_definition_id_persona_definition_id_fk",
+          "tableFrom": "project_persona",
+          "tableTo": "persona_definition",
+          "columnsFrom": [
+            "persona_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "project_persona_project_organization_fk": {
+          "name": "project_persona_project_organization_fk",
+          "tableFrom": "project_persona",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_persona_project_definition_unique": {
+          "name": "project_persona_project_definition_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "persona_definition_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_persona_id_prefix": {
+          "name": "project_persona_id_prefix",
+          "value": "\"project_persona\".\"id\" ~ '^ppr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "project_persona_parameters_are_object": {
+          "name": "project_persona_parameters_are_object",
+          "value": "jsonb_typeof(\"project_persona\".\"parameter_values\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_platform": {
+          "name": "agent_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_agent_id": {
+          "name": "platform_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monitoring_api_key": {
+          "name": "monitoring_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monitoring_api_key_hint": {
+          "name": "monitoring_api_key_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_production_calls": {
+          "name": "pull_production_calls",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_project_id_name_unique": {
+          "name": "agent_project_id_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_organization_id_project_id_idx": {
+          "name": "agent_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pulled_platform_agent_unique": {
+          "name": "agent_pulled_platform_agent_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent\".\"pull_production_calls\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_organization_id_organization_id_fk": {
+          "name": "agent_organization_id_organization_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_created_by_user_id_fk": {
+          "name": "agent_created_by_user_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_project_organization_fk": {
+          "name": "agent_project_organization_fk",
+          "tableFrom": "agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_id_project_id_unique": {
+          "name": "agent_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_id_prefix": {
+          "name": "agent_id_prefix",
+          "value": "\"agent\".\"id\" ~ '^agt_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "agent_platform_allowed": {
+          "name": "agent_platform_allowed",
+          "value": "\"agent\".\"agent_platform\" in ('retell', 'livekit')"
+        },
+        "agent_monitoring_key_hint_agrees": {
+          "name": "agent_monitoring_key_hint_agrees",
+          "value": "(\"agent\".\"monitoring_api_key\" is null) = (\"agent\".\"monitoring_api_key_hint\" is null)"
+        },
+        "agent_monitoring_key_needs_platform": {
+          "name": "agent_monitoring_key_needs_platform",
+          "value": "\"agent\".\"monitoring_api_key\" is null or \"agent\".\"agent_platform\" is not null"
+        },
+        "agent_pull_needs_binding": {
+          "name": "agent_pull_needs_binding",
+          "value": "\"agent\".\"pull_production_calls\" = false or (\"agent\".\"agent_platform\" is not null and \"agent\".\"platform_agent_id\" is not null and \"agent\".\"monitoring_api_key\" is not null)"
+        },
+        "agent_archived_releases_pull": {
+          "name": "agent_archived_releases_pull",
+          "value": "\"agent\".\"pull_production_calls\" = false or \"agent\".\"archived_at\" is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_type": {
+          "name": "connection_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topology": {
+          "name": "topology",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_variant": {
+          "name": "access_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connection_agent_id_name_unique": {
+          "name": "connection_agent_id_name_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connection\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_agent_id_idx": {
+          "name": "connection_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connection\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connection_organization_id_organization_id_fk": {
+          "name": "connection_organization_id_organization_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_id_agent_id_fk": {
+          "name": "connection_agent_id_agent_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_created_by_user_id_fk": {
+          "name": "connection_created_by_user_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "connection_project_organization_fk": {
+          "name": "connection_project_organization_fk",
+          "tableFrom": "connection",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_project_fk": {
+          "name": "connection_agent_project_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connection_id_agent_id_unique": {
+          "name": "connection_id_agent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "agent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "connection_id_prefix": {
+          "name": "connection_id_prefix",
+          "value": "\"connection\".\"id\" ~ '^con_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "connection_type_allowed": {
+          "name": "connection_type_allowed",
+          "value": "\"connection\".\"connection_type\" in ('retell_text_mode', 'retell_web_call', 'phone_number', 'livekit_room', 'retell_chat_api')"
+        },
+        "connection_access_variant_allowed": {
+          "name": "connection_access_variant_allowed",
+          "value": "\"connection\".\"access_variant\" in ('retell_text_mode.api_key', 'retell_web_call.api_key', 'phone_number.public_e164', 'livekit_room.project_credentials', 'livekit_room.customer_token_endpoint', 'retell_chat_api.api_key')"
+        },
+        "connection_modality_allowed": {
+          "name": "connection_modality_allowed",
+          "value": "\"connection\".\"modality\" in ('voice', 'chat')"
+        },
+        "connection_topology_allowed": {
+          "name": "connection_topology_allowed",
+          "value": "\"connection\".\"topology\" in ('agent-dials-out', 'hosted-broker', 'egma-dials-in')"
+        },
+        "connection_credentials_hint_agrees": {
+          "name": "connection_credentials_hint_agrees",
+          "value": "(\"connection\".\"credentials\" is null) = (\"connection\".\"credentials_hint\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.monitoring_state": {
+      "name": "monitoring_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scan_kind": {
+          "name": "scan_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scan_from": {
+          "name": "scan_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scan_through": {
+          "name": "scan_through",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pagination_key": {
+          "name": "pagination_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pagination_trail": {
+          "name": "pagination_trail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "completed_through": {
+          "name": "completed_through",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_poll_at": {
+          "name": "next_poll_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regular_floor_at": {
+          "name": "regular_floor_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_generation": {
+          "name": "import_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_started_at": {
+          "name": "failure_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_kind": {
+          "name": "last_error_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_received_at": {
+          "name": "last_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "monitoring_state_due_idx": {
+          "name": "monitoring_state_due_idx",
+          "columns": [
+            {
+              "expression": "next_poll_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "monitoring_state_project_idx": {
+          "name": "monitoring_state_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "monitoring_state_organization_id_organization_id_fk": {
+          "name": "monitoring_state_organization_id_organization_id_fk",
+          "tableFrom": "monitoring_state",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "monitoring_state_project_organization_fk": {
+          "name": "monitoring_state_project_organization_fk",
+          "tableFrom": "monitoring_state",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "monitoring_state_agent_project_fk": {
+          "name": "monitoring_state_agent_project_fk",
+          "tableFrom": "monitoring_state",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "monitoring_state_agent_unique": {
+          "name": "monitoring_state_agent_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "monitoring_state_id_prefix": {
+          "name": "monitoring_state_id_prefix",
+          "value": "\"monitoring_state\".\"id\" ~ '^mst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "monitoring_state_scan_kind_allowed": {
+          "name": "monitoring_state_scan_kind_allowed",
+          "value": "\"monitoring_state\".\"scan_kind\" in ('historical_import', 'regular')"
+        },
+        "monitoring_state_scan_agrees": {
+          "name": "monitoring_state_scan_agrees",
+          "value": "(\"monitoring_state\".\"scan_kind\" is null and \"monitoring_state\".\"scan_from\" is null and \"monitoring_state\".\"scan_through\" is null and \"monitoring_state\".\"pagination_key\" is null) or (\"monitoring_state\".\"scan_kind\" is not null and \"monitoring_state\".\"scan_from\" is not null and \"monitoring_state\".\"scan_through\" is not null)"
+        },
+        "monitoring_state_lease_agrees": {
+          "name": "monitoring_state_lease_agrees",
+          "value": "(\"monitoring_state\".\"lease_owner\" is null) = (\"monitoring_state\".\"lease_expires_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.retell_call_retry": {
+      "name": "retell_call_retry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_call_id": {
+          "name": "provider_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_kind": {
+          "name": "error_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_generation": {
+          "name": "import_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retell_call_retry_due_idx": {
+          "name": "retell_call_retry_due_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"retell_call_retry\".\"next_attempt_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retell_call_retry_organization_id_organization_id_fk": {
+          "name": "retell_call_retry_organization_id_organization_id_fk",
+          "tableFrom": "retell_call_retry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retell_call_retry_project_organization_fk": {
+          "name": "retell_call_retry_project_organization_fk",
+          "tableFrom": "retell_call_retry",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retell_call_retry_agent_project_fk": {
+          "name": "retell_call_retry_agent_project_fk",
+          "tableFrom": "retell_call_retry",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "retell_call_retry_project_call_unique": {
+          "name": "retell_call_retry_project_call_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "provider_call_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "retell_call_retry_id_prefix": {
+          "name": "retell_call_retry_id_prefix",
+          "value": "\"retell_call_retry\".\"id\" ~ '^rcr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "retell_call_retry_one_schedule": {
+          "name": "retell_call_retry_one_schedule",
+          "value": "(\"retell_call_retry\".\"next_attempt_at\" is null) <> (\"retell_call_retry\".\"expires_at\" is null)"
+        },
+        "retell_call_retry_attempts_bounded": {
+          "name": "retell_call_retry_attempts_bounded",
+          "value": "\"retell_call_retry\".\"attempts\" between 1 and 4"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader_definition": {
+      "name": "grader_definition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_editable": {
+          "name": "scope_editable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_definition_version": {
+          "name": "current_definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grader_definition_predefined_name_unique": {
+          "name": "grader_definition_predefined_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"grader_definition\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grader_definition_organization_id_idx": {
+          "name": "grader_definition_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grader_definition_organization_id_organization_id_fk": {
+          "name": "grader_definition_organization_id_organization_id_fk",
+          "tableFrom": "grader_definition",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_definition_project_organization_fk": {
+          "name": "grader_definition_project_organization_fk",
+          "tableFrom": "grader_definition",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_definition_current_version_fk": {
+          "name": "grader_definition_current_version_fk",
+          "tableFrom": "grader_definition",
+          "tableTo": "grader_definition_version",
+          "columnsFrom": [
+            "id",
+            "current_definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grader_definition_id_prefix": {
+          "name": "grader_definition_id_prefix",
+          "value": "\"grader_definition\".\"id\" ~ '^grl_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_definition_ownership_pair": {
+          "name": "grader_definition_ownership_pair",
+          "value": "(\"grader_definition\".\"organization_id\" is null) = (\"grader_definition\".\"project_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader_definition_version": {
+      "name": "grader_definition_version",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parameter_contract": {
+          "name": "parameter_contract",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modalities": {
+          "name": "modalities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grader_definition_version_definition_id_grader_definition_id_fk": {
+          "name": "grader_definition_version_definition_id_grader_definition_id_fk",
+          "tableFrom": "grader_definition_version",
+          "tableTo": "grader_definition",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "grader_definition_version_definition_id_version_pk": {
+          "name": "grader_definition_version_definition_id_version_pk",
+          "columns": [
+            "definition_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grader_definition_version_definition_id_prefix": {
+          "name": "grader_definition_version_definition_id_prefix",
+          "value": "\"grader_definition_version\".\"definition_id\" ~ '^grl_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_definition_version_version_is_positive": {
+          "name": "grader_definition_version_version_is_positive",
+          "value": "\"grader_definition_version\".\"version\" >= 1"
+        },
+        "grader_definition_version_type_allowed": {
+          "name": "grader_definition_version_type_allowed",
+          "value": "\"grader_definition_version\".\"type\" in ('llm_as_judge', 'code')"
+        },
+        "grader_definition_version_modalities_allowed": {
+          "name": "grader_definition_version_modalities_allowed",
+          "value": "\"grader_definition_version\".\"modalities\" in (\n        '[\"chat\"]'::jsonb,\n        '[\"voice\"]'::jsonb,\n        '[\"chat\", \"voice\"]'::jsonb,\n        '[\"voice\", \"chat\"]'::jsonb\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_grader": {
+      "name": "project_grader",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grader_definition_id": {
+          "name": "grader_definition_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parameter_values": {
+          "name": "parameter_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_threshold": {
+          "name": "pass_threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_grader_active_definition_unique": {
+          "name": "project_grader_active_definition_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grader_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_grader\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_grader_organization_id_project_id_idx": {
+          "name": "project_grader_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"project_grader\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_grader_definition_id_idx": {
+          "name": "project_grader_definition_id_idx",
+          "columns": [
+            {
+              "expression": "grader_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_grader_organization_id_organization_id_fk": {
+          "name": "project_grader_organization_id_organization_id_fk",
+          "tableFrom": "project_grader",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_grader_grader_definition_id_grader_definition_id_fk": {
+          "name": "project_grader_grader_definition_id_grader_definition_id_fk",
+          "tableFrom": "project_grader",
+          "tableTo": "grader_definition",
+          "columnsFrom": [
+            "grader_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_grader_project_organization_fk": {
+          "name": "project_grader_project_organization_fk",
+          "tableFrom": "project_grader",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_grader_id_prefix": {
+          "name": "project_grader_id_prefix",
+          "value": "\"project_grader\".\"id\" ~ '^grd_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "project_grader_scope_is_closed_object": {
+          "name": "project_grader_scope_is_closed_object",
+          "value": "jsonb_typeof(\"project_grader\".\"scope\") is not distinct from 'object'\n        and (\"project_grader\".\"scope\" - array['simulations', 'production']::text[])\n          is not distinct from '{}'::jsonb\n        and \"project_grader\".\"scope\" ?& array['simulations', 'production']::text[]\n        and jsonb_typeof(\"project_grader\".\"scope\"->'simulations') is not distinct from 'array'\n        and (\n          \"project_grader\".\"scope\"->'production' = 'null'::jsonb\n          or jsonb_typeof(\"project_grader\".\"scope\"->'production') is not distinct from 'object'\n        )"
+        },
+        "project_grader_pass_threshold_is_normalized": {
+          "name": "project_grader_pass_threshold_is_normalized",
+          "value": "\"project_grader\".\"pass_threshold\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test": {
+      "name": "test",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_organization_id_project_id_idx": {
+          "name": "test_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"test\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_suite_id_id_idx": {
+          "name": "test_suite_id_id_idx",
+          "columns": [
+            {
+              "expression": "suite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"test\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_organization_id_organization_id_fk": {
+          "name": "test_organization_id_organization_id_fk",
+          "tableFrom": "test",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_current_version_id_test_version_id_fk": {
+          "name": "test_current_version_id_test_version_id_fk",
+          "tableFrom": "test",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_created_by_user_id_fk": {
+          "name": "test_created_by_user_id_fk",
+          "tableFrom": "test",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_project_organization_fk": {
+          "name": "test_project_organization_fk",
+          "tableFrom": "test",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_suite_project_fk": {
+          "name": "test_suite_project_fk",
+          "tableFrom": "test",
+          "tableTo": "test_suite",
+          "columnsFrom": [
+            "suite_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_id_project_id_unique": {
+          "name": "test_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_id_prefix": {
+          "name": "test_id_prefix",
+          "value": "\"test\".\"id\" ~ '^tst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_revision_prefix": {
+          "name": "test_revision_prefix",
+          "value": "\"test\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_persona": {
+      "name": "test_persona",
+      "schema": "",
+      "columns": {
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "test_persona_persona_id_idx": {
+          "name": "test_persona_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_persona_test_version_id_test_version_id_fk": {
+          "name": "test_persona_test_version_id_test_version_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_persona_persona_id_persona_definition_id_fk": {
+          "name": "test_persona_persona_id_persona_definition_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "persona_definition",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_persona_pk": {
+          "name": "test_persona_pk",
+          "columns": [
+            "test_version_id",
+            "persona_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "test_persona_version_id_position_unique": {
+          "name": "test_persona_version_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_version_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_persona_test_version_id_prefix": {
+          "name": "test_persona_test_version_id_prefix",
+          "value": "\"test_persona\".\"test_version_id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_suite": {
+      "name": "test_suite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_suite_organization_id_project_id_idx": {
+          "name": "test_suite_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"test_suite\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_suite_organization_id_organization_id_fk": {
+          "name": "test_suite_organization_id_organization_id_fk",
+          "tableFrom": "test_suite",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_suite_created_by_user_id_fk": {
+          "name": "test_suite_created_by_user_id_fk",
+          "tableFrom": "test_suite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_suite_project_organization_fk": {
+          "name": "test_suite_project_organization_fk",
+          "tableFrom": "test_suite",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_suite_id_project_id_unique": {
+          "name": "test_suite_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_suite_id_prefix": {
+          "name": "test_suite_id_prefix",
+          "value": "\"test_suite\".\"id\" ~ '^ste_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_suite_name_is_not_blank": {
+          "name": "test_suite_name_is_not_blank",
+          "value": "btrim(\"test_suite\".\"name\") <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_version": {
+      "name": "test_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mock_tools": {
+          "name": "mock_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_version_test_id_test_id_fk": {
+          "name": "test_version_test_id_test_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_version_created_by_user_id_fk": {
+          "name": "test_version_created_by_user_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_version_test_id_version_unique": {
+          "name": "test_version_test_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_id",
+            "version"
+          ]
+        },
+        "test_version_id_test_id_unique": {
+          "name": "test_version_id_test_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "test_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_version_id_prefix": {
+          "name": "test_version_id_prefix",
+          "value": "\"test_version\".\"id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run": {
+      "name": "run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_via": {
+          "name": "triggered_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_snapshot": {
+          "name": "connection_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_mock_agent_version": {
+          "name": "temp_mock_agent_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_mock_agent_version_cleanup": {
+          "name": "temp_mock_agent_version_cleanup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mock_metadata": {
+          "name": "mock_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grading_plan": {
+          "name": "grading_plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "concurrency": {
+          "name": "concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4
+        },
+        "expected_simulation_count": {
+          "name": "expected_simulation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_count": {
+          "name": "completed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_count": {
+          "name": "canceled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_organization_id_id_idx": {
+          "name": "run_organization_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_organization_id_project_id_id_idx": {
+          "name": "run_organization_id_project_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_agent_id_idx": {
+          "name": "run_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_suite_id_idx": {
+          "name": "run_suite_id_idx",
+          "columns": [
+            {
+              "expression": "suite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_mock_tools_cleanup_owed_idx": {
+          "name": "run_mock_tools_cleanup_owed_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"run\".\"temp_mock_agent_version_cleanup\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_organization_id_organization_id_fk": {
+          "name": "run_organization_id_organization_id_fk",
+          "tableFrom": "run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_triggered_by_user_id_fk": {
+          "name": "run_triggered_by_user_id_fk",
+          "tableFrom": "run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_project_organization_fk": {
+          "name": "run_project_organization_fk",
+          "tableFrom": "run",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_suite_project_fk": {
+          "name": "run_suite_project_fk",
+          "tableFrom": "run",
+          "tableTo": "test_suite",
+          "columnsFrom": [
+            "suite_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "run_agent_project_fk": {
+          "name": "run_agent_project_fk",
+          "tableFrom": "run",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_connection_agent_fk": {
+          "name": "run_connection_agent_fk",
+          "tableFrom": "run",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "run_id_project_id_unique": {
+          "name": "run_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "run_id_prefix": {
+          "name": "run_id_prefix",
+          "value": "\"run\".\"id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_concurrency_positive": {
+          "name": "run_concurrency_positive",
+          "value": "\"run\".\"concurrency\" > 0"
+        },
+        "run_status_allowed": {
+          "name": "run_status_allowed",
+          "value": "\"run\".\"status\" in ('pending', 'running', 'completed', 'canceled')"
+        },
+        "run_triggered_via_allowed": {
+          "name": "run_triggered_via_allowed",
+          "value": "\"run\".\"triggered_via\" in ('manual')"
+        },
+        "run_expects_at_least_one_simulation": {
+          "name": "run_expects_at_least_one_simulation",
+          "value": "\"run\".\"expected_simulation_count\" > 0"
+        },
+        "run_counts_written_together": {
+          "name": "run_counts_written_together",
+          "value": "((\"run\".\"completed_count\" is null) = (\"run\".\"failed_count\" is null))\n        and ((\"run\".\"failed_count\" is null) = (\"run\".\"canceled_count\" is null))\n        and ((\"run\".\"canceled_count\" is null) = (\"run\".\"finished_at\" is null))"
+        },
+        "run_counts_are_counts": {
+          "name": "run_counts_are_counts",
+          "value": "(\"run\".\"completed_count\" is null)\n        or (\"run\".\"completed_count\" >= 0 and \"run\".\"failed_count\" >= 0\n          and \"run\".\"canceled_count\" >= 0)"
+        },
+        "run_finished_is_terminal": {
+          "name": "run_finished_is_terminal",
+          "value": "\"run\".\"finished_at\" is null or \"run\".\"status\" in ('completed', 'canceled')"
+        },
+        "run_completed_is_finished": {
+          "name": "run_completed_is_finished",
+          "value": "\"run\".\"status\" <> 'completed' or \"run\".\"finished_at\" is not null"
+        },
+        "run_started_when_left_pending": {
+          "name": "run_started_when_left_pending",
+          "value": "case\n        when \"run\".\"status\" = 'pending' then \"run\".\"started_at\" is null\n        when \"run\".\"status\" in ('running', 'completed') then \"run\".\"started_at\" is not null\n        else true\n      end"
+        },
+        "run_agent_version_is_a_version": {
+          "name": "run_agent_version_is_a_version",
+          "value": "\"run\".\"agent_version\" is null or \"run\".\"agent_version\" >= 0"
+        },
+        "run_temp_mock_agent_version_is_a_version": {
+          "name": "run_temp_mock_agent_version_is_a_version",
+          "value": "\"run\".\"temp_mock_agent_version\" is null\n        or \"run\".\"temp_mock_agent_version\" >= 0"
+        },
+        "run_temp_mock_agent_version_owes_cleanup": {
+          "name": "run_temp_mock_agent_version_owes_cleanup",
+          "value": "\"run\".\"temp_mock_agent_version\" is null\n        or \"run\".\"temp_mock_agent_version_cleanup\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run_event": {
+      "name": "run_event",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_event_organization_id_organization_id_fk": {
+          "name": "run_event_organization_id_organization_id_fk",
+          "tableFrom": "run_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_project_organization_fk": {
+          "name": "run_event_project_organization_fk",
+          "tableFrom": "run_event",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_run_project_fk": {
+          "name": "run_event_run_project_fk",
+          "tableFrom": "run_event",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_simulation_run_fk": {
+          "name": "run_event_simulation_run_fk",
+          "tableFrom": "run_event",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "run_id"
+          ],
+          "columnsTo": [
+            "id",
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_event_pk": {
+          "name": "run_event_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "run_event_run_id_prefix": {
+          "name": "run_event_run_id_prefix",
+          "value": "\"run_event\".\"run_id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_event_kind_allowed": {
+          "name": "run_event_kind_allowed",
+          "value": "\"run_event\".\"kind\" in ('run', 'simulation')"
+        },
+        "run_event_seq_counts_from_one": {
+          "name": "run_event_seq_counts_from_one",
+          "value": "\"run_event\".\"seq\" >= 1"
+        },
+        "run_event_run_shape": {
+          "name": "run_event_run_shape",
+          "value": "\"run_event\".\"kind\" <> 'run'\n        or (\"run_event\".\"simulation_id\" is null\n          and \"run_event\".\"reason\" is null\n          and \"run_event\".\"status\" in ('pending', 'running', 'completed', 'canceled'))"
+        },
+        "run_event_simulation_shape": {
+          "name": "run_event_simulation_shape",
+          "value": "\"run_event\".\"kind\" <> 'simulation'\n        or (\"run_event\".\"simulation_id\" is not null\n          and \"run_event\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled'))"
+        },
+        "run_event_reason_agrees": {
+          "name": "run_event_reason_agrees",
+          "value": "\"run_event\".\"reason\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"reason\" in ('persona_concluded', 'agent_ended', 'limit_reached'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed', 'provider_key_unavailable'))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.simulation": {
+      "name": "simulation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_version_id": {
+          "name": "persona_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_parameter_values": {
+          "name": "persona_parameter_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_type": {
+          "name": "connection_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ending_reason": {
+          "name": "ending_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_failure": {
+          "name": "execution_failure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_ended_at": {
+          "name": "execution_ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recording_reference": {
+          "name": "recording_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "simulation_run_id_idx": {
+          "name": "simulation_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_queued_idx": {
+          "name": "simulation_queued_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_heartbeat_idx": {
+          "name": "simulation_heartbeat_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" in ('claimed', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_version_id_idx": {
+          "name": "simulation_persona_version_id_idx",
+          "columns": [
+            {
+              "expression": "persona_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_id_idx": {
+          "name": "simulation_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_version_id_idx": {
+          "name": "simulation_test_version_id_idx",
+          "columns": [
+            {
+              "expression": "test_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_id_idx": {
+          "name": "simulation_test_id_idx",
+          "columns": [
+            {
+              "expression": "test_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_organization_id_started_at_idx": {
+          "name": "simulation_organization_id_started_at_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulation_organization_id_organization_id_fk": {
+          "name": "simulation_organization_id_organization_id_fk",
+          "tableFrom": "simulation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_project_organization_fk": {
+          "name": "simulation_project_organization_fk",
+          "tableFrom": "simulation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_agent_project_fk": {
+          "name": "simulation_agent_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_connection_agent_fk": {
+          "name": "simulation_connection_agent_fk",
+          "tableFrom": "simulation",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_run_project_fk": {
+          "name": "simulation_run_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_version_persona_fk": {
+          "name": "simulation_persona_version_persona_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona_definition_version",
+          "columnsFrom": [
+            "persona_version_id",
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id",
+            "persona_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_version_test_fk": {
+          "name": "simulation_test_version_test_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id",
+            "test_id"
+          ],
+          "columnsTo": [
+            "id",
+            "test_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_project_fk": {
+          "name": "simulation_test_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulation_run_id_position_unique": {
+          "name": "simulation_run_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "position"
+          ]
+        },
+        "simulation_id_project_id_unique": {
+          "name": "simulation_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        },
+        "simulation_id_run_id_unique": {
+          "name": "simulation_id_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "simulation_id_prefix": {
+          "name": "simulation_id_prefix",
+          "value": "\"simulation\".\"id\" ~ '^sim_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "simulation_status_allowed": {
+          "name": "simulation_status_allowed",
+          "value": "\"simulation\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled')"
+        },
+        "simulation_modality_allowed": {
+          "name": "simulation_modality_allowed",
+          "value": "\"simulation\".\"modality\" in ('voice', 'chat')"
+        },
+        "simulation_connection_type_allowed": {
+          "name": "simulation_connection_type_allowed",
+          "value": "\"simulation\".\"connection_type\" in ('retell_text_mode', 'retell_web_call', 'phone_number', 'livekit_room')"
+        },
+        "simulation_position_counts_from_one": {
+          "name": "simulation_position_counts_from_one",
+          "value": "\"simulation\".\"position\" >= 1"
+        },
+        "simulation_ending_reason_allowed": {
+          "name": "simulation_ending_reason_allowed",
+          "value": "\"simulation\".\"ending_reason\" is null or \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached', 'agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed', 'provider_key_unavailable')"
+        },
+        "simulation_ending_reason_agrees": {
+          "name": "simulation_ending_reason_agrees",
+          "value": "case \"simulation\".\"status\"\n        when 'completed' then \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached')\n        when 'failed' then \"simulation\".\"ending_reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed', 'provider_key_unavailable')\n        else \"simulation\".\"ending_reason\" is null\n      end"
+        },
+        "simulation_execution_failure_agrees": {
+          "name": "simulation_execution_failure_agrees",
+          "value": "\"simulation\".\"execution_failure\" is null or \"simulation\".\"status\" = 'failed'"
+        },
+        "simulation_execution_failure_not_blank": {
+          "name": "simulation_execution_failure_not_blank",
+          "value": "\"simulation\".\"execution_failure\" is null or btrim(\"simulation\".\"execution_failure\") <> ''"
+        },
+        "simulation_claim_columns_agree": {
+          "name": "simulation_claim_columns_agree",
+          "value": "((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"claimed_by\" is null))\n        and ((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"heartbeat_at\" is null))"
+        },
+        "simulation_queued_shape": {
+          "name": "simulation_queued_shape",
+          "value": "\"simulation\".\"status\" <> 'queued'\n        or (\"simulation\".\"claimed_at\" is null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null and \"simulation\".\"cancel_requested_at\" is null)"
+        },
+        "simulation_claimed_shape": {
+          "name": "simulation_claimed_shape",
+          "value": "\"simulation\".\"status\" <> 'claimed'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_running_shape": {
+          "name": "simulation_running_shape",
+          "value": "\"simulation\".\"status\" <> 'running'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is not null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_completed_shape": {
+          "name": "simulation_completed_shape",
+          "value": "\"simulation\".\"status\" <> 'completed'\n        or (\"simulation\".\"started_at\" is not null and \"simulation\".\"ended_at\" is not null)"
+        },
+        "simulation_failed_shape": {
+          "name": "simulation_failed_shape",
+          "value": "\"simulation\".\"status\" <> 'failed' or \"simulation\".\"ended_at\" is not null"
+        },
+        "simulation_execution_end_is_measured": {
+          "name": "simulation_execution_end_is_measured",
+          "value": "\"simulation\".\"execution_ended_at\" is null or (\n        \"simulation\".\"started_at\" is not null and \"simulation\".\"ended_at\" is not null\n        and \"simulation\".\"execution_ended_at\" >= \"simulation\".\"started_at\")"
+        },
+        "simulation_canceled_shape": {
+          "name": "simulation_canceled_shape",
+          "value": "\"simulation\".\"status\" <> 'canceled'\n        or (\"simulation\".\"ended_at\" is not null and \"simulation\".\"cancel_requested_at\" is not null)"
+        },
+        "simulation_report_only_when_ended": {
+          "name": "simulation_report_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or \"simulation\".\"recording_reference\" is null"
+        },
+        "simulation_summary_facts_only_when_ended": {
+          "name": "simulation_summary_facts_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or \"simulation\".\"turn_count\" is null"
+        },
+        "simulation_provider_reference_after_claim": {
+          "name": "simulation_provider_reference_after_claim",
+          "value": "\"simulation\".\"status\" <> 'queued' or \"simulation\".\"provider_reference\" is null"
+        },
+        "simulation_turn_count_is_a_count": {
+          "name": "simulation_turn_count_is_a_count",
+          "value": "\"simulation\".\"turn_count\" is null or \"simulation\".\"turn_count\" >= 0"
+        },
+        "simulation_audio_facts_are_voice_facts": {
+          "name": "simulation_audio_facts_are_voice_facts",
+          "value": "\"simulation\".\"modality\" = 'voice'\n        or \"simulation\".\"recording_reference\" is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grading_job": {
+      "name": "grading_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_started_at": {
+          "name": "trace_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence_base": {
+          "name": "sequence_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grading_job_outstanding_idx": {
+          "name": "grading_job_outstanding_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grading_job\".\"status\" in ('pending', 'claimed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grading_job_organization_id_project_id_idx": {
+          "name": "grading_job_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grading_job_organization_id_organization_id_fk": {
+          "name": "grading_job_organization_id_organization_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_project_organization_fk": {
+          "name": "grading_job_project_organization_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_simulation_project_fk": {
+          "name": "grading_job_simulation_project_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grading_job_simulation_id_unique": {
+          "name": "grading_job_simulation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "simulation_id"
+          ]
+        },
+        "grading_job_project_id_trace_id_unique": {
+          "name": "grading_job_project_id_trace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "trace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grading_job_id_prefix": {
+          "name": "grading_job_id_prefix",
+          "value": "\"grading_job\".\"id\" ~ '^gjb_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grading_job_status_allowed": {
+          "name": "grading_job_status_allowed",
+          "value": "\"grading_job\".\"status\" in ('pending', 'claimed', 'abandoned')"
+        },
+        "grading_job_source_allowed": {
+          "name": "grading_job_source_allowed",
+          "value": "\"grading_job\".\"source\" in ('simulation', 'production')"
+        },
+        "grading_job_source_names_its_control_record": {
+          "name": "grading_job_source_names_its_control_record",
+          "value": "case \"grading_job\".\"source\"\n        when 'simulation' then \"grading_job\".\"simulation_id\" is not null and \"grading_job\".\"run_id\" is not null\n        when 'production' then \"grading_job\".\"simulation_id\" is null and \"grading_job\".\"run_id\" is null\n        else false\n      end"
+        },
+        "grading_job_entries_are_a_nonempty_list": {
+          "name": "grading_job_entries_are_a_nonempty_list",
+          "value": "jsonb_typeof(\"grading_job\".\"entries\") = 'array'\n        and jsonb_array_length(\"grading_job\".\"entries\") > 0"
+        },
+        "grading_job_claim_columns_agree": {
+          "name": "grading_job_claim_columns_agree",
+          "value": "((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"claimed_by\" is null))\n        and ((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"heartbeat_at\" is null))"
+        },
+        "grading_job_pending_shape": {
+          "name": "grading_job_pending_shape",
+          "value": "\"grading_job\".\"status\" <> 'pending'\n        or (\"grading_job\".\"claimed_at\" is null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_claimed_shape": {
+          "name": "grading_job_claimed_shape",
+          "value": "\"grading_job\".\"status\" <> 'claimed'\n        or (\"grading_job\".\"claimed_at\" is not null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_abandoned_shape": {
+          "name": "grading_job_abandoned_shape",
+          "value": "(\"grading_job\".\"status\" = 'abandoned') = (\"grading_job\".\"finished_at\" is not null)"
+        },
+        "grading_job_sequence_base_is_counted": {
+          "name": "grading_job_sequence_base_is_counted",
+          "value": "\"grading_job\".\"sequence_base\" >= 0"
+        },
+        "grading_job_attempts_are_counted": {
+          "name": "grading_job_attempts_are_counted",
+          "value": "\"grading_job\".\"attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.rate_card": {
+      "name": "rate_card",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_type": {
+          "name": "usage_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usd_per_million": {
+          "name": "usd_per_million",
+          "type": "numeric(24, 12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_card_effective_idx": {
+          "name": "rate_card_effective_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rate_card_price_identity_unique": {
+          "name": "rate_card_price_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "model",
+            "usage_type",
+            "effective_from"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "rate_card_id_prefix": {
+          "name": "rate_card_id_prefix",
+          "value": "\"rate_card\".\"id\" ~ '^rat_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "rate_card_usage_type_allowed": {
+          "name": "rate_card_usage_type_allowed",
+          "value": "\"rate_card\".\"usage_type\" in ('input_tokens', 'cached_input_tokens', 'output_tokens', 'audio_input_tokens', 'text_input_tokens', 'audio_seconds', 'characters')"
+        },
+        "rate_card_unit_allowed": {
+          "name": "rate_card_unit_allowed",
+          "value": "\"rate_card\".\"unit\" in ('tokens', 'seconds', 'characters')"
+        },
+        "rate_card_price_is_not_negative": {
+          "name": "rate_card_price_is_not_negative",
+          "value": "\"rate_card\".\"usd_per_million\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cloud_billing_account": {
+      "name": "cloud_billing_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_code": {
+          "name": "plan_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_anchor": {
+          "name": "period_anchor",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_status": {
+          "name": "stripe_subscription_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_refreshed_at": {
+          "name": "stripe_subscription_refreshed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_period_started_at": {
+          "name": "stripe_period_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_period_ends_at": {
+          "name": "stripe_period_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_cancel_at": {
+          "name": "stripe_cancel_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_failed_at": {
+          "name": "stripe_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_failure_version": {
+          "name": "stripe_failure_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inference_settled_through": {
+          "name": "inference_settled_through",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settlement_failed_at": {
+          "name": "settlement_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_micros": {
+          "name": "balance_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cloud_billing_account_organization_id_organization_id_fk": {
+          "name": "cloud_billing_account_organization_id_organization_id_fk",
+          "tableFrom": "cloud_billing_account",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_billing_account_plan_fk": {
+          "name": "cloud_billing_account_plan_fk",
+          "tableFrom": "cloud_billing_account",
+          "tableTo": "cloud_plan",
+          "columnsFrom": [
+            "plan_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cloud_billing_account_organization_unique": {
+          "name": "cloud_billing_account_organization_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        },
+        "cloud_billing_account_stripe_customer_unique": {
+          "name": "cloud_billing_account_stripe_customer_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "cloud_billing_account_stripe_subscription_unique": {
+          "name": "cloud_billing_account_stripe_subscription_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cloud_billing_account_id_prefix": {
+          "name": "cloud_billing_account_id_prefix",
+          "value": "\"cloud_billing_account\".\"id\" ~ '^cba_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "cloud_billing_account_plan_code_allowed": {
+          "name": "cloud_billing_account_plan_code_allowed",
+          "value": "\"cloud_billing_account\".\"plan_code\" in ('hobby', 'pro')"
+        },
+        "cloud_billing_account_stripe_failure_version_is_exact": {
+          "name": "cloud_billing_account_stripe_failure_version_is_exact",
+          "value": "\"cloud_billing_account\".\"stripe_failure_version\" >= 0 and \"cloud_billing_account\".\"stripe_failure_version\" <= 9007199254740991"
+        },
+        "cloud_billing_account_subscription_status_allowed": {
+          "name": "cloud_billing_account_subscription_status_allowed",
+          "value": "\"cloud_billing_account\".\"stripe_subscription_status\" is null\n        or \"cloud_billing_account\".\"stripe_subscription_status\" in ('trialing', 'active', 'past_due', 'canceled', 'unpaid', 'incomplete', 'incomplete_expired', 'paused')"
+        },
+        "cloud_billing_account_subscription_needs_a_customer": {
+          "name": "cloud_billing_account_subscription_needs_a_customer",
+          "value": "\"cloud_billing_account\".\"stripe_subscription_id\" is null\n        or \"cloud_billing_account\".\"stripe_customer_id\" is not null"
+        },
+        "cloud_billing_account_subscription_status_needs_a_subscription": {
+          "name": "cloud_billing_account_subscription_status_needs_a_subscription",
+          "value": "\"cloud_billing_account\".\"stripe_subscription_status\" is null\n        or \"cloud_billing_account\".\"stripe_subscription_id\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cloud_ledger_entry": {
+      "name": "cloud_ledger_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_micros": {
+          "name": "amount_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_kind": {
+          "name": "reference_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval_started_at": {
+          "name": "interval_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_ended_at": {
+          "name": "interval_ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloud_ledger_entry_organization_idx": {
+          "name": "cloud_ledger_entry_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_ledger_entry_account_fk": {
+          "name": "cloud_ledger_entry_account_fk",
+          "tableFrom": "cloud_ledger_entry",
+          "tableTo": "cloud_billing_account",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cloud_ledger_entry_organization_interval_unique": {
+          "name": "cloud_ledger_entry_organization_interval_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "interval_started_at",
+            "interval_ended_at"
+          ]
+        },
+        "cloud_ledger_entry_idempotency_key_unique": {
+          "name": "cloud_ledger_entry_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cloud_ledger_entry_id_prefix": {
+          "name": "cloud_ledger_entry_id_prefix",
+          "value": "\"cloud_ledger_entry\".\"id\" ~ '^cle_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "cloud_ledger_entry_kind_allowed": {
+          "name": "cloud_ledger_entry_kind_allowed",
+          "value": "\"cloud_ledger_entry\".\"kind\" in ('welcome_credit', 'purchased_credit', 'inference_charge', 'correction')"
+        },
+        "cloud_ledger_entry_reference_kind_allowed": {
+          "name": "cloud_ledger_entry_reference_kind_allowed",
+          "value": "\"cloud_ledger_entry\".\"reference_kind\" in ('organization', 'settlement_interval', 'checkout_session', 'operator')"
+        },
+        "cloud_ledger_entry_reference_id_is_not_blank": {
+          "name": "cloud_ledger_entry_reference_id_is_not_blank",
+          "value": "btrim(\"cloud_ledger_entry\".\"reference_id\") <> ''"
+        },
+        "cloud_ledger_entry_idempotency_key_is_not_blank": {
+          "name": "cloud_ledger_entry_idempotency_key_is_not_blank",
+          "value": "btrim(\"cloud_ledger_entry\".\"idempotency_key\") <> ''"
+        },
+        "cloud_ledger_entry_kind_names_its_cause": {
+          "name": "cloud_ledger_entry_kind_names_its_cause",
+          "value": "case \"cloud_ledger_entry\".\"kind\"\n        when 'welcome_credit' then \"cloud_ledger_entry\".\"reference_kind\" = 'organization'\n        when 'purchased_credit' then \"cloud_ledger_entry\".\"reference_kind\" = 'checkout_session'\n        when 'inference_charge' then \"cloud_ledger_entry\".\"reference_kind\" = 'settlement_interval'\n        else true\n      end"
+        },
+        "cloud_ledger_entry_interval_matches_kind": {
+          "name": "cloud_ledger_entry_interval_matches_kind",
+          "value": "case when \"cloud_ledger_entry\".\"kind\" = 'inference_charge'\n        then \"cloud_ledger_entry\".\"interval_started_at\" is not null and \"cloud_ledger_entry\".\"interval_ended_at\" is not null\n          and \"cloud_ledger_entry\".\"interval_started_at\" < \"cloud_ledger_entry\".\"interval_ended_at\"\n        else \"cloud_ledger_entry\".\"interval_started_at\" is null and \"cloud_ledger_entry\".\"interval_ended_at\" is null end"
+        },
+        "cloud_ledger_entry_sign_follows_its_kind": {
+          "name": "cloud_ledger_entry_sign_follows_its_kind",
+          "value": "case \"cloud_ledger_entry\".\"kind\"\n        when 'welcome_credit' then \"cloud_ledger_entry\".\"amount_micros\" > 0\n        when 'purchased_credit' then \"cloud_ledger_entry\".\"amount_micros\" > 0\n        when 'inference_charge' then \"cloud_ledger_entry\".\"amount_micros\" < 0\n        else \"cloud_ledger_entry\".\"amount_micros\" <> 0\n      end"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cloud_plan": {
+      "name": "cloud_plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_micros": {
+          "name": "fee_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_simulations_allowance": {
+          "name": "chat_simulations_allowance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "web_call_minutes_allowance": {
+          "name": "web_call_minutes_allowance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_minutes_allowance": {
+          "name": "phone_minutes_allowance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "web_call_overage_micros_per_minute": {
+          "name": "web_call_overage_micros_per_minute",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_overage_micros_per_minute": {
+          "name": "phone_overage_micros_per_minute",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_fee_price_id": {
+          "name": "stripe_fee_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_web_call_meter_price_id": {
+          "name": "stripe_web_call_meter_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_phone_meter_price_id": {
+          "name": "stripe_phone_meter_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_web_call_meter_id": {
+          "name": "stripe_web_call_meter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_phone_meter_id": {
+          "name": "stripe_phone_meter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_activated_at": {
+          "name": "billing_activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payments_ready": {
+          "name": "stripe_payments_ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cloud_plan_code_unique": {
+          "name": "cloud_plan_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cloud_plan_id_prefix": {
+          "name": "cloud_plan_id_prefix",
+          "value": "\"cloud_plan\".\"id\" ~ '^cpl_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "cloud_plan_code_allowed": {
+          "name": "cloud_plan_code_allowed",
+          "value": "\"cloud_plan\".\"code\" in ('hobby', 'pro')"
+        },
+        "cloud_plan_name_is_not_blank": {
+          "name": "cloud_plan_name_is_not_blank",
+          "value": "btrim(\"cloud_plan\".\"name\") <> ''"
+        },
+        "cloud_plan_fee_is_not_negative": {
+          "name": "cloud_plan_fee_is_not_negative",
+          "value": "\"cloud_plan\".\"fee_micros\" >= 0"
+        },
+        "cloud_plan_allowances_are_not_negative": {
+          "name": "cloud_plan_allowances_are_not_negative",
+          "value": "coalesce(\"cloud_plan\".\"chat_simulations_allowance\", 0) >= 0\n        and coalesce(\"cloud_plan\".\"web_call_minutes_allowance\", 0) >= 0\n        and coalesce(\"cloud_plan\".\"phone_minutes_allowance\", 0) >= 0"
+        },
+        "cloud_plan_overage_prices_are_not_negative": {
+          "name": "cloud_plan_overage_prices_are_not_negative",
+          "value": "\"cloud_plan\".\"web_call_overage_micros_per_minute\" >= 0\n        and \"cloud_plan\".\"phone_overage_micros_per_minute\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cloud_meter_period": {
+      "name": "cloud_meter_period",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_started_at": {
+          "name": "period_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_ends_at": {
+          "name": "period_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meter_id": {
+          "name": "meter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_through_hour": {
+          "name": "observed_through_hour",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_seconds": {
+          "name": "accepted_seconds",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "uncertain_seconds": {
+          "name": "uncertain_seconds",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_observed_seconds": {
+          "name": "last_observed_seconds",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pending_identifier": {
+          "name": "pending_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_seconds": {
+          "name": "pending_seconds",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_value": {
+          "name": "pending_value",
+          "type": "numeric(30, 12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_timestamp": {
+          "name": "pending_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_hour": {
+          "name": "pending_hour",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_first_sent_at": {
+          "name": "pending_first_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "late_invoiced_cents": {
+          "name": "late_invoiced_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "late_observed_seconds": {
+          "name": "late_observed_seconds",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "late_pending_identifier": {
+          "name": "late_pending_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "late_pending_through_seconds": {
+          "name": "late_pending_through_seconds",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "late_pending_amount_cents": {
+          "name": "late_pending_amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "late_invoice_create_started_at": {
+          "name": "late_invoice_create_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "late_invoice_id": {
+          "name": "late_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "late_item_create_started_at": {
+          "name": "late_item_create_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "late_invoice_item_id": {
+          "name": "late_invoice_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "last_outcome": {
+          "name": "last_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cloud_meter_period_organization_id_organization_id_fk": {
+          "name": "cloud_meter_period_organization_id_organization_id_fk",
+          "tableFrom": "cloud_meter_period",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "cloud_meter_period_pk": {
+          "name": "cloud_meter_period_pk",
+          "columns": [
+            "organization_id",
+            "stripe_subscription_id",
+            "period_started_at",
+            "period_ends_at",
+            "channel"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cloud_meter_period_channel_allowed": {
+          "name": "cloud_meter_period_channel_allowed",
+          "value": "\"cloud_meter_period\".\"channel\" in ('web_call_minutes', 'phone_minutes')"
+        },
+        "cloud_meter_period_state_allowed": {
+          "name": "cloud_meter_period_state_allowed",
+          "value": "\"cloud_meter_period\".\"state\" in ('open', 'needs_attention', 'closed')"
+        },
+        "cloud_meter_period_outcome_allowed": {
+          "name": "cloud_meter_period_outcome_allowed",
+          "value": "\"cloud_meter_period\".\"last_outcome\" is null or \"cloud_meter_period\".\"last_outcome\" in ('accepted', 'duplicate', 'uncertain', 'invoice_closed', 'timestamp_expired')"
+        },
+        "cloud_meter_period_subscription_not_blank": {
+          "name": "cloud_meter_period_subscription_not_blank",
+          "value": "btrim(\"cloud_meter_period\".\"stripe_subscription_id\") <> ''"
+        },
+        "cloud_meter_period_customer_not_blank": {
+          "name": "cloud_meter_period_customer_not_blank",
+          "value": "btrim(\"cloud_meter_period\".\"stripe_customer_id\") <> ''"
+        },
+        "cloud_meter_period_meter_not_blank": {
+          "name": "cloud_meter_period_meter_not_blank",
+          "value": "btrim(\"cloud_meter_period\".\"meter_id\") <> ''"
+        },
+        "cloud_meter_period_event_not_blank": {
+          "name": "cloud_meter_period_event_not_blank",
+          "value": "btrim(\"cloud_meter_period\".\"event_name\") <> ''"
+        },
+        "cloud_meter_period_price_not_blank": {
+          "name": "cloud_meter_period_price_not_blank",
+          "value": "btrim(\"cloud_meter_period\".\"price_id\") <> ''"
+        },
+        "cloud_meter_period_bounds": {
+          "name": "cloud_meter_period_bounds",
+          "value": "\"cloud_meter_period\".\"period_ends_at\" > \"cloud_meter_period\".\"period_started_at\""
+        },
+        "cloud_meter_period_seconds_counted": {
+          "name": "cloud_meter_period_seconds_counted",
+          "value": "\n      \"cloud_meter_period\".\"accepted_seconds\" between 0 and 9007199254740991\n      and \"cloud_meter_period\".\"uncertain_seconds\" between 0 and 9007199254740991\n      and \"cloud_meter_period\".\"last_observed_seconds\" between 0 and 9007199254740991\n    "
+        },
+        "cloud_meter_period_pending_complete": {
+          "name": "cloud_meter_period_pending_complete",
+          "value": "\n      num_nonnulls(\"cloud_meter_period\".\"pending_identifier\", \"cloud_meter_period\".\"pending_seconds\", \"cloud_meter_period\".\"pending_value\",\n        \"cloud_meter_period\".\"pending_timestamp\", \"cloud_meter_period\".\"pending_hour\", \"cloud_meter_period\".\"pending_first_sent_at\") in (0, 6)\n    "
+        },
+        "cloud_meter_period_late_counted": {
+          "name": "cloud_meter_period_late_counted",
+          "value": "\n      \"cloud_meter_period\".\"late_invoiced_cents\" between 0 and 9007199254740991\n      and \"cloud_meter_period\".\"late_observed_seconds\" between 0 and 9007199254740991\n    "
+        },
+        "cloud_meter_period_late_pending_complete": {
+          "name": "cloud_meter_period_late_pending_complete",
+          "value": "\n      num_nonnulls(\"cloud_meter_period\".\"late_pending_identifier\", \"cloud_meter_period\".\"late_pending_through_seconds\", \"cloud_meter_period\".\"late_pending_amount_cents\") in (0, 3)\n      and (\"cloud_meter_period\".\"late_pending_identifier\" is not null or num_nonnulls(\"cloud_meter_period\".\"late_invoice_create_started_at\", \"cloud_meter_period\".\"late_invoice_id\", \"cloud_meter_period\".\"late_item_create_started_at\", \"cloud_meter_period\".\"late_invoice_item_id\") = 0)\n    "
+        },
+        "cloud_meter_period_late_pending_valid": {
+          "name": "cloud_meter_period_late_pending_valid",
+          "value": "\"cloud_meter_period\".\"late_pending_identifier\" is null or (\n      btrim(\"cloud_meter_period\".\"late_pending_identifier\") <> ''\n      and \"cloud_meter_period\".\"late_pending_through_seconds\" between 1 and 9007199254740991\n      and \"cloud_meter_period\".\"late_pending_amount_cents\" between 1 and 9007199254740991\n      and (\"cloud_meter_period\".\"late_invoice_id\" is null or (\"cloud_meter_period\".\"late_invoice_create_started_at\" is not null and btrim(\"cloud_meter_period\".\"late_invoice_id\") <> ''))\n      and (\"cloud_meter_period\".\"late_item_create_started_at\" is null or \"cloud_meter_period\".\"late_invoice_id\" is not null)\n      and (\"cloud_meter_period\".\"late_invoice_item_id\" is null or (\"cloud_meter_period\".\"late_item_create_started_at\" is not null and btrim(\"cloud_meter_period\".\"late_invoice_item_id\") <> ''))\n    )"
+        },
+        "cloud_meter_period_pending_valid": {
+          "name": "cloud_meter_period_pending_valid",
+          "value": "\"cloud_meter_period\".\"pending_identifier\" is null or (\n      btrim(\"cloud_meter_period\".\"pending_identifier\") <> ''\n      and \"cloud_meter_period\".\"pending_seconds\" between 1 and 9007199254740991\n      and \"cloud_meter_period\".\"pending_value\" > 0\n      and \"cloud_meter_period\".\"pending_timestamp\" >= \"cloud_meter_period\".\"period_started_at\"\n      and \"cloud_meter_period\".\"pending_timestamp\" < \"cloud_meter_period\".\"period_ends_at\"\n    )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.provider_key": {
+      "name": "provider_key",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_key_organization_id_organization_id_fk": {
+          "name": "provider_key_organization_id_organization_id_fk",
+          "tableFrom": "provider_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "provider_key_organization_id_provider_pk": {
+          "name": "provider_key_organization_id_provider_pk",
+          "columns": [
+            "organization_id",
+            "provider"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "provider_key_provider_allowed": {
+          "name": "provider_key_provider_allowed",
+          "value": "\"provider_key\".\"provider\" in ('openai', 'deepgram', 'cartesia')"
+        },
+        "provider_key_revision_prefix": {
+          "name": "provider_key_revision_prefix",
+          "value": "\"provider_key\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "provider_key_hint_shape": {
+          "name": "provider_key_hint_shape",
+          "value": "char_length(\"provider_key\".\"hint\") = 8"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1788822388137,
       "tag": "0000_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1789082964373,
+      "tag": "0001_run_concurrency",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/access/runs.ts
+++ b/packages/db/src/access/runs.ts
@@ -114,6 +114,7 @@ export type NewRun = {
   readonly agentId: string;
   readonly connectionId: string;
   readonly name?: string | undefined;
+  readonly concurrency?: number | undefined;
   readonly expectedTestVersions?: readonly ExpectedTestVersion[] | undefined;
   /**
    * Agent platform version resolved before the run transaction. Required for
@@ -161,6 +162,7 @@ export type Run = {
   readonly tempMockAgentVersionCleanup: boolean | null;
   /** The put-it-back note, or null when nothing was put onto the account. */
   readonly mockMetadata: MockMetadata | null;
+  readonly concurrency: number;
   readonly expectedSimulationCount: number;
   readonly completedCount: number | null;
   readonly failedCount: number | null;
@@ -244,6 +246,7 @@ const RUN_COLUMNS = {
   tempMockAgentVersion: run.tempMockAgentVersion,
   tempMockAgentVersionCleanup: run.tempMockAgentVersionCleanup,
   mockMetadata: run.mockMetadata,
+  concurrency: run.concurrency,
   expectedSimulationCount: run.expectedSimulationCount,
   completedCount: run.completedCount,
   failedCount: run.failedCount,
@@ -296,6 +299,7 @@ type RunRow = {
   readonly tempMockAgentVersion: number | null;
   readonly tempMockAgentVersionCleanup: boolean | null;
   readonly mockMetadata: unknown;
+  readonly concurrency: number;
   readonly expectedSimulationCount: number;
   readonly completedCount: number | null;
   readonly failedCount: number | null;
@@ -528,6 +532,10 @@ export async function startRun(auth: AuthContext, input: NewRun): Promise<Starte
   if (!isId("ste", input.suiteId)) refuseRun("not_admitted", `"${input.suiteId}" is not a test suite id`);
   if (!isId("agt", input.agentId)) refuseRun("connection_not_on_agent", `"${input.agentId}" is not an agent id`);
   if (!isId("con", input.connectionId)) refuseRun("no_such_connection", `"${input.connectionId}" is not a connection id`);
+  const concurrency = input.concurrency;
+  if (concurrency !== undefined && (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 2147483647)) {
+    refuseRun("not_admitted", "concurrency must be a whole number between 1 and 2147483647");
+  }
   const expected = validateExpectedVersions(input.expectedTestVersions);
   const expectedInOrder = expected === undefined
     ? undefined
@@ -734,6 +742,7 @@ export async function startRun(auth: AuthContext, input: NewRun): Promise<Starte
       ...(input.agentVersion === undefined
         ? {}
         : { agentVersion: input.agentVersion }),
+      concurrency: concurrency ?? (reached.modality === "chat" ? 10 : 4),
       expectedSimulationCount,
       gradingPlan,
       createdAt: at,
@@ -1790,6 +1799,8 @@ function checkedModalities(
 }
 
 type CapCandidate = {
+  readonly runId: string;
+  readonly concurrency: number;
   readonly id: string;
   readonly modality: Modality;
   readonly parameterValues: PersonaParameterValues;
@@ -1797,6 +1808,7 @@ type CapCandidate = {
 };
 
 type CapUsage = {
+  readonly runs: Map<string, number>;
   voice: number;
   chat: number;
   readonly speechProviders: Map<string, number>;
@@ -1810,8 +1822,9 @@ function speechProvidersOf(candidate: CapCandidate): readonly ModelProvider[] {
 }
 
 function usageOf(active: readonly CapCandidate[]): CapUsage {
-  const usage: CapUsage = { voice: 0, chat: 0, speechProviders: new Map() };
+  const usage: CapUsage = { voice: 0, chat: 0, speechProviders: new Map(), runs: new Map() };
   for (const candidate of active) {
+    usage.runs.set(candidate.runId, (usage.runs.get(candidate.runId) ?? 0) + 1);
     usage[candidate.modality] += 1;
     if (candidate.modality === "chat") continue;
     let providers: readonly ModelProvider[];
@@ -1833,6 +1846,18 @@ function usageOf(active: readonly CapCandidate[]): CapUsage {
 }
 
 function admitWithinCaps(
+  candidate: CapCandidate,
+  caps: SimulationConcurrencyCaps,
+  usage: CapUsage,
+): boolean {
+  const active = usage.runs.get(candidate.runId) ?? 0;
+  if (active >= candidate.concurrency) return false;
+  if (!admitWithinDeploymentCaps(candidate, caps, usage)) return false;
+  usage.runs.set(candidate.runId, active + 1);
+  return true;
+}
+
+function admitWithinDeploymentCaps(
   candidate: CapCandidate,
   caps: SimulationConcurrencyCaps,
   usage: CapUsage,
@@ -1889,11 +1914,14 @@ async function activeSimulationCandidates(
   return (await on
     .select({
       id: simulation.id,
+      runId: simulation.runId,
+      concurrency: run.concurrency,
       modality: simulation.modality,
       parameterValues: simulation.personaParameterValues,
       parameterContract: personaVersion.parameterContract,
     })
     .from(simulation)
+    .innerJoin(run, eq(run.id, simulation.runId))
     .innerJoin(personaVersion, eq(personaVersion.id, simulation.personaVersionId))
     .where(
       and(
@@ -1918,11 +1946,14 @@ export async function estimateVoiceSimulationDemand(
       const queued = (await tx
         .select({
           id: simulation.id,
+          runId: simulation.runId,
+          concurrency: run.concurrency,
           modality: simulation.modality,
           parameterValues: simulation.personaParameterValues,
           parameterContract: personaVersion.parameterContract,
         })
         .from(simulation)
+        .innerJoin(run, eq(run.id, simulation.runId))
         .innerJoin(personaVersion, eq(personaVersion.id, simulation.personaVersionId))
         .where(
           and(
@@ -1971,22 +2002,9 @@ export async function claimSimulations(
   const now = new Date();
 
   const claimed = await db().transaction(async (tx) => {
-    const capsApply = caps.voice !== undefined || caps.chat !== undefined ||
-      Object.keys(caps.speechProviders ?? {}).length > 0;
-    const canClaimVoice = modalities === undefined || modalities.includes("voice");
-    const voiceCapsApply = caps.voice !== undefined ||
-      Object.keys(caps.speechProviders ?? {}).length > 0;
-    const cappedModalities: readonly Modality[] = [
-      ...(voiceCapsApply && canClaimVoice ? ["voice" as const] : []),
-      ...(caps.chat !== undefined &&
-          (modalities === undefined || modalities.includes("chat"))
-        ? ["chat" as const]
-        : []),
-    ];
-    const active = capsApply && cappedModalities.length > 0 ? await (async () => {
-      await lockCapAdmission(tx);
-      return activeSimulationCandidates(tx, cappedModalities);
-    })() : [];
+    // Serialize admission so separate workers share each run's active count.
+    await lockCapAdmission(tx);
+    const active = await activeSimulationCandidates(tx, modalities ?? ["voice", "chat"]);
     const usage = usageOf(active);
     const admitted: CapCandidate[] = [];
     let after: string | undefined;
@@ -1994,11 +2012,14 @@ export async function claimSimulations(
       const candidates = (await tx
         .select({
           id: simulation.id,
+          runId: simulation.runId,
+          concurrency: run.concurrency,
           modality: simulation.modality,
           parameterValues: simulation.personaParameterValues,
           parameterContract: personaVersion.parameterContract,
         })
         .from(simulation)
+        .innerJoin(run, eq(run.id, simulation.runId))
         .innerJoin(personaVersion, eq(personaVersion.id, simulation.personaVersionId))
         // Queued, **and** its run is ready to be conducted. For every run that
         // mocks nothing the second condition is true by construction; for a run
@@ -2016,11 +2037,7 @@ export async function claimSimulations(
           ),
         )
         .orderBy(asc(simulation.id))
-        .limit(
-          capsApply && cappedModalities.length > 0
-            ? SIMULATION_CLAIM_SCAN_WINDOW
-            : capacity - admitted.length,
-        )
+        .limit(SIMULATION_CLAIM_SCAN_WINDOW)
         .for("update", { of: simulation, skipLocked: true })) as readonly CapCandidate[];
       for (const candidate of candidates) {
         if (admitWithinCaps(candidate, caps, usage)) admitted.push(candidate);
@@ -2028,10 +2045,7 @@ export async function claimSimulations(
       }
       if (
         admitted.length >= capacity ||
-        candidates.length <
-          (capsApply && cappedModalities.length > 0
-            ? SIMULATION_CLAIM_SCAN_WINDOW
-            : capacity - admitted.length)
+        candidates.length < SIMULATION_CLAIM_SCAN_WINDOW
       ) {
         break;
       }

--- a/packages/db/src/schema/runs.ts
+++ b/packages/db/src/schema/runs.ts
@@ -162,6 +162,8 @@ export const run = pgTable(
     mockMetadata: jsonb("mock_metadata"),
     /** Immutable grader selection captured before the initial run insert. */
     gradingPlan: jsonb("grading_plan").$type<FrozenRunGradingPlan>().notNull(),
+    /** Maximum claimed and running simulations across all workers. */
+    concurrency: integer("concurrency").notNull().default(4),
     /** Set at start; the denominator a progress page divides by. */
     expectedSimulationCount: integer("expected_simulation_count").notNull(),
     /**
@@ -178,6 +180,7 @@ export const run = pgTable(
   },
   (table) => [
     prefixCheck("run_id_prefix", table.id, "run"),
+    check("run_concurrency_positive", sql`${table.concurrency} > 0`),
     oneOf("run_status_allowed", table.status, [...RUN_STATUSES]),
     oneOf("run_triggered_via_allowed", table.triggeredVia, [...RUN_TRIGGERS]),
     check(

--- a/packages/db/test/baseline-migration.test.ts
+++ b/packages/db/test/baseline-migration.test.ts
@@ -18,7 +18,10 @@ import {
 } from "./support/database.ts";
 
 const BASELINE = "0000_baseline.sql";
-const CURRENT_MIGRATIONS = [BASELINE];
+const RUN_CONCURRENCY = "0001_run_concurrency.sql";
+const SHIPPED_BASELINE_HASH =
+  "ea57d012e674f136f4ef74930865a8ccfeafaebcf92d7f628ce53e8deddc084a";
+const CURRENT_MIGRATIONS = [BASELINE, RUN_CONCURRENCY];
 let database: EmptyDatabase;
 let store: SingleConnection;
 let directory: string;
@@ -34,10 +37,12 @@ afterEach(async () => {
   await rm(directory, { recursive: true, force: true });
 });
 
-describe("the fresh Postgres baseline", () => {
-  it("installs one baseline and keeps organization data on repeated boot", async () => {
-    expect((await readMigrations()).map((migration) => migration.name)).toEqual(
-      CURRENT_MIGRATIONS,
+describe("the Postgres migration chain", () => {
+  it("keeps the shipped baseline and preserves organization data on repeated boot", async () => {
+    const migrations = await readMigrations();
+    expect(migrations.map((migration) => migration.name)).toEqual(CURRENT_MIGRATIONS);
+    expect(migrations.find((migration) => migration.name === BASELINE)?.hash).toBe(
+      SHIPPED_BASELINE_HASH,
     );
     expect(await runMigrations(database.url)).toEqual({
       applied: CURRENT_MIGRATIONS,
@@ -90,7 +95,7 @@ describe("the fresh Postgres baseline", () => {
 
     expect(await runMigrations(database.url)).toEqual({
       applied: [],
-      alreadyApplied: [BASELINE],
+      alreadyApplied: CURRENT_MIGRATIONS,
     });
     expect((await store.sql(
       "select organization_id, provider, credentials, hint, revision from provider_key",
@@ -107,6 +112,76 @@ describe("the fresh Postgres baseline", () => {
     expect((await store.sql(
       "select is_nullable from information_schema.columns where table_name = 'cloud_billing_account' and column_name = 'stripe_cancel_at'",
     )).rows).toEqual([{ is_nullable: "YES" }]);
+  });
+
+  it("upgrades a database that already has the production baseline", async () => {
+    const baseline = await readFile(
+      path.join(MIGRATIONS_DIRECTORY, BASELINE),
+      "utf8",
+    );
+    await writeFile(path.join(directory, BASELINE), baseline);
+    expect(await runMigrations(database.url, directory)).toEqual({
+      applied: [BASELINE],
+      alreadyApplied: [],
+    });
+    const organizationId = newId("org");
+    await store.sql(
+      "insert into organization (id, name, slug) values ($1, 'Before migration', 'before-migration')",
+      [organizationId],
+    );
+    const runIds = [newId("run"), newId("run")];
+    await store.sql("set session_replication_role = replica");
+    try {
+      for (const [index, modality] of ["voice", "chat"].entries()) {
+        await store.sql(
+          `insert into run
+            (id, organization_id, project_id, suite_id, agent_id, connection_id,
+             status, triggered_via, connection_snapshot, expected_simulation_count,
+             completed_count, failed_count, canceled_count, started_at, finished_at,
+             grading_plan)
+           values ($1, $2, $3, $4, $5, $6, 'completed', 'manual', $7, 1,
+                   1, 0, 0, now(), now(), $8)`,
+          [
+            runIds[index],
+            organizationId,
+            newId("prj"),
+            newId("ste"),
+            newId("agt"),
+            newId("con"),
+            { modality },
+            { capturedAt: "2026-09-10T00:00:00.000Z", groups: [] },
+          ],
+        );
+      }
+    } finally {
+      await store.sql("set session_replication_role = origin");
+    }
+
+    expect(await runMigrations(database.url)).toEqual({
+      applied: [RUN_CONCURRENCY],
+      alreadyApplied: [BASELINE],
+    });
+    expect((await store.sql("select id from organization where id = $1", [organizationId])).rows)
+      .toEqual([{ id: organizationId }]);
+    expect(
+      (
+        await store.sql(`select connection_snapshot->>'modality' as modality, concurrency
+          from run where id = any($1::text[]) order by modality`, [runIds])
+      ).rows,
+    ).toEqual([
+      { modality: "chat", concurrency: 10 },
+      { modality: "voice", concurrency: 4 },
+    ]);
+    expect(
+      (
+        await store.sql(`select column_default, is_nullable
+          from information_schema.columns
+          where table_schema = 'public' and table_name = 'run' and column_name = 'concurrency'`)
+      ).rows,
+    ).toEqual([{ column_default: "4", is_nullable: "NO" }]);
+    expect(
+      (await store.sql("select name from egma_meta.migration order by name")).rows,
+    ).toEqual(CURRENT_MIGRATIONS.map((name) => ({ name })));
   });
 
   it("applies once when API instances boot concurrently", async () => {

--- a/packages/db/test/simulation-concurrency-caps.test.ts
+++ b/packages/db/test/simulation-concurrency-caps.test.ts
@@ -65,10 +65,11 @@ let chatConnectionId: string;
 let personaId: string;
 let suiteId: string;
 
-async function queued(modality: "voice" | "chat", models = OPENAI): Promise<string> {
+async function queued(modality: "voice" | "chat", models = OPENAI, concurrency?: number): Promise<string> {
   await editPersona(auth, personaId, { models });
   const started = await startRun(auth, {
     suiteId,
+    ...(concurrency === undefined ? {} : { concurrency }),
     agentId: modality === "voice" ? voiceAgentId : chatAgentId,
     connectionId: modality === "voice" ? voiceConnectionId : chatConnectionId,
   });
@@ -157,8 +158,8 @@ describe("fleet claim selection", () => {
         [sourceId, ids, ids.map((_, index) => index + 2)],
       );
     };
-    await expand(await queued("voice"));
-    await expand(await queued("chat"));
+    await expand(await queued("voice", OPENAI, 110));
+    await expand(await queued("chat", OPENAI, 110));
     const caps = { voice: 100, chat: 100 } as const;
 
     const filled = await Promise.all([
@@ -358,5 +359,69 @@ describe("fleet claim selection", () => {
 
     expect(demand).toEqual({ active: 1, admissibleQueued: 1 });
     expect(claimed.map((claim) => claim.id)).toEqual([openai]);
+  });
+});
+
+async function queuedRun(modality: "voice" | "chat", concurrency?: number, count = 7) {
+  const suite = await createTestSuite(auth, { name: "Concurrency tests" });
+  for (let index = 0; index < count; index += 1) {
+    await createTest(auth, {
+      suiteId: suite.id, name: `Test ${index}`,
+      scenario: "Book an appointment.", expectedBehaviors: ["Confirms the time"],
+      personaIds: [personaId],
+    });
+  }
+  return startRun(auth, {
+    suiteId: suite.id,
+    agentId: modality === "voice" ? voiceAgentId : chatAgentId,
+    connectionId: modality === "voice" ? voiceConnectionId : chatConnectionId,
+    ...(concurrency === undefined ? {} : { concurrency }),
+  });
+}
+
+describe("per-run concurrency", () => {
+  it.each(["voice", "chat"] as const)("applies the %s default across simultaneous workers and refills freed slots", async (modality) => {
+    const expected = modality === "voice" ? 4 : 10;
+    const run = await queuedRun(modality, undefined, expected + 3);
+    expect(run.concurrency).toBe(expected);
+    if (modality === "voice") {
+      expect(await estimateVoiceSimulationDemand()).toEqual({ active: 0, admissibleQueued: 4 });
+    }
+    const claims = (await Promise.all([
+      claimSimulations({ claimant: "first", capacity: 10 }),
+      claimSimulations({ claimant: "second", capacity: 10 }),
+    ])).flat();
+    expect(claims).toHaveLength(expected);
+    expect(new Set(claims.map((claim) => claim.id)).size).toBe(expected);
+    const claim = claims[0]!;
+    await startSimulation(claim.auth, claim.id, claim.claimedBy);
+    expect(await claimSimulations({ claimant: "blocked", capacity: 10 })).toHaveLength(0);
+    await completeSimulation(claim.auth, claim.id, claim.claimedBy, { endingReason: "persona_concluded" });
+    expect(await claimSimulations({ claimant: "refill", capacity: 10 })).toHaveLength(1);
+  });
+
+  it.each(["voice", "chat"] as const)("admits all seven %s simulations with concurrency 100", async (modality) => {
+    const run = await queuedRun(modality, 100);
+    expect(run.concurrency).toBe(100);
+    expect(run.expectedSimulationCount).toBe(7);
+    expect(await claimSimulations({ claimant: "all-seven", capacity: 50 })).toHaveLength(7);
+  });
+
+  it("keeps run limits independent while respecting deployment caps", async () => {
+    const first = await queuedRun("voice", 1);
+    const second = await queuedRun("voice", 3);
+    const claims = await claimSimulations({ claimant: "shared", capacity: 20, caps: { voice: 3 } });
+    expect(claims).toHaveLength(3);
+    expect(claims.filter((claim) => claim.runId === first.id)).toHaveLength(1);
+    expect(claims.filter((claim) => claim.runId === second.id)).toHaveLength(2);
+    expect(await estimateVoiceSimulationDemand({ caps: { voice: 3 } })).toEqual({ active: 3, admissibleQueued: 0 });
+  });
+
+  it("rejects invalid limits and freezes the chosen limit", async () => {
+    for (const concurrency of [0, -1, 1.5, NaN, Infinity, 2147483648]) {
+      await expect(startRun(auth, { suiteId, agentId: voiceAgentId, connectionId: voiceConnectionId, concurrency })).rejects.toThrow("concurrency");
+    }
+    const run = await queuedRun("voice", 2);
+    await expect(database.sql("update run set concurrency = 3 where id = $1", [run.id])).rejects.toThrow("concurrency");
   });
 });

--- a/packages/platform-api/openapi/platform-api.openapi.json
+++ b/packages/platform-api/openapi/platform-api.openapi.json
@@ -16382,6 +16382,12 @@
                       "additionalProperties": false
                     },
                     "description": "Optional exact list of the suite's test IDs and current version IDs. Each test and version must appear once. The request is refused if the suite membership or any version changed. Omit this field to use the current suite."
+                  },
+                  "concurrency": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 2147483647,
+                    "description": "Maximum active simulations in this run. Defaults to 4 for voice and 10 for chat. Worker and provider limits still apply."
                   }
                 },
                 "required": [
@@ -16512,6 +16518,12 @@
                         }
                       ]
                     },
+                    "concurrency": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 2147483647,
+                      "description": "Maximum active simulations in this run, fixed when the run starts."
+                    },
                     "expectedSimulationCount": {
                       "type": "integer",
                       "description": "Number of test-and-persona combinations captured when the run started."
@@ -16639,6 +16651,7 @@
                     "productLabel",
                     "environment",
                     "agentVersion",
+                    "concurrency",
                     "expectedSimulationCount",
                     "completedCount",
                     "failedCount",
@@ -16976,6 +16989,12 @@
                               }
                             ]
                           },
+                          "concurrency": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 2147483647,
+                            "description": "Maximum active simulations in this run, fixed when the run starts."
+                          },
                           "expectedSimulationCount": {
                             "type": "integer",
                             "description": "Number of test-and-persona combinations captured when the run started."
@@ -17103,6 +17122,7 @@
                           "productLabel",
                           "environment",
                           "agentVersion",
+                          "concurrency",
                           "expectedSimulationCount",
                           "completedCount",
                           "failedCount",
@@ -17361,6 +17381,12 @@
                           "type": "null"
                         }
                       ]
+                    },
+                    "concurrency": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 2147483647,
+                      "description": "Maximum active simulations in this run, fixed when the run starts."
                     },
                     "expectedSimulationCount": {
                       "type": "integer",
@@ -17694,6 +17720,7 @@
                     "productLabel",
                     "environment",
                     "agentVersion",
+                    "concurrency",
                     "expectedSimulationCount",
                     "completedCount",
                     "failedCount",
@@ -18598,6 +18625,12 @@
                         }
                       ]
                     },
+                    "concurrency": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 2147483647,
+                      "description": "Maximum active simulations in this run, fixed when the run starts."
+                    },
                     "expectedSimulationCount": {
                       "type": "integer",
                       "description": "Number of test-and-persona combinations captured when the run started."
@@ -18725,6 +18758,7 @@
                     "productLabel",
                     "environment",
                     "agentVersion",
+                    "concurrency",
                     "expectedSimulationCount",
                     "completedCount",
                     "failedCount",

--- a/packages/platform-api/src/contract/operations/runs.ts
+++ b/packages/platform-api/src/contract/operations/runs.ts
@@ -140,6 +140,12 @@ const runHeaderSchema = {
     productLabel: stringSchema,
     environment: nullable(stringSchema),
     agentVersion: nullable(integerSchema),
+    concurrency: {
+      type: "integer",
+      minimum: 1,
+      maximum: 2147483647,
+      description: "Maximum active simulations in this run, fixed when the run starts.",
+    },
     expectedSimulationCount: {
       ...integerSchema,
       description: "Number of test-and-persona combinations captured when the run started.",
@@ -186,6 +192,7 @@ const runHeaderSchema = {
     "productLabel",
     "environment",
     "agentVersion",
+    "concurrency",
     "expectedSimulationCount",
     "completedCount",
     "failedCount",
@@ -441,6 +448,10 @@ export const runOperations = {
           expectedTestVersions: {
             ...arrayOf(expectedTestVersionSchema),
             description: "Optional exact list of the suite's test IDs and current version IDs. Each test and version must appear once. The request is refused if the suite membership or any version changed. Omit this field to use the current suite.",
+          },
+          concurrency: {
+            type: "integer", minimum: 1, maximum: 2147483647,
+            description: "Maximum active simulations in this run. Defaults to 4 for voice and 10 for chat. Worker and provider limits still apply.",
           },
         },
         required: ["suiteId", "agentId", "connectionId"],

--- a/packages/platform-api/src/generated/sdk.gen.ts
+++ b/packages/platform-api/src/generated/sdk.gen.ts
@@ -1837,6 +1837,7 @@ export const createRun = <ThrowOnError extends boolean = false>(parameters: {
          */
         versionId: string;
     }>;
+    concurrency?: number;
 }, options?: Options<never, ThrowOnError>): RequestResult<CreateRunResponses, CreateRunErrors, ThrowOnError> => {
     const params = buildClientParams([parameters], [{ args: [
                 { in: 'query', key: 'projectId' },
@@ -1844,7 +1845,8 @@ export const createRun = <ThrowOnError extends boolean = false>(parameters: {
                 { in: 'body', key: 'agentId' },
                 { in: 'body', key: 'connectionId' },
                 { in: 'body', key: 'name' },
-                { in: 'body', key: 'expectedTestVersions' }
+                { in: 'body', key: 'expectedTestVersions' },
+                { in: 'body', key: 'concurrency' }
             ] }]);
     return (options?.client ?? client).post<CreateRunResponses, CreateRunErrors, ThrowOnError>({
         security: [{ scheme: 'bearer', type: 'http' }, {

--- a/packages/platform-api/src/generated/types.gen.ts
+++ b/packages/platform-api/src/generated/types.gen.ts
@@ -4758,6 +4758,10 @@ export type ListRunsResponses = {
             environment: string | null;
             agentVersion: number | null;
             /**
+             * Maximum active simulations in this run, fixed when the run starts.
+             */
+            concurrency: number;
+            /**
              * Number of test-and-persona combinations captured when the run started.
              */
             expectedSimulationCount: number;
@@ -4829,6 +4833,10 @@ export type CreateRunData = {
              */
             versionId: string;
         }>;
+        /**
+         * Maximum active simulations in this run. Defaults to 4 for voice and 10 for chat. Worker and provider limits still apply.
+         */
+        concurrency?: number;
     };
     path?: never;
     query?: {
@@ -4902,6 +4910,10 @@ export type CreateRunResponses = {
         productLabel: string;
         environment: string | null;
         agentVersion: number | null;
+        /**
+         * Maximum active simulations in this run, fixed when the run starts.
+         */
+        concurrency: number;
         /**
          * Number of test-and-persona combinations captured when the run started.
          */
@@ -5012,6 +5024,10 @@ export type GetRunResponses = {
         productLabel: string;
         environment: string | null;
         agentVersion: number | null;
+        /**
+         * Maximum active simulations in this run, fixed when the run starts.
+         */
+        concurrency: number;
         /**
          * Number of test-and-persona combinations captured when the run started.
          */
@@ -5332,6 +5348,10 @@ export type CancelRunResponses = {
         productLabel: string;
         environment: string | null;
         agentVersion: number | null;
+        /**
+         * Maximum active simulations in this run, fixed when the run starts.
+         */
+        concurrency: number;
         /**
          * Number of test-and-persona combinations captured when the run started.
          */


### PR DESCRIPTION
Customers can now inspect a run from a local coding agent and limit how many simulations that run executes at once. This lets a run fit the customer's LiveKit worker or speech-provider allowance while Egma's existing platform caps continue to apply.

- Add `egma run get <Run ID>` to collect every simulation and event page into one JSON result, including transcripts, tool calls, metrics, grades, and grade history. Preserve the API's transcript truncation flag and report it in `warnings`; failed reads produce no partial JSON.
- Add `concurrency` to run creation and responses, `--concurrency` to the CLI, and a collapsed **Advanced Settings** section in the run creation sheet. Omission defaults to **4 for voice** and **10 for chat**. Seven simulations with concurrency 100 can all be admitted when capacity permits.
- Store the limit on the run and enforce it across workers, including fleet demand estimates. Claimed and running simulations consume slots; terminal simulations free slots. Platform and speech-provider caps remain enforced.

Validation: workspace build, lint, type checks, focused API/CLI/database contract and lifecycle tests, and a real-browser check of collapsed/expanded settings, default and custom submissions, invalid input, keyboard access, and desktop/mobile dark-mode layouts.

Database: preserves the production-applied `0000_baseline.sql` and adds `0001_run_concurrency.sql`. Existing voice runs are backfilled to 4 and chat runs to 10. The API applies the migration before health checks pass, and the release workflow waits for the exact healthy commit.

Release: **CLI 0.3.7 is required.** The version bump is included so the CLI release workflow can publish it after merge. No LiveKit SDK release is required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791495303&installation_model_id=431960&pr_number=330&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F330&signature=265d34588e2ac2237079778009f9cc0d8ffc23cd6c28e68e817acc81b48d3343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds detailed CLI retrieval for runs and configurable per-run simulation concurrency.
- Adds `egma run get`, which collects all simulation and event pages into one JSON document without emitting partial output on failure.
- Adds validated run concurrency settings to the API, CLI, web interface, database schema, and generated contracts.
- Enforces each run’s concurrency limit across workers while retaining deployment and speech-provider caps.
- Updates documentation and bumps the CLI to version 0.3.7.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no outstanding correctness or repository-rule issues identified.

The run limit is validated and persisted consistently, admission counts claimed and running simulations under serialized locking, terminal simulations release capacity, and run-detail collection guards pagination while withholding partial output after failures.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/db/src/access/runs.ts | Persists modality-aware concurrency defaults and enforces per-run, deployment, and provider limits during serialized admission and demand estimation. |
| apps/cli/src/platform/runs.ts | Adds complete run-detail collection with guarded simulation pagination, event cursors, transcript warnings, and all-or-nothing failure behavior. |
| apps/cli/src/commands/run.ts | Adds the `run get` command and validates concurrency before creating or pushing a run. |
| apps/api/src/routes/runs.ts | Validates concurrency input and includes the persisted limit in public run responses. |
| apps/web/app/projects/[projectId]/runs/create-run-sheet.tsx | Adds an optional, collapsed concurrency control with modality-specific defaults and inline validation. |
| packages/platform-api/src/contract/operations/runs.ts | Extends run request and response contracts with the bounded concurrency field. |
| packages/db/migrations/0000_baseline.sql | Adds the positive, immutable concurrency column to the pre-launch database baseline. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Create run from API, CLI, or web] --> B[Validate optional concurrency]
    B --> C[Choose explicit limit or modality default]
    C --> D[Persist immutable run limit]
    D --> E[Worker requests simulations]
    E --> F[Lock shared admission]
    F --> G[Count claimed and running simulations per run]
    G --> H{Run, deployment, and provider capacity available?}
    H -->|Yes| I[Claim simulation and consume slot]
    H -->|No| J[Leave simulation queued]
    I --> K[Simulation reaches terminal state]
    K --> L[Slot becomes available]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Add run details and per-run concurrency"](https://github.com/egma-ai/egma/commit/9fa6a3d99186a755aa5edc8acb49d5ef42e1462a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61818043)</sub>

<!-- /greptile_comment -->
