### PR TITLE
Start Daytona simulator snapshot entrypoint

### DIFF
--- a/apps/api/scripts/create-daytona-snapshot.mjs
+++ b/apps/api/scripts/create-daytona-snapshot.mjs
@@ -1,36 +1,61 @@
 import { writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
 import { Daytona } from "@daytona/sdk";
 
-const sha = process.env.RELEASE_SHA ?? "";
-const image = process.env.SIMULATOR_IMAGE ?? "";
-if (!/^[0-9a-f]{40}$/.test(sha) || !image.endsWith(`:${sha}`)) {
-  throw new Error("RELEASE_SHA and SIMULATOR_IMAGE must name the same exact commit");
+export const SNAPSHOT_ENTRYPOINT = Object.freeze(["egma-simulator"]);
+
+function hasExactEntrypoint(snapshot) {
+  return Array.isArray(snapshot.entrypoint)
+    && snapshot.entrypoint.length === SNAPSHOT_ENTRYPOINT.length
+    && snapshot.entrypoint.every((value, index) => value === SNAPSHOT_ENTRYPOINT[index]);
 }
 
-const daytona = new Daytona({ apiKey: process.env.DAYTONA_API_KEY });
-const name = `egma-simulator-${sha}`;
-let existing;
-for (let page = 1; existing === undefined; page += 1) {
-  const listed = await daytona.snapshot.list({ page, limit: 100 });
-  existing = listed.items.find((snapshot) => snapshot.name === name);
-  if (page >= listed.totalPages) break;
-}
-const snapshot = existing ?? await daytona.snapshot.create(
-  { name, image },
-  { timeout: 900, onLogs: (chunk) => process.stdout.write(chunk) },
-);
-if (snapshot.imageName !== image) {
-  throw new Error(`${name} already names a different simulator image`);
-}
-let active = snapshot;
-if (active.state === "inactive") active = await daytona.snapshot.activate(active);
-const deadline = Date.now() + 15 * 60_000;
-while (active.state !== "active") {
-  if (active.state === "error" || active.state === "build_failed") {
-    throw new Error(`${name} failed: ${active.errorReason ?? active.state}`);
+export async function createOrReuseSnapshot({ daytona, sha, image, onLogs }) {
+  if (!/^[0-9a-f]{40}$/.test(sha) || !image.endsWith(`:${sha}`)) {
+    throw new Error("RELEASE_SHA and SIMULATOR_IMAGE must name the same exact commit");
   }
-  if (Date.now() >= deadline) throw new Error(`${name} did not become active within 15 minutes`);
-  await new Promise((resolve) => setTimeout(resolve, 1_000));
-  active = await daytona.snapshot.get(active.id);
+
+  const name = `egma-simulator-${sha}`;
+  let existing;
+  for (let page = 1; existing === undefined; page += 1) {
+    const listed = await daytona.snapshot.list({ page, limit: 100 });
+    existing = listed.items.find((snapshot) => snapshot.name === name);
+    if (page >= listed.totalPages) break;
+  }
+  const snapshot = existing ?? await daytona.snapshot.create(
+    { name, image, entrypoint: [...SNAPSHOT_ENTRYPOINT] },
+    { timeout: 900, onLogs },
+  );
+  if (snapshot.imageName !== image) {
+    throw new Error(`${name} already names a different simulator image`);
+  }
+  if (!hasExactEntrypoint(snapshot)) {
+    throw new Error(`${name} does not run the required egma-simulator entrypoint`);
+  }
+  let active = snapshot;
+  if (active.state === "inactive") active = await daytona.snapshot.activate(active);
+  const deadline = Date.now() + 15 * 60_000;
+  while (active.state !== "active") {
+    if (active.state === "error" || active.state === "build_failed") {
+      throw new Error(`${name} failed: ${active.errorReason ?? active.state}`);
+    }
+    if (Date.now() >= deadline) throw new Error(`${name} did not become active within 15 minutes`);
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    active = await daytona.snapshot.get(active.id);
+  }
+  return active.id;
 }
-await writeFile("daytona-snapshot-id.txt", `${active.id}\n`, { mode: 0o600 });
+
+async function main() {
+  const id = await createOrReuseSnapshot({
+    daytona: new Daytona({ apiKey: process.env.DAYTONA_API_KEY }),
+    sha: process.env.RELEASE_SHA ?? "",
+    image: process.env.SIMULATOR_IMAGE ?? "",
+    onLogs: (chunk) => process.stdout.write(chunk),
+  });
+  await writeFile("daytona-snapshot-id.txt", `${id}\n`, { mode: 0o600 });
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/apps/api/test/create-daytona-snapshot.test.mjs
+++ b/apps/api/test/create-daytona-snapshot.test.mjs
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createOrReuseSnapshot,
+  SNAPSHOT_ENTRYPOINT,
+} from "../scripts/create-daytona-snapshot.mjs";
+
+const sha = "e259b92bf149e841bee03cb52defcd86c4415fc5";
+const image = `registry.example/egma/simulator:${sha}`;
+const name = `egma-simulator-${sha}`;
+
+function daytona(items) {
+  return {
+    snapshot: {
+      list: vi.fn(async () => ({ items, totalPages: 1 })),
+      create: vi.fn(async (params) => ({
+        id: "created",
+        imageName: params.image,
+        entrypoint: params.entrypoint,
+        state: "active",
+      })),
+      activate: vi.fn(),
+      get: vi.fn(),
+    },
+  };
+}
+
+describe("Daytona snapshot entrypoint", () => {
+  it("sets the simulator entrypoint when it creates a snapshot", async () => {
+    const client = daytona([]);
+
+    await expect(createOrReuseSnapshot({ daytona: client, sha, image })).resolves.toBe("created");
+    expect(client.snapshot.create).toHaveBeenCalledWith(
+      { name, image, entrypoint: [...SNAPSHOT_ENTRYPOINT] },
+      { timeout: 900, onLogs: undefined },
+    );
+  });
+
+  it("reuses a snapshot only when its entrypoint is exact", async () => {
+    const valid = daytona([{
+      id: "existing",
+      name,
+      imageName: image,
+      entrypoint: ["egma-simulator"],
+      state: "active",
+    }]);
+    await expect(createOrReuseSnapshot({ daytona: valid, sha, image })).resolves.toBe("existing");
+    expect(valid.snapshot.create).not.toHaveBeenCalled();
+
+    const invalid = daytona([{
+      id: "broken",
+      name,
+      imageName: image,
+      entrypoint: null,
+      state: "active",
+    }]);
+    await expect(createOrReuseSnapshot({ daytona: invalid, sha, image }))
+      .rejects.toThrow("does not run the required egma-simulator entrypoint");
+  });
+});


### PR DESCRIPTION
The production Daytona snapshot had `entrypoint: null`. Daytona started the sandbox but did not inherit the simulator image's Docker `CMD`, so no `egma-simulator` process claimed the queued voice simulation.

This change passes `egma-simulator` as the explicit Daytona snapshot entrypoint and rejects a reused immutable snapshot unless its image and entrypoint both match the release contract.

Validation:
- `pnpm exec vitest run apps/api/test/create-daytona-snapshot.test.mjs`
- `pnpm exec tsc -p tsconfig.tests.json --noEmit --pretty false`
- `pnpm lint`
- `node --check apps/api/scripts/create-daytona-snapshot.mjs`
- `node --check apps/api/test/create-daytona-snapshot.test.mjs`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791541665&installation_model_id=431960&pr_number=336&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F336&signature=53b80001efbc00c5ced33c6f2d141949536cc04463e02db13878ab536f391d63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR ensures Daytona simulator snapshots explicitly start the simulator process and prevents incompatible immutable snapshots from being reused.
- Adds `egma-simulator` as the snapshot entrypoint.
- Extracts snapshot creation and reuse into a testable helper.
- Validates both image identity and exact entrypoint compatibility before activation.
- Adds focused tests for creation and compatible/incompatible reuse.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, or repository-rule violations identified.

The entrypoint shape matches the Daytona SDK contract, production script invocation still reaches `main`, and reuse validation operates on metadata provided consistently by Daytona snapshot responses.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/scripts/create-daytona-snapshot.mjs | Adds the explicit simulator entrypoint, validates reusable snapshots, and preserves activation and artifact-writing behavior through a testable helper. |
| apps/api/test/create-daytona-snapshot.test.mjs | Verifies that new snapshots receive the required entrypoint and snapshots with missing entrypoint metadata are rejected. |

<sub>Reviews (1): Last reviewed commit: ["Start Daytona simulator snapshot entrypo..."](https://github.com/egma-ai/egma/commit/f8f56c3abe2d344c553d12b54ed23eb7c35fc2eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62047399)</sub>

<!-- /greptile_comment -->