### PR TITLE
Release LiveKit startup fixes in SDKs 0.3.3

### DIFF
--- a/fixtures/livekit-dumb-agent/uv.lock
+++ b/fixtures/livekit-dumb-agent/uv.lock
@@ -444,7 +444,7 @@ wheels = [
 
 [[package]]
 name = "egma"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "../../sdks/python" }
 dependencies = [
     { name = "livekit-agents" },

--- a/sdks/livekit-js/package.json
+++ b/sdks/livekit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egma/livekit",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Test and monitor LiveKit Agents JS workers with Egma.",
   "type": "module",
   "license": "MIT",

--- a/sdks/python/package.json
+++ b/sdks/python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egma/sdk-python",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "description": "pnpm's door into the Python package customers install: the real toolchain is uv. See README.md.",
   "scripts": {

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "egma"
-version = "0.3.2"
+version = "0.3.3"
 description = "Test and monitor LiveKit agents with Egma."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "egma"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "livekit-agents" },


### PR DESCRIPTION
Publish the LiveKit startup fixes from #326 as Python `egma` and JavaScript `@egma/livekit` version **0.3.3**. PR #325 had already published 0.3.2 before #326 merged, so its release workflows correctly skipped publication.

This changes only package versions and the Python lock metadata. Both SDK releases are required; merging triggers the existing compatibility and real LiveKit package tests before publication.

Validation: frozen pnpm install, frozen Python SDK and fixture syncs, and 27 release-helper tests passed. All eight PR test jobs and Greptile passed on `456d475db6206a6e9e1c278ed959d8a489fc2f23`; the fixture-lock review thread is fixed and resolved. Version 0.3.3 was confirmed unused in PyPI and npm immediately before merge. Publication will be verified in both registries after merge.
