### PR TITLE
Fix Daytona simulator credential transport

### DIFF
--- a/apps/simulator/src/egma_simulator/client.py
+++ b/apps/simulator/src/egma_simulator/client.py
@@ -32,6 +32,8 @@ CLAIM_TIMEOUT_MARGIN_SECONDS = 15.0
 # Everything else answers promptly or is broken.
 BRISK_TIMEOUT_SECONDS = 10.0
 
+SIMULATOR_USER_AGENT = "egma-simulator/0.0.0"
+
 # Room registration is idempotent and must finish before a worker starts.
 # Keep transient retries short and finite, within the simulation watchdog.
 REGISTRATION_ATTEMPTS = 3
@@ -100,14 +102,19 @@ class ControlPlaneClient:
         # carries it" is not a thing to remember three times. No token
         # means no header at all — the workbench asks for nothing, and a
         # bare `Bearer ` would be a worse answer than silence.
-        self._headers = (
-            {"Authorization": f"Bearer {service_token}"} if service_token else {}
-        )
+        self._headers = {"User-Agent": SIMULATOR_USER_AGENT}
+        if service_token:
+            self._headers["Authorization"] = f"Bearer {service_token}"
         self._runtime = runtime
         self._session: aiohttp.ClientSession | None = None
 
     async def __aenter__(self) -> ControlPlaneClient:
-        self._session = aiohttp.ClientSession(headers=self._headers)
+        # Daytona exposes its secret-substituting outbound proxy through the
+        # standard HTTP(S)_PROXY environment variables.
+        self._session = aiohttp.ClientSession(
+            headers=self._headers,
+            trust_env=self._runtime == "daytona",
+        )
         return self
 
     async def __aexit__(self, *exc_info: object) -> None:

--- a/apps/simulator/src/egma_simulator/model.py
+++ b/apps/simulator/src/egma_simulator/model.py
@@ -162,6 +162,7 @@ class OpenAICompatibleModel:
         reasoning_effort: str | None = None,
         timeout_seconds: float = MODEL_TIMEOUT_SECONDS,
         customer_funded: bool = False,
+        use_environment_proxy: bool = False,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._api_key = api_key
@@ -169,6 +170,7 @@ class OpenAICompatibleModel:
         self._model_name = model_name
         self._reasoning_effort = reasoning_effort
         self._timeout = aiohttp.ClientTimeout(total=timeout_seconds)
+        self._use_environment_proxy = use_environment_proxy
         self._session: aiohttp.ClientSession | None = None
 
     @property
@@ -177,7 +179,7 @@ class OpenAICompatibleModel:
 
     def _live_session(self) -> aiohttp.ClientSession:
         if self._session is None:
-            self._session = aiohttp.ClientSession()
+            self._session = aiohttp.ClientSession(trust_env=self._use_environment_proxy)
         return self._session
 
     def _provider_detail(self, value: object) -> str:
@@ -366,4 +368,5 @@ def build_model_client(
         model_name=selected.model,
         reasoning_effort=selected.reasoning_effort,
         customer_funded=selected.funding_receipt is not None,
+        use_environment_proxy=getattr(spec, "runtime", None) is not None,
     )

--- a/apps/simulator/src/egma_simulator/model.py
+++ b/apps/simulator/src/egma_simulator/model.py
@@ -221,9 +221,7 @@ class OpenAICompatibleModel:
         )
         asked: dict[str, Any] = {"model": self._model_name}
         asked.update(
-            (name, value)
-            for name, value in invocation.items()
-            if is_given(value)
+            (name, value) for name, value in invocation.items() if is_given(value)
         )
         if self._reasoning_effort is not None:
             asked["reasoning_effort"] = self._reasoning_effort

--- a/apps/simulator/src/egma_simulator/service.py
+++ b/apps/simulator/src/egma_simulator/service.py
@@ -278,8 +278,11 @@ class RunningSimulation:
                 blobs=self._blobs,
                 # The pinned persona version is the only model and voice
                 # source. The current direct keys arrived on this claim.
