### PR TITLE
Keep hosted voice workers ready between calls

### DIFF
--- a/.github/deploy_vercel.py
+++ b/.github/deploy_vercel.py
@@ -10,7 +10,6 @@ import time
 import urllib.parse
 import urllib.request
 
-
 TERMINAL_FAILURES = {"ERROR", "CANCELED"}
 
 
@@ -20,7 +19,10 @@ def request(method: str, url: str, token: str, body: dict | None = None) -> dict
         url,
         data=data,
         method=method,
-        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
     )
     with urllib.request.urlopen(call, timeout=30) as response:
         return json.load(response)
@@ -30,11 +32,15 @@ def source_sha(deployment: dict) -> str | None:
     source = deployment.get("gitSource") or {}
     metadata = deployment.get("meta") or {}
     source_value = source.get("sha") if isinstance(source, dict) else None
-    metadata_value = metadata.get("githubCommitSha") if isinstance(metadata, dict) else None
+    metadata_value = (
+        metadata.get("githubCommitSha") if isinstance(metadata, dict) else None
+    )
     return source_value or metadata_value
 
 
-def deploy(token: str, team: str, project: str, repository: str, sha: str, fetch=request) -> str:
+def deploy(
+    token: str, team: str, project: str, repository: str, sha: str, fetch=request
+) -> str:
     project_details = fetch(
         "GET",
         f"https://api.vercel.com/v9/projects/{urllib.parse.quote(project)}?teamId={urllib.parse.quote(team)}",
@@ -50,7 +56,12 @@ def deploy(token: str, team: str, project: str, repository: str, sha: str, fetch
         {
             "name": "egma-web",
             "project": project,
-            "gitSource": {"type": "github", "repoId": int(repository), "ref": sha, "sha": sha},
+            "gitSource": {
+                "type": "github",
+                "repoId": int(repository),
+                "ref": sha,
+                "sha": sha,
+            },
             "target": "production",
         },
     )
@@ -66,7 +77,9 @@ def deploy(token: str, team: str, project: str, repository: str, sha: str, fetch
         state = current.get("readyState")
         if state == "READY":
             if current.get("target") != "production" or source_sha(current) != sha:
-                raise ValueError("Vercel completed a deployment for another target or commit")
+                raise ValueError(
+                    "Vercel completed a deployment for another target or commit"
+                )
             return deployment_id
         if state in TERMINAL_FAILURES:
             raise ValueError(f"Vercel deployment ended in {state}")
@@ -75,17 +88,26 @@ def deploy(token: str, team: str, project: str, repository: str, sha: str, fetch
 
 
 def main() -> int:
-    required = ("VERCEL_TOKEN", "VERCEL_ORG_ID", "VERCEL_PROJECT_ID", "VERCEL_GITHUB_REPO_ID", "GITHUB_SHA")
+    required = (
+        "VERCEL_TOKEN",
+        "VERCEL_ORG_ID",
+        "VERCEL_PROJECT_ID",
+        "VERCEL_GITHUB_REPO_ID",
+        "GITHUB_SHA",
+    )
     missing = [name for name in required if not os.environ.get(name)]
     if missing:
-        print(f"Missing Vercel deployment settings: {' '.join(missing)}", file=sys.stderr)
+        print(
+            f"Missing Vercel deployment settings: {' '.join(missing)}", file=sys.stderr
+        )
         return 2
     try:
         deployment_id = deploy(*(os.environ[name] for name in required))
     except (OSError, TimeoutError, ValueError) as error:
         print(f"Vercel production deployment failed: {error}", file=sys.stderr)
         return 1
-    print(f"Vercel production deployment {deployment_id} is READY for {os.environ['GITHUB_SHA']}.")
+    sha = os.environ["GITHUB_SHA"]
+    print(f"Vercel production deployment {deployment_id} is READY for {sha}.")
     return 0
 
 

--- a/.github/deploy_vercel.py
+++ b/.github/deploy_vercel.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Deploy one reviewed Git commit to Vercel production and wait for it."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.parse
+import urllib.request
+
+
+TERMINAL_FAILURES = {"ERROR", "CANCELED"}
+
+
+def request(method: str, url: str, token: str, body: dict | None = None) -> dict:
+    data = None if body is None else json.dumps(body).encode()
+    call = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(call, timeout=30) as response:
+        return json.load(response)
+
+
+def source_sha(deployment: dict) -> str | None:
+    source = deployment.get("gitSource") or {}
+    metadata = deployment.get("meta") or {}
+    source_value = source.get("sha") if isinstance(source, dict) else None
+    metadata_value = metadata.get("githubCommitSha") if isinstance(metadata, dict) else None
+    return source_value or metadata_value
+
+
+def deploy(token: str, team: str, project: str, repository: str, sha: str, fetch=request) -> str:
+    project_details = fetch(
+        "GET",
+        f"https://api.vercel.com/v9/projects/{urllib.parse.quote(project)}?teamId={urllib.parse.quote(team)}",
+        token,
+    )
+    if project_details.get("id") != project:
+        raise ValueError("Vercel token cannot access the configured project")
+    query = urllib.parse.urlencode({"teamId": team, "forceNew": "1"})
+    created = fetch(
+        "POST",
+        f"https://api.vercel.com/v13/deployments?{query}",
+        token,
+        {
+            "name": "egma-web",
+            "project": project,
+            "gitSource": {"type": "github", "repoId": int(repository), "ref": sha, "sha": sha},
+            "target": "production",
+        },
+    )
+    deployment_id = created.get("id")
+    if not isinstance(deployment_id, str) or not deployment_id:
+        raise ValueError("Vercel did not return a deployment ID")
+    for _ in range(180):
+        current = fetch(
+            "GET",
+            f"https://api.vercel.com/v13/deployments/{deployment_id}?teamId={urllib.parse.quote(team)}",
+            token,
+        )
+        state = current.get("readyState")
+        if state == "READY":
+            if current.get("target") != "production" or source_sha(current) != sha:
+                raise ValueError("Vercel completed a deployment for another target or commit")
+            return deployment_id
+        if state in TERMINAL_FAILURES:
+            raise ValueError(f"Vercel deployment ended in {state}")
+        time.sleep(10)
+    raise TimeoutError("Vercel deployment did not finish within 30 minutes")
+
+
+def main() -> int:
+    required = ("VERCEL_TOKEN", "VERCEL_ORG_ID", "VERCEL_PROJECT_ID", "VERCEL_GITHUB_REPO_ID", "GITHUB_SHA")
+    missing = [name for name in required if not os.environ.get(name)]
+    if missing:
+        print(f"Missing Vercel deployment settings: {' '.join(missing)}", file=sys.stderr)
+        return 2
+    try:
+        deployment_id = deploy(*(os.environ[name] for name in required))
+    except (OSError, TimeoutError, ValueError) as error:
+        print(f"Vercel production deployment failed: {error}", file=sys.stderr)
+        return 1
+    print(f"Vercel production deployment {deployment_id} is READY for {os.environ['GITHUB_SHA']}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/test_deploy_vercel.py
+++ b/.github/test_deploy_vercel.py
@@ -1,0 +1,43 @@
+import importlib.util
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).with_name("deploy_vercel.py")
+SPEC = importlib.util.spec_from_file_location("deploy_vercel", SCRIPT)
+assert SPEC and SPEC.loader
+module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(module)
+
+
+class VercelDeploymentTest(unittest.TestCase):
+    @patch.object(module.time, "sleep")
+    def test_waits_for_exact_production_commit(self, _sleep):
+        calls = []
+        responses = iter([
+            {"id": "project"},
+            {"id": "dpl_1"},
+            {"id": "dpl_1", "readyState": "BUILDING"},
+            {"id": "dpl_1", "readyState": "READY", "target": "production", "gitSource": {"sha": "a" * 40}},
+        ])
+
+        def fetch(*args):
+            calls.append(args)
+            return next(responses)
+
+        self.assertEqual(module.deploy("token", "team", "project", "123", "a" * 40, fetch), "dpl_1")
+        self.assertEqual(calls[0][0], "GET")
+        self.assertEqual(calls[1][3]["gitSource"]["sha"], "a" * 40)
+
+    @patch.object(module.time, "sleep")
+    def test_rejects_failed_or_wrong_commit(self, _sleep):
+        for final, message in [({"readyState": "ERROR"}, "ERROR"), ({"readyState": "READY", "target": "production", "gitSource": {"sha": "b" * 40}}, "another")]:
+            with self.subTest(final=final):
+                responses = iter([{"id": "project"}, {"id": "dpl_1"}, final])
+                with self.assertRaisesRegex(ValueError, message):
+                    module.deploy("token", "team", "project", "123", "a" * 40, lambda *_: next(responses))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/test_deploy_vercel.py
+++ b/.github/test_deploy_vercel.py
@@ -1,8 +1,7 @@
 import importlib.util
-from pathlib import Path
 import unittest
+from pathlib import Path
 from unittest.mock import patch
-
 
 SCRIPT = Path(__file__).with_name("deploy_vercel.py")
 SPEC = importlib.util.spec_from_file_location("deploy_vercel", SCRIPT)
@@ -15,28 +14,54 @@ class VercelDeploymentTest(unittest.TestCase):
     @patch.object(module.time, "sleep")
     def test_waits_for_exact_production_commit(self, _sleep):
         calls = []
-        responses = iter([
-            {"id": "project"},
-            {"id": "dpl_1"},
-            {"id": "dpl_1", "readyState": "BUILDING"},
-            {"id": "dpl_1", "readyState": "READY", "target": "production", "gitSource": {"sha": "a" * 40}},
-        ])
+        responses = iter(
+            [
+                {"id": "project"},
+                {"id": "dpl_1"},
+                {"id": "dpl_1", "readyState": "BUILDING"},
+                {
+                    "id": "dpl_1",
+                    "readyState": "READY",
+                    "target": "production",
+                    "gitSource": {"sha": "a" * 40},
+                },
+            ]
+        )
 
         def fetch(*args):
             calls.append(args)
             return next(responses)
 
-        self.assertEqual(module.deploy("token", "team", "project", "123", "a" * 40, fetch), "dpl_1")
+        self.assertEqual(
+            module.deploy("token", "team", "project", "123", "a" * 40, fetch), "dpl_1"
+        )
         self.assertEqual(calls[0][0], "GET")
         self.assertEqual(calls[1][3]["gitSource"]["sha"], "a" * 40)
 
     @patch.object(module.time, "sleep")
     def test_rejects_failed_or_wrong_commit(self, _sleep):
-        for final, message in [({"readyState": "ERROR"}, "ERROR"), ({"readyState": "READY", "target": "production", "gitSource": {"sha": "b" * 40}}, "another")]:
+        for final, message in [
+            ({"readyState": "ERROR"}, "ERROR"),
+            (
+                {
+                    "readyState": "READY",
+                    "target": "production",
+                    "gitSource": {"sha": "b" * 40},
+                },
+                "another",
+            ),
+        ]:
             with self.subTest(final=final):
                 responses = iter([{"id": "project"}, {"id": "dpl_1"}, final])
                 with self.assertRaisesRegex(ValueError, message):
-                    module.deploy("token", "team", "project", "123", "a" * 40, lambda *_: next(responses))
+                    module.deploy(
+                        "token",
+                        "team",
+                        "project",
+                        "123",
+                        "a" * 40,
+                        lambda *_, responses=responses: next(responses),
+                    )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -461,7 +461,7 @@ jobs:
               docker-compose.yml|docker-compose.managed.yml|.env.example) platform=true ;;
               pnpm-lock.yaml|pnpm-workspace.yaml|package.json|tsconfig.base.json) platform=true ;;
               certificates/*|.github/ecr-image-exists.sh|.github/verify-platform-images.py|.github/workflows/test.yml|.github/workflows/build-platform-images.yml) platform=true ;;
-              apps/web/*|tools/*) web=true ;;
+              apps/web/*|tools/*|.github/deploy_vercel.py) web=true ;;
             esac
           done <<< "$changed"
           echo "platform=$platform" >> "$GITHUB_OUTPUT"
@@ -474,14 +474,26 @@ jobs:
             echo "Nothing here deploys."
           fi
 
+      - name: Mint a short-lived cloud release token
+        id: cloud-token
+        if: steps.decide.outputs.platform == 'true' && env.REPLACE_PRODUCTION == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.EGMA_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.EGMA_RELEASE_APP_PRIVATE_KEY }}
+          owner: egma-ai
+          repositories: egma-cloud
+          permission-actions: read
+          permission-contents: write
+
       - name: Check the platform deployment is configured
         if: steps.decide.outputs.platform == 'true'
         env:
-          CLOUD_RELEASE_TOKEN: ${{ secrets.EGMA_CLOUD_RELEASE_TOKEN }}
+          CLOUD_RELEASE_TOKEN: ${{ steps.cloud-token.outputs.token }}
         run: |
           missing=""
           if [ "$REPLACE_PRODUCTION" = "true" ]; then
-            [ -n "$CLOUD_RELEASE_TOKEN" ] || missing="$missing EGMA_CLOUD_RELEASE_TOKEN"
+            [ -n "$CLOUD_RELEASE_TOKEN" ] || missing="$missing release GitHub App credentials"
             [ -n "$DEPLOYMENT_HEALTH_URL" ] || missing="$missing DEPLOYMENT_HEALTH_URL"
           fi
           if [ -n "$missing" ]; then
@@ -493,10 +505,25 @@ jobs:
               -H "Authorization: Bearer $CLOUD_RELEASE_TOKEN" \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/$CLOUD_REPOSITORY/actions/workflows/infrastructure.yml" >/dev/null || {
-                echo "Configure the cloud workflow and EGMA_CLOUD_RELEASE_TOKEN with egma-cloud Contents:write and Actions:read before deployment." >&2
+                echo "Install the release GitHub App on egma-cloud with Contents:write and Actions:read before deployment." >&2
                 exit 1
               }
           fi
+
+      - name: Check the Vercel deployment is configured
+        if: >-
+          env.REPLACE_PRODUCTION == 'true' &&
+          (steps.decide.outputs.web == 'true' || steps.decide.outputs.platform == 'true')
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+          VERCEL_GITHUB_REPO_ID: ${{ vars.VERCEL_GITHUB_REPO_ID }}
+        run: |
+          set -euo pipefail
+          for name in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID VERCEL_GITHUB_REPO_ID; do
+            [ -n "${!name}" ] || { echo "$name is required for the gated production deployment." >&2; exit 1; }
+          done
 
       - name: Publish the immutable native images
         if: steps.decide.outputs.platform == 'true'
@@ -523,7 +550,7 @@ jobs:
       - name: Ask the cloud repository to deploy this release
         if: steps.decide.outputs.platform == 'true' && env.REPLACE_PRODUCTION == 'true'
         env:
-          CLOUD_RELEASE_TOKEN: ${{ secrets.EGMA_CLOUD_RELEASE_TOKEN }}
+          CLOUD_RELEASE_TOKEN: ${{ steps.cloud-token.outputs.token }}
         run: |
           set -euo pipefail
           started=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -602,7 +629,7 @@ jobs:
               docker-compose.yml|docker-compose.managed.yml|.env.example) deployable=true ;;
               pnpm-lock.yaml|pnpm-workspace.yaml|package.json|tsconfig.base.json) deployable=true ;;
               certificates/*|.github/ecr-image-exists.sh|.github/verify-platform-images.py|.github/workflows/test.yml|.github/workflows/build-platform-images.yml) deployable=true ;;
-              apps/web/*|tools/*) deployable=true ;;
+              apps/web/*|tools/*|.github/deploy_vercel.py) deployable=true ;;
             esac
           done <<< "$(git diff --name-only "${{ github.sha }}" "$head")"
           if [ "$deployable" = "true" ]; then
@@ -613,18 +640,16 @@ jobs:
             echo "fire=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Tell Vercel to ship
+      - name: Deploy this exact commit to Vercel production
         if: >-
           env.REPLACE_PRODUCTION == 'true' &&
           (steps.decide.outputs.platform == 'true' || steps.decide.outputs.web == 'true') &&
           steps.yield.outputs.fire == 'true'
         env:
-          HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+          VERCEL_GITHUB_REPO_ID: ${{ vars.VERCEL_GITHUB_REPO_ID }}
         run: |
           set -euo pipefail
-          if [ -z "$HOOK" ]; then
-            echo "VERCEL_DEPLOY_HOOK_URL is not set, so the web cannot deploy." >&2
-            exit 1
-          fi
-          curl -fsS -X POST "$HOOK" >/dev/null
-          echo "Vercel told to ship the web application."
+          python3 .github/deploy_vercel.py

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -18,6 +18,7 @@ import { platformEvent } from "./platform-log.ts";
 import { buildApi } from "./server.ts";
 import { startRateCardInitialization } from "./rate-card.ts";
 import {
+  createVoiceFleetWake,
   createVoiceFleetReconciler,
   type VoiceFleetReconcileResult,
 } from "./voice-fleet.ts";
@@ -104,27 +105,17 @@ const voiceFleetReadiness =
 let reconcileVoiceFleet:
   | (() => Promise<VoiceFleetReconcileResult>)
   | undefined;
-let voiceWakeRunning = false;
-let voiceWakeRequested = false;
 const wakeVoiceFleet = config.voiceFleet === undefined
   ? undefined
-  : () => {
-      voiceWakeRequested = true;
-      if (voiceWakeRunning) return;
-      voiceWakeRunning = true;
-      void (async () => {
-        try {
-          do {
-            voiceWakeRequested = false;
-            await reconcileVoiceFleet?.();
-          } while (voiceWakeRequested);
-        } catch (err) {
-          app.log.error({ err }, "voice fleet reconciliation failed; the sweep will retry");
-        } finally {
-          voiceWakeRunning = false;
-        }
-      })();
-    };
+  : createVoiceFleetWake({
+      reconcile: () => reconcileVoiceFleet?.(),
+      failed: (err) => {
+        app.log.error(
+          { err },
+          "voice fleet reconciliation failed; the sweep will retry",
+        );
+      },
+    });
 
 const { app } = buildApi({
   config: running,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,3 +1,4 @@
+import { createVoiceFleetReadiness } from "./voice-fleet-readiness.ts";
 import {
   connect,
   connectClickHouse,
@@ -93,23 +94,42 @@ const running: Config = cloudBilling === undefined
 // the claim door and the write that stores a usage record — start reaching it.
 installBillingPlugIn(running.billing);
 
+const voiceFleetReadiness =
+  config.voiceFleet === undefined
+    ? undefined
+    : createVoiceFleetReadiness({
+        taskDefinition: config.voiceFleet.taskDefinition,
+      });
+
 let reconcileVoiceFleet:
   | (() => Promise<VoiceFleetReconcileResult>)
   | undefined;
+let voiceWakeRunning = false;
+let voiceWakeRequested = false;
 const wakeVoiceFleet = config.voiceFleet === undefined
   ? undefined
   : () => {
-      void reconcileVoiceFleet?.().catch((err: unknown) => {
-        app.log.error(
-          { err },
-          "voice fleet reconciliation failed; queued work will retry on the next sweep",
-        );
-      });
+      voiceWakeRequested = true;
+      if (voiceWakeRunning) return;
+      voiceWakeRunning = true;
+      void (async () => {
+        try {
+          do {
+            voiceWakeRequested = false;
+            await reconcileVoiceFleet?.();
+          } while (voiceWakeRequested);
+        } catch (err) {
+          app.log.error({ err }, "voice fleet reconciliation failed; the sweep will retry");
+        } finally {
+          voiceWakeRunning = false;
+        }
+      })();
     };
 
 const { app } = buildApi({
   config: running,
   traceStoreReady: () => traceSchema.state === "ready",
+  ...(voiceFleetReadiness === undefined ? {} : { voiceFleetReadiness }),
   ...(wakeVoiceFleet === undefined ? {} : { wakeVoiceFleet }),
   ...(cloudBilling === undefined ? {} : { billingRoutes: cloudBilling.routes }),
   ...(cloudBilling?.webhookRoutes === undefined
@@ -121,8 +141,15 @@ if (config.voiceFleet !== undefined) {
   // The AWS package is absent from the self-hosted boot path. Merely having
   // ordinary AWS credentials in the environment cannot select this adapter.
   const { awsVoiceFleet } = await import("./voice-fleet-aws.ts");
+  const fleet = awsVoiceFleet(config.voiceFleet);
   const reconciler = createVoiceFleetReconciler({
-    fleet: awsVoiceFleet(config.voiceFleet),
+    fleet: {
+      launchTasks: (request) => fleet.launchTasks(request),
+      listTasks: async () => {
+        const tasks = await fleet.listTasks();
+        return voiceFleetReadiness?.observeTasks(tasks) ?? tasks;
+      },
+    },
     estimateDemand: () => estimateVoiceSimulationDemand({
       caps: config.simulationConcurrencyCaps,
     }),

--- a/apps/api/src/routes/claims.ts
+++ b/apps/api/src/routes/claims.ts
@@ -1,3 +1,4 @@
+import type { VoiceFleetReadiness } from "../voice-fleet-readiness.ts";
 import { setTimeout as sleep } from "node:timers/promises";
 
 import {
@@ -64,6 +65,8 @@ import {
  */
 
 export type ClaimRoutesOptions = {
+  readonly voiceFleetReadiness?: VoiceFleetReadiness | undefined;
+  readonly wakeVoiceFleet?: (() => void) | undefined;
   /** The deployment's service token, from configuration. */
   readonly serviceToken: string;
   /**
@@ -681,6 +684,15 @@ export async function claimRoutes(
   app.post(CLAIMS_PATH, async (request, reply) => {
     const ask = claimAsk((request.body ?? {}) as Body);
     if ("refusal" in ask) return invalid(reply, ask.refusal);
+    const fleet = options.voiceFleetReadiness;
+    const identity = fleet?.identity(((request.body ?? {}) as Body).fleet);
+    if (identity !== undefined) {
+      fleet?.waiting(identity);
+      options.wakeVoiceFleet?.();
+      if (fleet?.shouldRetire(identity)) {
+        return reply.send({ specs: [], retire: true });
+      }
+    }
 
     // A client that hangs up mid-hold should stop being worked for: rows
     // claimed for nobody would sit claimed until the sweep called them
@@ -712,6 +724,9 @@ export async function claimRoutes(
           Math.min(RECHECK_MILLISECONDS, holdDeadline - Date.now()),
         );
         if (gone) break;
+        if (identity !== undefined && fleet?.shouldRetire(identity)) {
+          return reply.send({ specs: [], retire: true });
+        }
         claims = await claimSimulations({
           claimant: ask.claimant,
           capacity: ask.capacity,
@@ -788,6 +803,7 @@ export async function claimRoutes(
       );
 
       const specs: Record<string, unknown>[] = [];
+      let dispatchedVoice = false;
       const claimedAt: Record<string, string> = {};
       // One read of each run, however many of its conversations this batch
       // took. Lives exactly as long as this response.
@@ -985,6 +1001,7 @@ export async function claimRoutes(
           continue;
         }
         specs.push(spec);
+        dispatchedVoice ||= claim.modality === "voice";
         claimedAt[claim.id] = claim.claimedAt.toISOString();
         request.log.info(
           platformEvent(
@@ -998,6 +1015,14 @@ export async function claimRoutes(
         );
       }
 
+      if (identity !== undefined) {
+        if (dispatchedVoice) {
+          fleet?.busy(identity);
+          options.wakeVoiceFleet?.();
+        } else {
+          fleet?.unclaimed(identity);
+        }
+      }
       return await reply.send({ specs, claimed_at: claimedAt });
     } finally {
       // Taken back off rather than left behind: a keep-alive socket outlives

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,3 +1,4 @@
+import type { VoiceFleetReadiness } from "./voice-fleet-readiness.ts";
 import {
   openDrainOwnership,
   ping,
@@ -125,6 +126,7 @@ export type ServerOptions = {
   readonly traceStoreReady?: (() => boolean) | undefined;
   /** Hosted-only wake-up shared by run creation and the standing sweep. */
   readonly wakeVoiceFleet?: (() => void) | undefined;
+  readonly voiceFleetReadiness?: VoiceFleetReadiness | undefined;
   /**
    * The Billing section's reads, on a deployment whose settings selected the
    * cloud adapter. Absent on every other deployment, and absent is the
@@ -337,6 +339,9 @@ export function buildApi(options: ServerOptions): Api {
       ...(config.releaseSha === undefined
         ? {}
         : { releaseSha: config.releaseSha }),
+      ...(options.voiceFleetReadiness === undefined
+        ? {}
+        : { voiceFleet: options.voiceFleetReadiness.snapshot() }),
       role,
       postgres,
       clickhouse,
@@ -495,6 +500,10 @@ export function buildApi(options: ServerOptions): Api {
   // customer — so there is no organization to key a budget on, and a busy
   // run can never eat a customer's request budget from the inside.
   void app.register(claimRoutes, {
+    ...(options.voiceFleetReadiness === undefined
+      ? {}
+      : { voiceFleetReadiness: options.voiceFleetReadiness }),
+    ...(options.wakeVoiceFleet === undefined ? {} : { wakeVoiceFleet: options.wakeVoiceFleet }),
     serviceToken: config.simulatorServiceToken,
     providerCredentials: config.providerCredentials,
     carrierRoute: config.carrierRoute,

--- a/apps/api/src/voice-fleet-aws.ts
+++ b/apps/api/src/voice-fleet-aws.ts
@@ -17,7 +17,7 @@ import type {
 type EcsSender = Pick<ECSClient, "send">;
 
 const MODE_ENVIRONMENT = "EGMA_SIMULATOR_MODE";
-const LIST_STATUSES = ["PENDING", "RUNNING"] as const;
+const LIST_STATUSES = ["RUNNING"] as const;
 const DESCRIBE_BATCH = 100;
 const RUN_BATCH = 10;
 
@@ -88,7 +88,13 @@ export function awsVoiceFleet(
             task.taskArn !== undefined &&
             ["PROVISIONING", "PENDING", "RUNNING"].includes(task.lastStatus ?? "")
           ) {
-            found.push({ id: task.taskArn, mode: modeOf(task) });
+            found.push({
+              id: task.taskArn, mode: modeOf(task),
+              ...(task.taskDefinitionArn === undefined
+                ? {}
+                : { taskDefinition: task.taskDefinitionArn }),
+              ...(task.createdAt === undefined ? {} : { createdAt: task.createdAt.getTime() }),
+            });
           }
         }
       }

--- a/apps/api/src/voice-fleet-readiness.ts
+++ b/apps/api/src/voice-fleet-readiness.ts
@@ -1,0 +1,109 @@
+import type { VoiceFleetTask } from "./voice-fleet.ts";
+
+export type VoiceFleetIdentity = {
+  readonly taskArn: string;
+  readonly taskDefinition: string;
+};
+type Observation = VoiceFleetIdentity & { state: "ready" | "busy"; seenAt: number };
+const READY_FRESH_MILLISECONDS = 40_000;
+const REPLACE_AFTER_MILLISECONDS = 28 * 60_000;
+
+/** Observations expire; ECS remains the source of task existence. */
+export function createVoiceFleetReadiness(options: {
+  taskDefinition: string;
+  standbyTarget?: number;
+  now?: () => number;
+}) {
+  const now = options.now ?? Date.now;
+  const standbyTarget = options.standbyTarget ?? 2;
+  const observations = new Map<string, Observation>();
+  let listed: readonly VoiceFleetTask[] = [];
+  const current = (task: VoiceFleetTask) => task.taskDefinition === options.taskDefinition;
+  const aging = (task: VoiceFleetTask) =>
+    task.createdAt !== undefined &&
+    now() - task.createdAt >= REPLACE_AFTER_MILLISECONDS;
+  const observed = (task: VoiceFleetTask) => {
+    const entry = observations.get(task.id);
+    return entry?.state === "busy" ||
+      (entry !== undefined && now() - entry.seenAt < READY_FRESH_MILLISECONDS)
+      ? entry
+      : undefined;
+  };
+  const ready = (task: VoiceFleetTask) =>
+    task.mode === "standby" &&
+    current(task) &&
+    !aging(task) &&
+    observed(task)?.state === "ready";
+  const snapshot = () => ({
+    taskDefinition: options.taskDefinition,
+    standbyTarget,
+    readyStandbys: listed.filter(ready).length,
+    starting: listed.filter(
+      (task) => current(task) && !aging(task) && observed(task) === undefined,
+    ).length,
+  });
+  return {
+    snapshot,
+    identity(value: unknown): VoiceFleetIdentity | undefined {
+      if (value === null || typeof value !== "object") return undefined;
+      const data = value as Record<string, unknown>;
+      if (
+        typeof data.taskArn !== "string" ||
+        typeof data.taskDefinition !== "string"
+      ) {
+        return undefined;
+      }
+      // Only task identities from this configured account, region and family.
+      const prefix = options.taskDefinition.split(":task-definition/")[0];
+      const family = options.taskDefinition.replace(/:\d+$/u, "");
+      if (
+        !data.taskArn.startsWith(`${prefix}:task/`) ||
+        !data.taskDefinition.startsWith(`${family}:`)
+      ) {
+        return undefined;
+      }
+      return { taskArn: data.taskArn, taskDefinition: data.taskDefinition };
+    },
+    waiting(identity: VoiceFleetIdentity): void {
+      // A duplicate request must not make a task with granted work idle again.
+      if (observations.get(identity.taskArn)?.state === "busy") return;
+      observations.set(identity.taskArn, { ...identity, state: "ready", seenAt: now() });
+    },
+    busy(identity: VoiceFleetIdentity): void {
+      observations.set(identity.taskArn, { ...identity, state: "busy", seenAt: now() });
+    },
+    unclaimed(identity: VoiceFleetIdentity): void {
+      observations.set(identity.taskArn, { ...identity, state: "ready", seenAt: now() });
+    },
+    shouldRetire(identity: VoiceFleetIdentity): boolean {
+      const task = listed.find((item) => item.id === identity.taskArn);
+      return (
+        task !== undefined &&
+        observed(task)?.state !== "busy" &&
+        (!current(task) || aging(task)) &&
+        snapshot().readyStandbys >= standbyTarget
+      );
+    },
+    observeTasks(tasks: readonly VoiceFleetTask[]): readonly VoiceFleetTask[] {
+      listed = tasks;
+      const ids = new Set(tasks.map((task) => task.id));
+      for (const [id, entry] of observations) {
+        if (!ids.has(id) && now() - entry.seenAt > 120_000) {
+          observations.delete(id);
+        }
+      }
+      return tasks.map((task) => {
+        const observation = observed(task);
+        return {
+          ...task,
+          retiring:
+            observation?.state !== "busy" && (!current(task) || aging(task)),
+          ...(observation === undefined
+            ? {}
+            : { readiness: observation.state }),
+        };
+      });
+    },
+  };
+}
+export type VoiceFleetReadiness = ReturnType<typeof createVoiceFleetReadiness>;

--- a/apps/api/src/voice-fleet.ts
+++ b/apps/api/src/voice-fleet.ts
@@ -12,6 +12,10 @@ export type AwsVoiceFleetSettings = {
 export type VoiceFleetTask = {
   readonly id: string;
   readonly mode: VoiceTaskMode;
+  readonly taskDefinition?: string;
+  readonly createdAt?: number;
+  readonly retiring?: boolean;
+  readonly readiness?: "ready" | "busy";
 };
 
 export type VoiceFleetLaunchFailure = {
@@ -153,11 +157,34 @@ export function createVoiceFleetReconciler(
         const tasks = new Map<string, VoiceFleetTask>();
         for (const task of recent) tasks.set(task.id, task);
         for (const task of listed) tasks.set(task.id, task);
+        for (const task of tasks.values()) {
+          if (task.retiring) tasks.delete(task.id);
+        }
+        const retiring = new Set(
+          listed.filter((task) => task.retiring).map((task) => task.id),
+        );
+        recent = recent.filter((task) => !retiring.has(task.id));
+
+        // After an API rollout, old workers may still be conducting calls but
+        // their in-memory busy observations are gone. Reserve enough unknown
+        // old capacity to cover active database work. Known-idle old workers
+        // can still make way for the new ready pool.
+        const knownBusy = listed.filter(
+          (task) => task.readiness === "busy",
+        ).length;
+        const unknownRetiring = listed.filter(
+          (task) => task.retiring && task.readiness === undefined,
+        ).length;
+        const unknownActive = Math.min(
+          unknownRetiring,
+          Math.max(0, demand.active - knownBusy),
+        );
 
         const desiredWork = demand.active + demand.admissibleQueued;
         const desiredTotal = desiredWork + standbyTarget;
         const present = { "one-shot": 0, standby: 0 };
         for (const task of tasks.values()) present[task.mode] += 1;
+        present["one-shot"] += unknownActive;
         const presentTotal = present["one-shot"] + present.standby;
         const missingTotal = Math.max(0, desiredTotal - presentTotal);
         // A standby keeps its launch mode after it claims. Active simulations

--- a/apps/api/src/voice-fleet.ts
+++ b/apps/api/src/voice-fleet.ts
@@ -66,6 +66,34 @@ export type VoiceFleetReconcileResult = {
   readonly skipped: "overlap" | "backoff" | undefined;
 };
 
+/** Coalesce wake-ups while preserving one that arrives during a failed pass. */
+export function createVoiceFleetWake(options: {
+  readonly reconcile: () => Promise<unknown> | undefined;
+  readonly failed: (error: unknown) => void;
+}): () => void {
+  let running = false;
+  let requested = false;
+  return () => {
+    requested = true;
+    if (running) return;
+    running = true;
+    void (async () => {
+      try {
+        do {
+          requested = false;
+          try {
+            await options.reconcile();
+          } catch (error) {
+            options.failed(error);
+          }
+        } while (requested);
+      } finally {
+        running = false;
+      }
+    })();
+  };
+}
+
 type RecentLaunch = VoiceFleetTask & { readonly launchedAt: number };
 
 const DEFAULT_STANDBY_TARGET = 2;

--- a/apps/api/test/claims-routes.test.ts
+++ b/apps/api/test/claims-routes.test.ts
@@ -1,3 +1,4 @@
+import { createVoiceFleetReadiness } from "../src/voice-fleet-readiness.ts";
 import {
   createPersona,
   resolveSimulationStanding,
@@ -1711,4 +1712,49 @@ it("names an unreadable customer key at dispatch and does not fall back to the d
   expect(row?.executionFailure).toContain("OpenAI API key");
   expect(row?.executionFailure).not.toContain("not-a-sealed-credential");
   expect(load).not.toHaveBeenCalled();
+});
+
+
+describe("hosted voice standby claims", () => {
+  const prefix = "arn:aws:ecs:us-east-1:123456789012";
+  const taskDefinition = `${prefix}:task-definition/egma-voice:2`;
+  const fleetIdentity = { taskArn: `${prefix}:task/egma/worker`, taskDefinition };
+
+  it("marks a voice claimant busy and wakes replacement capacity before returning its spec", async () => {
+    const readiness = createVoiceFleetReadiness({ taskDefinition });
+    const wakeVoiceFleet = vi.fn();
+    const { key, connectionId, versionId } = await aRealtimeVoiceCustomerReadyToRun(
+      "claims_ready_standby", { voiceFleetReadiness: readiness, wakeVoiceFleet },
+    );
+    readiness.observeTasks([{ id: fleetIdentity.taskArn, taskDefinition, mode: "standby", createdAt: Date.now() }]);
+    await aQueuedRun(key, connectionId, versionId);
+    wakeVoiceFleet.mockClear();
+    const answered = await claim(api.config.simulatorServiceToken, {
+      claimant: "standby-under-test", capacity: 1, wait_seconds: 0, modalities: ["voice"], fleet: fleetIdentity,
+    });
+    expect(answered.statusCode).toBe(200);
+    expect(answered.body.specs).toHaveLength(1);
+    expect(readiness.snapshot().readyStandbys).toBe(0);
+    expect(wakeVoiceFleet).toHaveBeenCalledTimes(2);
+  });
+
+  it("retires an old idle revision without taking queued work once replacement standbys are ready", async () => {
+    const readiness = createVoiceFleetReadiness({ taskDefinition });
+    const { key, connectionId, versionId } = await aRealtimeVoiceCustomerReadyToRun(
+      "claims_retire_standby", { voiceFleetReadiness: readiness },
+    );
+    const old = { ...fleetIdentity, taskDefinition: `${prefix}:task-definition/egma-voice:1` };
+    const replacements = ["ready-a", "ready-b"].map((id) => ({ taskArn: `${prefix}:task/egma/${id}`, taskDefinition }));
+    readiness.observeTasks([old, ...replacements].map((item) => ({id: item.taskArn, taskDefinition: item.taskDefinition, mode: "standby", createdAt: Date.now()})));
+    replacements.forEach((item) => readiness.waiting(item));
+    const { simulationId } = await aQueuedRun(key, connectionId, versionId);
+    const answered = await claim(api.config.simulatorServiceToken, {
+      claimant: "old-standby", capacity: 1, wait_seconds: 0, modalities: ["voice"], fleet: old,
+    });
+    expect(answered.body).toEqual({ specs: [], retire: true });
+    const fresh = await claim(api.config.simulatorServiceToken, {
+      claimant: "new-standby", capacity: 1, wait_seconds: 0, modalities: ["voice"], fleet: replacements[0],
+    });
+    expect((fresh.body.specs as Record<string, unknown>[])[0]?.simulation_id).toBe(simulationId);
+  });
 });

--- a/apps/api/test/support/api.ts
+++ b/apps/api/test/support/api.ts
@@ -105,6 +105,7 @@ export type TestApiOptions = {
   /** A sweep cadence short enough to observe, for the tests about the sweep. */
   readonly orphanSweepIntervalMilliseconds?: number;
   readonly wakeVoiceFleet?: ServerOptions["wakeVoiceFleet"];
+  readonly voiceFleetReadiness?: ServerOptions["voiceFleetReadiness"];
   /** Where Retell answers. A test stands a Retell-shaped server on loopback. */
   readonly retellReach?: ServerOptions["retellReach"];
   /**
@@ -339,6 +340,9 @@ export async function createApi(
       : undefined;
 
   const { app, identity, drainer } = buildApi({
+    ...(options.voiceFleetReadiness === undefined
+      ? {}
+      : { voiceFleetReadiness: options.voiceFleetReadiness }),
     config,
     drainsPendingEvidence: options.drainsPendingEvidence ?? false,
     ...(options.ingestionShutdownTimeoutMilliseconds === undefined

--- a/apps/api/test/voice-fleet-aws.test.ts
+++ b/apps/api/test/voice-fleet-aws.test.ts
@@ -18,16 +18,15 @@ const settings: AwsVoiceFleetSettings = {
 };
 
 describe("the AWS voice fleet", () => {
-  it("pages pending and running tasks, describes in hundreds, and keeps task identities unique", async () => {
+  it("pages tasks that ECS desires running, including starting tasks, describes in hundreds, and keeps task identities unique", async () => {
     const pending = Array.from({ length: 101 }, (_, index) => `arn:pending:${index}`);
     const send = vi.fn(async (command: unknown) => {
       if (command instanceof ListTasksCommand) {
         const input = command.input;
-        if (input.desiredStatus === "PENDING" && input.nextToken === undefined) {
+        if (input.nextToken === undefined) {
           return { taskArns: pending.slice(0, 100), nextToken: "more" };
         }
-        if (input.desiredStatus === "PENDING") return { taskArns: pending.slice(100) };
-        return { taskArns: [pending[0], "arn:running"] };
+        return { taskArns: [...pending.slice(100), pending[0], "arn:running"] };
       }
       if (command instanceof DescribeTasksCommand) {
         return {
@@ -50,7 +49,7 @@ describe("the AWS voice fleet", () => {
 
     expect(tasks).toHaveLength(101);
     expect(tasks.at(-1)).toEqual({ id: "arn:running", mode: "standby" });
-    expect(send.mock.calls.filter(([command]) => command instanceof ListTasksCommand)).toHaveLength(3);
+    expect(send.mock.calls.filter(([command]) => command instanceof ListTasksCommand)).toHaveLength(2);
     const describes = send.mock.calls.filter(([command]) => command instanceof DescribeTasksCommand);
     expect(describes.map(([command]) => (command as DescribeTasksCommand).input.tasks?.length)).toEqual([100, 2]);
   });

--- a/apps/api/test/voice-fleet-readiness.test.ts
+++ b/apps/api/test/voice-fleet-readiness.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import { createVoiceFleetReadiness } from "../src/voice-fleet-readiness.ts";
+import { createVoiceFleetReconciler, type VoiceFleetTask } from "../src/voice-fleet.ts";
+const prefix = "arn:aws:ecs:us-east-1:123456789012";
+const taskDefinition = `${prefix}:task-definition/egma-voice:2`;
+const identity = (id: string, revision = 2) => ({taskArn: `${prefix}:task/egma/${id}`, taskDefinition: `${prefix}:task-definition/egma-voice:${revision}`});
+const task = (id: string, revision = 2, createdAt = 0): VoiceFleetTask => ({id: identity(id).taskArn, taskDefinition: identity(id, revision).taskDefinition, mode: "standby", createdAt});
+
+describe("voice worker readiness", () => {
+  it("counts observed ready standbys, excluding starting, busy, one-shot, and old revisions", () => {
+    const fleet = createVoiceFleetReadiness({taskDefinition, now: () => 1000});
+    const tasks = [task("ready"), task("starting"), task("busy"), task("old", 1), {...task("one"), mode: "one-shot" as const}];
+    fleet.observeTasks(tasks);
+    for (const id of ["ready", "busy", "one"]) fleet.waiting(identity(id));
+    fleet.waiting(identity("old", 1));
+    fleet.busy(identity("busy"));
+    fleet.waiting(identity("busy"));
+    expect(fleet.snapshot()).toMatchObject({readyStandbys: 1, starting: 1});
+    expect(fleet.shouldRetire(identity("busy"))).toBe(false);
+  });
+  it("warms replacements before expiry and retires old idle workers only after two replacements are ready", () => {
+    let now = 28 * 60_000;
+    const fleet = createVoiceFleetReadiness({taskDefinition, now: () => now});
+    const tasks = [task("aging"), task("old", 1, now), task("new1", 2, now), task("new2", 2, now)];
+    fleet.waiting(identity("aging"));
+    fleet.waiting(identity("old", 1));
+    expect(fleet.observeTasks(tasks).filter((item) => item.retiring)).toHaveLength(2);
+    expect(fleet.shouldRetire(identity("old", 1))).toBe(false);
+    fleet.waiting(identity("new1"));
+    fleet.waiting(identity("new2"));
+    expect(fleet.shouldRetire(identity("old", 1))).toBe(true);
+    expect(fleet.shouldRetire(identity("aging"))).toBe(true);
+    fleet.busy(identity("old", 1));
+    expect(fleet.shouldRetire(identity("old", 1))).toBe(false);
+    now += 41_000;
+    expect(fleet.snapshot().readyStandbys).toBe(0);
+  });
+  it("keeps a readiness report that precedes ECS listing and rejects unrelated identities", () => {
+    const fleet = createVoiceFleetReadiness({taskDefinition, now: () => 1000});
+    fleet.waiting(identity("new"));
+    fleet.observeTasks([]);
+    fleet.observeTasks([task("new")]);
+    expect(fleet.snapshot().readyStandbys).toBe(1);
+    expect(fleet.identity(identity("new"))).toEqual(identity("new"));
+    expect(fleet.identity({...identity("new"), taskDefinition: "unrelated"})).toBeUndefined();
+    expect(fleet.identity({taskArn: 1})).toBeUndefined();
+  });
+  it("replenishes a consumed standby while counting pending launches once", async () => {
+    const observations = createVoiceFleetReadiness({taskDefinition, now: () => 1000});
+    let active = 0;
+    const tasks = [task("a"), task("b")];
+    tasks.forEach((item) => observations.waiting({taskArn: item.id, taskDefinition}));
+    const launchTasks = vi.fn(async ({count, mode}: {count: number; mode: "one-shot" | "standby"}) => ({tasks: Array.from({length:count}, (_, index) => ({id:`new-${index}`, mode})), failures: []}));
+    const reconciler = createVoiceFleetReconciler({
+      fleet: {listTasks: async () => observations.observeTasks(tasks), launchTasks},
+      estimateDemand: async () => ({active, admissibleQueued:0}),
+      log: {info:vi.fn(),warn:vi.fn(),error:vi.fn()}, now: () => 1000,
+    });
+    await reconciler.reconcile();
+    expect(launchTasks).not.toHaveBeenCalled();
+    observations.busy(identity("a")); active = 1;
+    await reconciler.reconcile();
+    expect(launchTasks).toHaveBeenCalledExactlyOnceWith({count:1, mode:"standby"});
+    await reconciler.reconcile();
+    expect(launchTasks).toHaveBeenCalledTimes(1);
+  });
+  it("does not replace active old workers after an API restart loses their observations", async () => {
+    const observations = createVoiceFleetReadiness({taskDefinition, now: () => 1000});
+    const oldWorkers = Array.from({length: 102}, (_, index) => ({
+      ...task(`old-${index}`, 1, 0),
+      mode: index < 100 ? "one-shot" as const : "standby" as const,
+    }));
+    const listed = [...oldWorkers];
+    const launchTasks = vi.fn(async ({count, mode}: {count: number; mode: "one-shot" | "standby"}) => {
+      const launched = Array.from({length: count}, (_, index) => task(`new-${index}`));
+      listed.push(...launched);
+      return {tasks: launched.map((item) => ({...item, mode})), failures: []};
+    });
+    const reconciler = createVoiceFleetReconciler({
+      fleet: {listTasks: async () => observations.observeTasks(listed), launchTasks},
+      estimateDemand: async () => ({active:100, admissibleQueued:0}),
+      log: {info:vi.fn(),warn:vi.fn(),error:vi.fn()}, now: () => 1000,
+    });
+
+    await reconciler.reconcile();
+    await reconciler.reconcile();
+
+    expect(launchTasks).toHaveBeenCalledExactlyOnceWith({count:2, mode:"standby"});
+  });
+});

--- a/apps/api/test/voice-fleet.test.ts
+++ b/apps/api/test/voice-fleet.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  createVoiceFleetWake,
   createVoiceFleetReconciler,
   type VoiceFleet,
   type VoiceFleetTask,
@@ -227,5 +228,37 @@ describe("the voice fleet reconciler", () => {
       { count: 2, mode: "standby" },
       { count: 2, mode: "standby" },
     ]);
+  });
+});
+
+describe("the voice fleet wake-up", () => {
+  it("keeps a wake that arrives while a reconciliation fails", async () => {
+    let rejectFirst!: (error: Error) => void;
+    const first = new Promise<void>((_resolve, reject) => {
+      rejectFirst = reject;
+    });
+    let finishSecond!: () => void;
+    const secondFinished = new Promise<void>((resolve) => {
+      finishSecond = resolve;
+    });
+    let calls = 0;
+    const failures: unknown[] = [];
+    const wake = createVoiceFleetWake({
+      reconcile: () => {
+        calls += 1;
+        if (calls === 1) return first;
+        finishSecond();
+        return Promise.resolve();
+      },
+      failed: (error) => failures.push(error),
+    });
+
+    wake();
+    wake();
+    rejectFirst(new Error("ECS list failed"));
+    await secondFinished;
+
+    expect(calls).toBe(2);
+    expect(failures).toHaveLength(1);
   });
 });

--- a/apps/simulator/src/egma_simulator/client.py
+++ b/apps/simulator/src/egma_simulator/client.py
@@ -82,6 +82,7 @@ class ControlPlaneClient:
         *,
         claim_wait_seconds: float,
         service_token: str | None = None,
+        fleet: dict[str, str] | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         # Sent on every claim as ``wait_seconds`` and enforced locally as the
@@ -102,7 +103,14 @@ class ControlPlaneClient:
         self._headers = (
             {"Authorization": f"Bearer {service_token}"} if service_token else {}
         )
+        self._fleet = fleet
+        self._retire_requested = False
         self._session: aiohttp.ClientSession | None = None
+
+    @property
+    def retire_requested(self) -> bool:
+        """Whether the latest empty claim answer retired this hosted task."""
+        return self._retire_requested
 
     async def __aenter__(self) -> ControlPlaneClient:
         self._session = aiohttp.ClientSession(headers=self._headers)
@@ -125,6 +133,7 @@ class ControlPlaneClient:
         modalities: tuple[str, ...] | None = None,
     ) -> list[ClaimedSpec]:
         """Ask for compatible specs; an empty list is a quiet queue."""
+        self._retire_requested = False
         try:
             async with self._live_session().post(
                 f"{self._base_url}/v1/claims",
@@ -134,6 +143,7 @@ class ControlPlaneClient:
                     "wait_seconds": self._claim_wait_seconds,
                     "contract_versions": [spec_contract_version()],
                     **({} if modalities is None else {"modalities": list(modalities)}),
+                    **({} if self._fleet is None else {"fleet": self._fleet}),
                 },
                 timeout=self._claim_timeout,
             ) as response:
@@ -148,6 +158,12 @@ class ControlPlaneClient:
         specs = body.get("specs") if isinstance(body, dict) else None
         if not isinstance(specs, list):
             raise ClaimFailure(f"claim answer has no specs list: {body!r}")
+        retire = body.get("retire", False)
+        if not isinstance(retire, bool):
+            raise ClaimFailure("claim answer has an invalid retire flag")
+        if retire and specs:
+            raise ClaimFailure("claim answer cannot retire a task while granting work")
+        self._retire_requested = retire
         claimed_at = body.get("claimed_at", {}) if isinstance(body, dict) else {}
         if not isinstance(claimed_at, dict):
             claimed_at = {}

--- a/apps/simulator/src/egma_simulator/fleet.py
+++ b/apps/simulator/src/egma_simulator/fleet.py
@@ -1,0 +1,115 @@
+"""Read the identity of a hosted one-shot simulator from local ECS metadata."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+import aiohttp
+
+METADATA_TIMEOUT_SECONDS = 2.0
+ECS_METADATA_HOST = "169.254.170.2"
+TASK_ARN = re.compile(
+    r"^arn:(?P<partition>[^:]+):ecs:(?P<region>[^:]+):(?P<account>[0-9]{12}):task/.+$"
+)
+FAMILY = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+class FleetMetadataFailure(RuntimeError):
+    """The hosted task could not establish the identity used for retirement."""
+
+
+@dataclass(frozen=True)
+class FleetIdentity:
+    task_arn: str
+    task_definition: str
+
+    def document(self) -> dict[str, str]:
+        return {"taskArn": self.task_arn, "taskDefinition": self.task_definition}
+
+
+async def discover_fleet_identity(metadata_uri: str) -> FleetIdentity:
+    """Fetch one task document from the link-local ECS metadata endpoint."""
+    parsed = urlparse(metadata_uri)
+    try:
+        port = parsed.port
+    except ValueError as error:
+        raise FleetMetadataFailure(
+            "ECS task metadata URI is not the local ECS endpoint"
+        ) from error
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname != ECS_METADATA_HOST
+        or port is not None
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise FleetMetadataFailure(
+            "ECS task metadata URI is not the local ECS endpoint"
+        )
+
+    url = metadata_uri.rstrip("/") + "/task"
+    try:
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=METADATA_TIMEOUT_SECONDS)
+        ) as session:
+            async with session.get(url, allow_redirects=False) as response:
+                if response.status != 200:
+                    raise FleetMetadataFailure(
+                        f"ECS task metadata answered HTTP {response.status}"
+                    )
+                body = await response.json()
+    except FleetMetadataFailure:
+        raise
+    except (aiohttp.ClientError, TimeoutError, ValueError) as error:
+        raise FleetMetadataFailure(
+            f"ECS task metadata could not be read: {type(error).__name__}"
+        ) from error
+
+    return fleet_identity_from_document(body)
+
+
+async def fleet_identity_for(
+    mode: str, metadata_uri: str | None
+) -> FleetIdentity | None:
+    """Discover identity only for hosted processes that claim one voice job."""
+    if mode not in ("one-shot", "standby") or metadata_uri is None:
+        return None
+    return await discover_fleet_identity(metadata_uri)
+
+
+def fleet_identity_from_document(body: object) -> FleetIdentity:
+    """Validate the task identity returned by ECS metadata."""
+    if not isinstance(body, dict):
+        raise FleetMetadataFailure("ECS task metadata was not an object")
+    task_arn = body.get("TaskARN")
+    family = body.get("Family")
+    raw_revision = body.get("Revision")
+    if (
+        isinstance(raw_revision, str)
+        and raw_revision.isascii()
+        and raw_revision.isdigit()
+    ):
+        revision = int(raw_revision)
+    elif isinstance(raw_revision, int) and not isinstance(raw_revision, bool):
+        revision = raw_revision
+    else:
+        revision = None
+    match = TASK_ARN.fullmatch(task_arn) if isinstance(task_arn, str) else None
+    if (
+        match is None
+        or not isinstance(family, str)
+        or FAMILY.fullmatch(family) is None
+        or revision is None
+        or revision < 1
+    ):
+        raise FleetMetadataFailure("ECS task metadata has no valid task identity")
+
+    task_definition = (
+        f"arn:{match['partition']}:ecs:{match['region']}:{match['account']}:"
+        f"task-definition/{family}:{revision}"
+    )
+    return FleetIdentity(task_arn=task_arn, task_definition=task_definition)

--- a/apps/simulator/src/egma_simulator/service.py
+++ b/apps/simulator/src/egma_simulator/service.py
@@ -22,6 +22,7 @@ from .client import ClaimedSpec, ClaimFailure, ControlPlaneClient, HeartbeatFail
 from .config import MediaSettings, SimulatorConfig
 from .contract import ContractViolation
 from .conversation import Conducted, ConversationControls, conduct
+from .fleet import FleetMetadataFailure, fleet_identity_for
 from .model import build_model_client
 from .persona import Persona
 from .pipeline import Assembled, assemble
@@ -569,10 +570,24 @@ class SimulatorService:
         records what a disappearing simulator means.
         """
         config = self._config
+        metadata_uri = os.environ.get("ECS_CONTAINER_METADATA_URI_V4")
+        try:
+            identity = await fleet_identity_for(config.mode, metadata_uri)
+        except FleetMetadataFailure as error:
+            log_event(
+                logger,
+                logging.ERROR,
+                "egma.service.fleet_metadata_failed",
+                "hosted simulator could not read its ECS task identity",
+                attributes={"error.type": type(error).__name__},
+            )
+            raise
+        fleet = None if identity is None else identity.document()
         async with ControlPlaneClient(
             config.control_plane_url,
             claim_wait_seconds=config.claim_wait_seconds,
             service_token=config.service_token,
+            fleet=fleet,
         ) as client:
             executor = AsyncioExecutor(
                 config.capacity,
@@ -679,6 +694,14 @@ class SimulatorService:
                     continue
                 self._last_claim_failure = None
                 self._accept(specs, executor)
+                if client.retire_requested:
+                    log_event(
+                        logger,
+                        logging.INFO,
+                        "egma.service.retired",
+                        "hosted simulator retired before claiming work",
+                    )
+                    return
                 if specs or self._config.mode == "one-shot":
                     return
 

--- a/apps/simulator/tests/test_client_claims.py
+++ b/apps/simulator/tests/test_client_claims.py
@@ -10,7 +10,7 @@ from collections.abc import AsyncIterator
 import pytest
 from aiohttp import web
 
-from egma_simulator.client import ControlPlaneClient
+from egma_simulator.client import ClaimFailure, ControlPlaneClient
 
 
 @pytest.fixture
@@ -81,3 +81,44 @@ async def test_a_claim_can_select_a_modality_and_reads_the_server_claim_time():
     assert bodies[0]["modalities"] == ["voice"]
     assert answer.document == {"simulation_id": "sim-voice"}
     assert answer.claimed_at.isoformat() == "2026-09-08T01:02:03+00:00"
+
+
+async def test_a_hosted_claim_carries_its_exact_fleet_identity(recording_control_plane):
+    base_url, bodies = recording_control_plane
+    fleet = {
+        "taskArn": "arn:aws:ecs:us-east-1:123456789012:task/egma/task-id",
+        "taskDefinition": (
+            "arn:aws:ecs:us-east-1:123456789012:task-definition/egma-voice:7"
+        ),
+    }
+
+    async with ControlPlaneClient(
+        base_url, claim_wait_seconds=7.0, fleet=fleet
+    ) as client:
+        await client.claim("voice-one-shot", 1, ("voice",))
+
+    assert bodies[0]["fleet"] == fleet
+
+
+async def test_retirement_requires_an_empty_claim_answer():
+    answers = iter(({"specs": [], "retire": True}, {"specs": [{}], "retire": True}))
+
+    async def claim(_request: web.Request) -> web.Response:
+        return web.json_response(next(answers))
+
+    app = web.Application()
+    app.router.add_post("/v1/claims", claim)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    try:
+        async with ControlPlaneClient(
+            f"http://127.0.0.1:{runner.addresses[0][1]}", claim_wait_seconds=1
+        ) as client:
+            assert await client.claim("voice-standby", 1) == []
+            assert client.retire_requested
+            with pytest.raises(ClaimFailure, match="cannot retire"):
+                await client.claim("voice-standby", 1)
+    finally:
+        await runner.cleanup()

--- a/apps/simulator/tests/test_fleet.py
+++ b/apps/simulator/tests/test_fleet.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import pytest
+
+from egma_simulator.fleet import (
+    FleetMetadataFailure,
+    discover_fleet_identity,
+    fleet_identity_for,
+    fleet_identity_from_document,
+)
+
+
+def test_ecs_task_document_forms_the_full_task_definition_arn():
+    identity = fleet_identity_from_document(
+        {
+            "TaskARN": (
+                "arn:aws:ecs:us-east-1:123456789012:task/egma-production/task-id"
+            ),
+            "Family": "egma-voice",
+            "Revision": "17",
+        }
+    )
+
+    assert identity.document() == {
+        "taskArn": "arn:aws:ecs:us-east-1:123456789012:task/egma-production/task-id",
+        "taskDefinition": (
+            "arn:aws:ecs:us-east-1:123456789012:task-definition/egma-voice:17"
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        {},
+        {"TaskARN": "not-an-arn", "Family": "egma-voice", "Revision": 1},
+        {
+            "TaskARN": "arn:aws:ecs:us-east-1:123456789012:task/cluster/id",
+            "Family": "bad/family",
+            "Revision": 1,
+        },
+        {
+            "TaskARN": "arn:aws:ecs:us-east-1:123456789012:task/cluster/id",
+            "Family": "egma-voice",
+            "Revision": True,
+        },
+        {
+            "TaskARN": "arn:aws:ecs:us-east-1:123456789012:task/cluster/id",
+            "Family": "egma-voice",
+            "Revision": "1.5",
+        },
+    ],
+)
+def test_malformed_ecs_identity_is_refused(document):
+    with pytest.raises(FleetMetadataFailure, match="valid task identity"):
+        fleet_identity_from_document(document)
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "https://169.254.170.2/v4/task-id",
+        "http://example.com/v4/task-id",
+        "http://169.254.170.2:8080/v4/task-id",
+        "http://169.254.170.2:bad/v4/task-id",
+        "http://169.254.170.2/v4/task-id?redirect=http://example.com",
+    ],
+)
+async def test_metadata_discovery_refuses_every_non_ecs_endpoint(uri):
+    with pytest.raises(FleetMetadataFailure, match="local ECS endpoint"):
+        await discover_fleet_identity(uri)
+
+
+async def test_non_ecs_and_persistent_processes_do_not_read_metadata():
+    assert await fleet_identity_for("one-shot", None) is None
+    assert await fleet_identity_for("standby", None) is None
+    assert await fleet_identity_for("persistent", "http://example.com/not-ecs") is None

--- a/apps/simulator/tests/test_service.py
+++ b/apps/simulator/tests/test_service.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+from dataclasses import replace
 from datetime import UTC, datetime
 
 import pytest
@@ -170,6 +171,43 @@ class RefusingClient:
         if self.attempts >= self._wanted:
             self.enough.set()
         raise ClaimFailure("claim answered 404: Route POST:/v1/claims not found")
+
+
+class RetiringClient:
+    retire_requested = False
+
+    def __init__(self) -> None:
+        self.attempts = 0
+
+    async def claim(
+        self,
+        claimant: str,
+        capacity: int,
+        modalities: tuple[str, ...] | None = None,
+    ) -> list[ClaimedSpec]:
+        del claimant, capacity, modalities
+        self.attempts += 1
+        self.retire_requested = True
+        return []
+
+
+@pytest.mark.parametrize("mode", ["one-shot", "standby"])
+async def test_a_hosted_retirement_answer_exits_without_claiming(
+    tmp_path, mode, caplog
+):
+    caplog.set_level(logging.INFO, logger="egma_simulator.service")
+    service = a_service(tmp_path)
+    service._config = replace(
+        service._config, mode=mode, capacity=1, modalities=("voice",)
+    )
+    client = RetiringClient()
+    executor = RecordingExecutor(capacity=1)
+
+    await service._claim_for_mode(client, executor)
+
+    assert client.attempts == 1
+    assert executor.accepted == []
+    assert "retired before claiming work" in caplog.text
 
 
 async def test_a_claim_failure_that_never_changes_is_said_once_not_forever(


### PR DESCRIPTION
Hosted voice work previously paid the full Fargate startup delay for each run, and a public release could finish without proving the exact Vercel deployment. This change keeps two initialized standby voice tasks ready to claim, refills the pool when one accepts work, retires old or aging idle tasks only after two current replacements are ready, and makes the public release deploy and verify the exact web SHA through the Vercel API.

A hosted simulator reports its ECS task and task-definition identity on each claim. The API records the first waiting claim as readiness, preserves active calls during replacement, and conservatively counts old tasks after an API restart so a lost in-memory busy observation cannot cause a replacement fanout. Self-hosted and persistent chat workers keep their existing behavior.

Validation:
- 59 focused API claim, reconciler, readiness, and AWS adapter tests
- 34 focused simulator client, metadata, service, and process-mode tests
- API production build and test typecheck
- repository lint, simulator Ruff, and diff checks
- 2 Vercel release helper tests

No CLI or SDK release is required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791501904&installation_model_id=431960&pr_number=332&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F332&signature=43d844c4311df25476ae9439f4b6e86132b1b2919e26dab7e82b1c58501b7280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps hosted voice capacity warm between calls and strengthens production web deployment verification.
- Maintains two ready standby ECS voice workers and replenishes capacity when a worker accepts work.
- Tracks worker readiness, busy state, task-definition identity, aging, and safe retirement.
- Preserves active calls while replacing old workers and conservatively handles lost observations after API restarts.
- Reports ECS task identity from hosted simulators and supports server-directed retirement.
- Deploys and verifies the exact production web commit through the Vercel API.
- The final-head wake coalescing change preserves wake requests that arrive during a failed reconciliation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no outstanding correctness or repository-rule issues identified at the final head.

The prior wake-loss issue is fully fixed by retaining wake requests across failed reconciliation passes, and the production startup sequence assigns the reconciler before any route or sweep can invoke it. No accepted new findings remain.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/src/voice-fleet-readiness.ts | Adds readiness, busy-state, aging, revision replacement, and retirement tracking for hosted voice tasks. |
| apps/api/src/voice-fleet.ts | Extends reconciliation for retiring and restart-unknown workers and adds failure-safe wake coalescing. |
| apps/api/src/routes/claims.ts | Records hosted worker readiness and dispatch state while returning retirement instructions only to eligible idle workers. |
| apps/simulator/src/egma_simulator/fleet.py | Validates and derives hosted worker identity from the link-local ECS metadata endpoint. |
| apps/simulator/src/egma_simulator/service.py | Reports fleet identity on claims and exits cleanly when the control plane retires an idle worker. |
| .github/deploy_vercel.py | Deploys the reviewed SHA through Vercel and verifies the resulting production deployment targets that exact commit. |
| .github/workflows/test.yml | Uses short-lived cloud credentials and gates production release on exact Vercel deployment completion. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Worker as Standby voice worker
    participant API as Claims API
    participant Ready as Fleet readiness
    participant Fleet as ECS reconciler
    participant Vercel as Vercel API

    Worker->>API: Claim with ECS task identity
    API->>Ready: Record waiting/ready
    API->>Fleet: Wake reconciliation
    API-->>Worker: Voice work
    API->>Ready: Mark worker busy
    API->>Fleet: Refill standby capacity
    Fleet->>Fleet: Launch replacement standby
    Worker->>API: Later idle claim
    API->>Ready: Check revision and age
    Ready-->>API: Retire only when two replacements are ready
    API-->>Worker: "Empty response with retire=true"

    Note over Vercel: Public release path
    API->>Vercel: Deploy exact reviewed SHA
    Vercel-->>API: Deployment state and source SHA
    API->>API: Accept only READY production deployment for exact SHA
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Meet release helper lint gate"](https://github.com/egma-ai/egma/commit/1acd4ac5e3169bb3adec233ead2e5475263e4e71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61864695)</sub>

<!-- /greptile_comment -->