-                speech=SpeechProviders.from_models(
-                    self._spec.models, vad=self._config.vad_provider
+                speech=replace(
+                    SpeechProviders.from_models(
+                        self._spec.models, vad=self._config.vad_provider
+                    ),
+                    use_environment_proxy=self._spec.runtime is not None,
                 ),
                 media=MediaSettings.for_simulation(
                     self._config.media, self._spec.platform.carrier

--- a/apps/simulator/src/egma_simulator/speech.py
+++ b/apps/simulator/src/egma_simulator/speech.py
@@ -14,10 +14,12 @@ import logging
 import math
 import struct
 import sys
+import urllib.parse
 from array import array
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass, field
 from functools import cache
+from typing import Any
 
 from pipecat.audio.vad.vad_analyzer import VADAnalyzer, VADParams
 from pipecat.frames.frames import (
@@ -642,8 +644,30 @@ def _cartesia_mouth(
     The voice and speed are the pinned TTS selection's own. This adapter
     neither substitutes nor clamps them.
     """
-    from pipecat.services.cartesia.tts import CartesiaTTSService, GenerationConfig
+    from pipecat.services.cartesia.tts import (
+        CartesiaTTSService as StockCartesiaTTSService,
+    )
+    from pipecat.services.cartesia.tts import GenerationConfig
     from pipecat.services.tts_service import TextAggregationMode
+
+    class CartesiaTTSService(StockCartesiaTTSService):
+        async def _websocket_connect(self, uri: str, **kwargs: Any):
+            parsed = urllib.parse.urlsplit(uri)
+            query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+            safe_uri = urllib.parse.urlunsplit(
+                parsed._replace(
+                    query=urllib.parse.urlencode(
+                        [(name, value) for name, value in query if name != "api_key"]
+                    )
+                )
+            )
+            headers = dict(kwargs.pop("additional_headers", {}) or {})
+            headers["X-API-Key"] = self._api_key
+            return await super()._websocket_connect(
+                safe_uri,
+                additional_headers=headers,
+                **kwargs,
+            )
 
     if not providers.tts_key:
         raise SpeechFault("the cartesia speaking leg was chosen without a key")

--- a/apps/simulator/src/egma_simulator/speech.py
+++ b/apps/simulator/src/egma_simulator/speech.py
@@ -369,6 +369,9 @@ class SpeechProviders:
     stt_customer_funded: bool = False
     tts_customer_funded: bool = False
 
+    use_environment_proxy: bool = False
+    """Whether provider sockets must honor the runtime's proxy settings."""
+
     stt_provider: str | None = None
     tts_provider: str | None = None
     """Who bills for each leg.
@@ -565,6 +568,15 @@ def _ears(
     if not providers.stt_model:
         raise SpeechFault("the deepgram listening leg was chosen without a model")
 
+    if providers.use_environment_proxy:
+        # Deepgram's pinned async client still uses the legacy websockets
+        # connector, which ignores Daytona's HTTPS_PROXY. A Daytona sandbox
+        # runs one claim, so selecting the current connector here is scoped to
+        # that dedicated runtime process.
+        from deepgram.listen.v1 import client as deepgram_listen_client
+
+        deepgram_listen_client.websockets_client_connect = _daytona_deepgram_connect
+
     leg = DeepgramSTTService(
         api_key=providers.stt_key,
         settings=DeepgramSTTService.Settings(model=providers.stt_model),
@@ -587,6 +599,19 @@ def _ears(
         await connection_ready.wait()
 
     return leg, connected
+
+
+def _daytona_deepgram_connect(
+    url: str, extra_headers: dict[str, str] | None = None
+) -> Any:
+    """Open Deepgram through Daytona's proxy with credentials in headers."""
+    from websockets.asyncio.client import connect
+
+    return connect(
+        url,
+        additional_headers=extra_headers,
+        proxy=True,
+    )
 
 
 def _connection_opened_by(leg: FrameProcessor) -> asyncio.Event:

--- a/apps/simulator/src/egma_simulator/speech.py
+++ b/apps/simulator/src/egma_simulator/speech.py
@@ -17,6 +17,7 @@ import sys
 import urllib.parse
 from array import array
 from collections.abc import AsyncGenerator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from functools import cache
 from typing import Any
@@ -601,17 +602,29 @@ def _ears(
     return leg, connected
 
 
-def _daytona_deepgram_connect(
+@asynccontextmanager
+async def _daytona_deepgram_connect(
     url: str, extra_headers: dict[str, str] | None = None
-) -> Any:
+) -> AsyncGenerator[Any, None]:
     """Open Deepgram through Daytona's proxy with credentials in headers."""
+    from deepgram.core.api_error import ApiError
     from websockets.asyncio.client import connect
+    from websockets.exceptions import InvalidStatus
 
-    return connect(
-        url,
-        additional_headers=extra_headers,
-        proxy=True,
-    )
+    try:
+        async with connect(
+            url,
+            additional_headers=extra_headers,
+            proxy=True,
+        ) as protocol:
+            yield protocol
+    except InvalidStatus as fault:
+        if fault.response.status_code not in {401, 403}:
+            raise
+        raise ApiError(
+            status_code=fault.response.status_code,
+            body="Websocket initialized with invalid credentials.",
+        ) from fault
 
 
 def _connection_opened_by(leg: FrameProcessor) -> asyncio.Event:

--- a/apps/simulator/tests/test_client_auth.py
+++ b/apps/simulator/tests/test_client_auth.py
@@ -16,24 +16,31 @@ from egma_simulator.client import ControlPlaneClient
 
 
 @pytest.fixture
-async def listening_control_plane() -> AsyncIterator[tuple[str, list[str | None]]]:
-    """Answers everything agreeably and keeps every ``Authorization`` it saw."""
+async def listening_control_plane() -> AsyncIterator[
+    tuple[str, list[str | None], list[str | None]]
+]:
+    """Answers everything agreeably and keeps the client identity it saw."""
     offered: list[str | None] = []
+    user_agents: list[str | None] = []
+
+    def record(request: web.Request) -> None:
+        offered.append(request.headers.get("Authorization"))
+        user_agents.append(request.headers.get("User-Agent"))
 
     async def claim(request: web.Request) -> web.Response:
-        offered.append(request.headers.get("Authorization"))
+        record(request)
         return web.json_response({"specs": []})
 
     async def heartbeat(request: web.Request) -> web.Response:
-        offered.append(request.headers.get("Authorization"))
+        record(request)
         return web.json_response({"directive": None})
 
     async def report(request: web.Request) -> web.Response:
-        offered.append(request.headers.get("Authorization"))
+        record(request)
         return web.Response(status=204)
 
     async def traces(request: web.Request) -> web.Response:
-        offered.append(request.headers.get("Authorization"))
+        record(request)
         return web.json_response({})
 
     app = web.Application()
@@ -47,7 +54,7 @@ async def listening_control_plane() -> AsyncIterator[tuple[str, list[str | None]
     site = web.TCPSite(runner, "127.0.0.1", 0)
     await site.start()
     try:
-        yield f"http://127.0.0.1:{runner.addresses[0][1]}", offered
+        yield f"http://127.0.0.1:{runner.addresses[0][1]}", offered, user_agents
     finally:
         await runner.cleanup()
 
@@ -59,8 +66,8 @@ async def _make_every_call(client: ControlPlaneClient) -> None:
     await client.spans("sim-1", b'{"resourceSpans":[]}')
 
 
-async def test_a_service_token_rides_every_outbound_call(listening_control_plane):
-    base_url, offered = listening_control_plane
+async def test_client_identity_rides_every_outbound_call(listening_control_plane):
+    base_url, offered, user_agents = listening_control_plane
 
     async with ControlPlaneClient(
         base_url, claim_wait_seconds=1, service_token="egma_service_token_under_test"
@@ -68,16 +75,56 @@ async def test_a_service_token_rides_every_outbound_call(listening_control_plane
         await _make_every_call(client)
 
     assert offered == ["Bearer egma_service_token_under_test"] * 4
+    assert user_agents == ["egma-simulator/0.0.0"] * 4
 
 
 async def test_no_token_means_no_header(listening_control_plane):
     """The workbench asks for nothing, and gets nothing, rather than "Bearer "."""
-    base_url, offered = listening_control_plane
+    base_url, offered, _ = listening_control_plane
 
     async with ControlPlaneClient(base_url, claim_wait_seconds=1) as client:
         await _make_every_call(client)
 
     assert offered == [None] * 4
+
+
+async def test_control_plane_calls_use_the_environment_proxy(monkeypatch):
+    """Daytona's proxy can replace its mounted secret placeholder."""
+    requests: list[tuple[str, str | None]] = []
+
+    async def proxy(request: web.Request) -> web.Response:
+        requests.append((request.raw_path, request.headers.get("Authorization")))
+        return web.json_response({"specs": []})
+
+    app = web.Application()
+    app.router.add_route("*", "/{tail:.*}", proxy)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    proxy_url = f"http://127.0.0.1:{runner.addresses[0][1]}"
+    monkeypatch.setenv("HTTP_PROXY", proxy_url)
+    monkeypatch.setenv("http_proxy", proxy_url)
+    monkeypatch.setenv("NO_PROXY", "")
+    monkeypatch.setenv("no_proxy", "")
+
+    try:
+        async with ControlPlaneClient(
+            "http://control-plane.invalid",
+            claim_wait_seconds=1,
+            service_token="dtn_secret_under_test",
+            runtime="daytona",
+        ) as client:
+            await client.claim("sim-under-test", 1)
+    finally:
+        await runner.cleanup()
+
+    assert requests == [
+        (
+            "http://control-plane.invalid/v1/claims",
+            "Bearer dtn_secret_under_test",
+        )
+    ]
 
 
 # -- And nowhere else --------------------------------------------------------

--- a/apps/simulator/tests/test_model.py
+++ b/apps/simulator/tests/test_model.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from types import SimpleNamespace
 
 import pytest
 from aiohttp import web
@@ -170,6 +171,56 @@ async def test_the_openai_client_sends_the_messages_and_returns_the_reply(
     ]
     assert sent["tool_choice"] == "auto"
     assert model_stub.headers[0]["Authorization"] == "Bearer key-under-test"
+
+
+async def test_the_daytona_model_uses_the_environment_proxy(monkeypatch):
+    requests: list[tuple[str, str | None]] = []
+
+    async def proxy(request: web.Request) -> web.Response:
+        requests.append((request.raw_path, request.headers.get("Authorization")))
+        return web.json_response(
+            {"choices": [{"message": {"role": "assistant", "content": "Hello."}}]}
+        )
+
+    app = web.Application()
+    app.router.add_route("*", "/{tail:.*}", proxy)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    proxy_url = f"http://127.0.0.1:{runner.addresses[0][1]}"
+    monkeypatch.setenv("HTTP_PROXY", proxy_url)
+    monkeypatch.setenv("http_proxy", proxy_url)
+    monkeypatch.setenv("NO_PROXY", "")
+    monkeypatch.setenv("no_proxy", "")
+
+    client = build_model_client(
+        SimpleNamespace(
+            runtime=object(),
+            models=SimpleNamespace(
+                llm=SimpleNamespace(
+                    adapter="openai_chat_completions",
+                    key="dtn_secret_openai_under_test",
+                    model="model-under-test",
+                    reasoning_effort=None,
+                    funding_receipt=None,
+                )
+            ),
+        ),
+        _base_url="http://model.invalid/v1",
+    )
+    try:
+        await client.reply(system_and_history())
+    finally:
+        await client.close()
+        await runner.cleanup()
+
+    assert requests == [
+        (
+            "http://model.invalid/v1/chat/completions",
+            "Bearer dtn_secret_openai_under_test",
+        )
+    ]
 
 
 async def test_the_structured_end_call_is_returned_for_pipecat_to_execute(model_stub):

--- a/apps/simulator/tests/test_quarantine.py
+++ b/apps/simulator/tests/test_quarantine.py
@@ -125,8 +125,11 @@ def test_no_module_imports_anything_from_outside_the_app():
     """Third-party imports are the declared ones; everything else is stdlib."""
     # Distribution names above are not always module names. The OTLP encoder's
     # generated protobuf types live under Google's shared namespace.
+    # Deepgram and websockets are locked by the declared Pipecat Deepgram extra
+    # and used directly only by its Daytona transport shim.
     allowed_modules = {
         "aiohttp",
+        "deepgram",
         "jsonschema",
         "pipecat",
         "loguru",
@@ -136,6 +139,7 @@ def test_no_module_imports_anything_from_outside_the_app():
         "boto3",
         "botocore",
         "opentelemetry",
+        "websockets",
         "google",
     }
     permitted = allowed_modules | set(sys.stdlib_module_names) | {"egma_simulator"}

--- a/apps/simulator/tests/test_streaming_legs.py
+++ b/apps/simulator/tests/test_streaming_legs.py
@@ -80,6 +80,38 @@ def test_cartesia_receives_the_pinned_model_voice_and_speed(
     assert closers == ()
 
 
+async def test_cartesia_tts_sends_its_key_in_a_websocket_header(monkeypatch):
+    from pipecat.services.websocket_service import WebsocketService
+
+    connected: list[tuple[str, dict[str, str]]] = []
+
+    async def connect(_service: object, uri: str, **kwargs: Any) -> object:
+        connected.append((uri, kwargs["additional_headers"]))
+        return object()
+
+    monkeypatch.setattr(WebsocketService, "_websocket_connect", connect)
+    placeholder = "dtn_secret_cartesia_under_test"
+    leg, _, _ = _mouth(
+        SpeechProviders(
+            tts="cartesia",
+            tts_key=placeholder,
+            tts_model="sonic-3.5",
+        ),
+        cartesia_voice(),
+    )
+
+    await leg._websocket_connect(
+        f"wss://api.cartesia.ai/tts/websocket?api_key={placeholder}"
+        "&cartesia_version=2026-03-01"
+    )
+
+    uri, headers = connected[0]
+    assert placeholder not in uri
+    assert "api_key" not in uri
+    assert "cartesia_version=2026-03-01" in uri
+    assert headers == {"X-API-Key": placeholder}
+
+
 @pytest.mark.parametrize(
     ("providers", "reason"),
     [

--- a/apps/simulator/tests/test_streaming_legs.py
+++ b/apps/simulator/tests/test_streaming_legs.py
@@ -13,6 +13,7 @@ from egma_simulator.speech import (
     PersonaVoice,
     SpeechFault,
     SpeechProviders,
+    _daytona_deepgram_connect,
     _ears,
     _mouth,
 )
@@ -154,6 +155,79 @@ def test_cartesia_stt_receives_the_pinned_model(
 
     assert calls[0]["settings"].model == "ink-2"
     assert connected is not None
+
+
+def test_daytona_deepgram_sends_its_key_through_the_environment_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from deepgram.listen.v1 import client as deepgram_listen_client
+    from websockets.asyncio import client as websocket_client
+
+    original_connector = deepgram_listen_client.websockets_client_connect
+    monkeypatch.setattr(
+        deepgram_listen_client,
+        "websockets_client_connect",
+        original_connector,
+    )
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def connect(url: str, **kwargs: Any) -> object:
+        calls.append((url, kwargs))
+        return object()
+
+    monkeypatch.setattr(websocket_client, "connect", connect)
+    _ears(
+        SpeechProviders(
+            stt="deepgram",
+            stt_key="dtn_secret_deepgram_under_test",
+            stt_model="nova-3",
+            use_environment_proxy=True,
+        )
+    )
+
+    assert deepgram_listen_client.websockets_client_connect is (
+        _daytona_deepgram_connect
+    )
+    connector = deepgram_listen_client.websockets_client_connect
+    connector(
+        "wss://api.deepgram.com/v1/listen",
+        extra_headers={
+            "Authorization": "Token dtn_secret_deepgram_under_test",
+        },
+    )
+    assert calls == [
+        (
+            "wss://api.deepgram.com/v1/listen",
+            {
+                "additional_headers": {
+                    "Authorization": "Token dtn_secret_deepgram_under_test",
+                },
+                "proxy": True,
+            },
+        )
+    ]
+
+
+def test_non_daytona_deepgram_keeps_the_sdk_connector(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from deepgram.listen.v1 import client as deepgram_listen_client
+
+    original_connector = deepgram_listen_client.websockets_client_connect
+    monkeypatch.setattr(
+        deepgram_listen_client,
+        "websockets_client_connect",
+        original_connector,
+    )
+    _ears(
+        SpeechProviders(
+            stt="deepgram",
+            stt_key=A_KEY,
+            stt_model="nova-3",
+        )
+    )
+
+    assert deepgram_listen_client.websockets_client_connect is original_connector
 
 
 @pytest.mark.parametrize(

--- a/apps/simulator/tests/test_streaming_legs.py
+++ b/apps/simulator/tests/test_streaming_legs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -157,7 +158,7 @@ def test_cartesia_stt_receives_the_pinned_model(
     assert connected is not None
 
 
-def test_daytona_deepgram_sends_its_key_through_the_environment_proxy(
+async def test_daytona_deepgram_sends_its_key_through_the_environment_proxy(
     monkeypatch: pytest.MonkeyPatch,
 ):
     from deepgram.listen.v1 import client as deepgram_listen_client
@@ -171,9 +172,18 @@ def test_daytona_deepgram_sends_its_key_through_the_environment_proxy(
     )
     calls: list[tuple[str, dict[str, Any]]] = []
 
-    def connect(url: str, **kwargs: Any) -> object:
+    protocol = object()
+
+    class Connected:
+        async def __aenter__(self) -> object:
+            return protocol
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+    def connect(url: str, **kwargs: Any) -> Connected:
         calls.append((url, kwargs))
-        return object()
+        return Connected()
 
     monkeypatch.setattr(websocket_client, "connect", connect)
     _ears(
@@ -189,12 +199,11 @@ def test_daytona_deepgram_sends_its_key_through_the_environment_proxy(
         _daytona_deepgram_connect
     )
     connector = deepgram_listen_client.websockets_client_connect
-    connector(
+    async with connector(
         "wss://api.deepgram.com/v1/listen",
-        extra_headers={
-            "Authorization": "Token dtn_secret_deepgram_under_test",
-        },
-    )
+        extra_headers={"Authorization": "Token dtn_secret_deepgram_under_test"},
+    ) as connected:
+        assert connected is protocol
     assert calls == [
         (
             "wss://api.deepgram.com/v1/listen",
@@ -206,6 +215,37 @@ def test_daytona_deepgram_sends_its_key_through_the_environment_proxy(
             },
         )
     ]
+
+
+async def test_daytona_deepgram_redacts_modern_auth_failure(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from deepgram.core.api_error import ApiError
+    from websockets.asyncio import client as websocket_client
+    from websockets.exceptions import InvalidStatus
+
+    class Rejected:
+        async def __aenter__(self) -> object:
+            raise InvalidStatus(SimpleNamespace(status_code=401))
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+    monkeypatch.setattr(
+        websocket_client, "connect", lambda *_args, **_kwargs: Rejected()
+    )
+    placeholder = "dtn_secret_deepgram_under_test"
+
+    with pytest.raises(ApiError) as caught:
+        async with _daytona_deepgram_connect(
+            "wss://api.deepgram.com/v1/listen",
+            extra_headers={"Authorization": f"Token {placeholder}"},
+        ):
+            pass
+
+    assert caught.value.status_code == 401
+    assert caught.value.headers is None
+    assert placeholder not in str(caught.value)
 
 
 def test_non_daytona_deepgram_keeps_the_sdk_connector(


### PR DESCRIPTION
Daytona starts the simulator with secret placeholders and replaces them through its outbound proxy. Production sandboxes reached `POST /v1/claims` with the service-token placeholder and received 401 because aiohttp ignored the proxy environment.

This change fixes the full Daytona credential path:
- Daytona control-plane and OpenAI model HTTP sessions use the sandbox proxy; other runtimes keep their existing proxy behavior.
- Every control-plane request uses a stable `egma-simulator/0.0.0` user agent, which also avoids Cloudflare rejecting the Python default identity.
- Cartesia TTS WebSocket authentication moves the API key from the URL query to the supported `X-API-Key` header, where Daytona can substitute the placeholder and the key stays out of URLs.
- Deepgram STT uses the proxy-aware WebSocket connector only for Daytona claims, preserving its `Authorization` header so Daytona can substitute the placeholder.

Customer-provided direct keys, OpenAI realtime, non-Daytona workers, and the one-shot claim lifecycle keep their existing behavior.

Focused validation:
- `uv run --frozen pytest tests/test_client_auth.py tests/test_client_claims.py tests/test_client_failures.py tests/test_model.py tests/test_streaming_legs.py -q` (69 passed)
- `uv run --frozen ruff check src/egma_simulator/client.py src/egma_simulator/model.py src/egma_simulator/speech.py tests/test_client_auth.py tests/test_model.py tests/test_streaming_legs.py`
- `uv run --project apps/simulator pytest -q apps/simulator/tests/test_streaming_legs.py apps/simulator/tests/test_execution_timing.py apps/simulator/tests/test_selected_models.py` (39 passed)
- focused Ruff check and format check for the changed simulator files
- `git diff --check`











<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR repairs credential transport for Daytona-hosted simulations while preserving existing behavior in other runtimes.
- Enables environment-proxy handling for Daytona control-plane, model, and speech-provider connections.
- Adds a stable simulator user agent to control-plane requests.
- Moves Cartesia WebSocket credentials from the URL into the `X-API-Key` header.
- Routes Daytona Deepgram WebSockets through a proxy-aware connector while preserving authorization headers.
- Updates focused tests, including the import quarantine for the already-declared Deepgram transport modules.

<h3>Confidence Score: 5/5</h3>

The exact reviewed head appears safe to merge, with no actionable issue introduced by the latest quarantine update or the complete credential-transport change.

The latest commit only permits imports for Deepgram and WebSockets modules that are already supplied by the declared Pipecat Deepgram extra and pinned in the simulator lockfile. The full change consistently scopes environment-proxy behavior to managed runtimes, keeps provider credentials in substitutable headers, and preserves non-Daytona behavior.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/simulator/src/egma_simulator/client.py | Enables Daytona environment-proxy use for control-plane requests and supplies a stable user agent. |
| apps/simulator/src/egma_simulator/model.py | Makes OpenAI-compatible model sessions proxy-aware when running under a managed runtime. |
| apps/simulator/src/egma_simulator/service.py | Propagates managed-runtime proxy requirements into speech-provider configuration. |
| apps/simulator/src/egma_simulator/speech.py | Adds proxy-aware Deepgram transport and moves Cartesia authentication from URL parameters to a header. |
| apps/simulator/tests/test_quarantine.py | Allows the Deepgram and WebSockets modules supplied and pinned through the declared Pipecat Deepgram dependency. |
| apps/simulator/tests/test_streaming_legs.py | Verifies provider credential placement, proxy transport, error redaction, and non-Daytona behavior. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    S[Daytona simulator] -->|HTTP via environment proxy| C[Control plane]
    S -->|HTTP via environment proxy| O[OpenAI-compatible model]
    S -->|WebSocket via proxy<br/>Authorization header| D[Deepgram STT]
    S -->|WebSocket via proxy<br/>X-API-Key header| T[Cartesia TTS]
    P[Daytona outbound proxy] -. substitutes secret placeholders .-> C
    P -. substitutes secret placeholders .-> O
    P -. substitutes secret placeholders .-> D
    P -. substitutes secret placeholders .-> T
```
</details>

<sub>Reviews (6): Last reviewed commit: ["Allow pinned Deepgram transport imports"](https://github.com/egma-ai/egma/commit/033496c463905805aede5815b67f3e490696ad39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62064902)</sub>

<!-- /greptile_comment -->