### PR TITLE
Allow slower Daytona OpenAI handshakes

### DIFF
--- a/apps/simulator/src/egma_simulator/speech.py
+++ b/apps/simulator/src/egma_simulator/speech.py
@@ -72,6 +72,12 @@ CARTESIA_SPEED_RANGE = (0.6, 1.5)
 A speed outside this range is refused. The adapter never changes the value
 selected by the pinned TTS model."""
 
+OPENAI_REALTIME_PROXY_OPEN_SECONDS = 30.0
+"""How long a proxied OpenAI Realtime socket may take to open."""
+
+OPENAI_REALTIME_PROXY_READY_SECONDS = 45.0
+"""How long proxied OpenAI Realtime may take to become ready."""
+
 LISTENING_READY_SECONDS = 15.0
 """How long a listening leg may take to become able to hear.
 
@@ -437,6 +443,9 @@ class SpeechLegs:
     voice: PersonaVoice
     """The exact voice pinned by this work order's TTS selection."""
 
+    listening_ready_seconds: float = LISTENING_READY_SECONDS
+    """How long the listening leg may take to become ready."""
+
     listening: Callable[[], Awaitable[None]] | None = None
     """Waits until the listening leg can hear, for a leg that connects."""
 
@@ -448,11 +457,13 @@ class SpeechLegs:
         if self.listening is None:
             return
         try:
-            await asyncio.wait_for(self.listening(), timeout=LISTENING_READY_SECONDS)
+            await asyncio.wait_for(
+                self.listening(), timeout=self.listening_ready_seconds
+            )
         except TimeoutError as never_ready:
             raise SpeechFault(
                 "the listening leg did not connect within "
-                f"{LISTENING_READY_SECONDS:.0f}s; nothing said would have been "
+                f"{self.listening_ready_seconds:.0f}s; nothing said would have been "
                 "heard"
             ) from never_ready
 
@@ -480,6 +491,11 @@ def build_legs(providers: SpeechProviders, *, voice: PersonaVoice) -> SpeechLegs
         stt=listening_leg,
         tts=speaking,
         voice=spoken_with,
+        listening_ready_seconds=(
+            OPENAI_REALTIME_PROXY_READY_SECONDS
+            if providers.stt == "openai_realtime" and providers.use_environment_proxy
+            else LISTENING_READY_SECONDS
+        ),
         listening=listening,
         closers=closers,
     )
@@ -818,6 +834,12 @@ def _openai_realtime_ears(
 
     class OpenAIRealtimeSTTService(PipecatOpenAIRealtimeSTTService):
         """Pipecat's realtime service with the live model's current wire shape."""
+
+        async def _websocket_connect(self, uri: str, **kwargs: Any) -> Any:
+            if providers.use_environment_proxy:
+                kwargs.setdefault("proxy", True)
+                kwargs.setdefault("open_timeout", OPENAI_REALTIME_PROXY_OPEN_SECONDS)
+            return await super()._websocket_connect(uri, **kwargs)
 
         async def _handle_transcription_completed(self, evt: dict) -> None:
             """Keep what the provider says the transcription cost.

--- a/apps/simulator/tests/test_streaming_legs.py
+++ b/apps/simulator/tests/test_streaming_legs.py
@@ -11,12 +11,16 @@ import pytest
 from egma_simulator.contract import spec_validator
 from egma_simulator.speech import (
     CARTESIA_SPEED_RANGE,
+    LISTENING_READY_SECONDS,
+    OPENAI_REALTIME_PROXY_OPEN_SECONDS,
+    OPENAI_REALTIME_PROXY_READY_SECONDS,
     PersonaVoice,
     SpeechFault,
     SpeechProviders,
     _daytona_deepgram_connect,
     _ears,
     _mouth,
+    build_legs,
 )
 
 A_KEY = "sk-only-this-test-holds-this-one"
@@ -349,6 +353,60 @@ def test_openai_realtime_receives_the_pinned_model(
     assert calls[0]["settings"].model == "gpt-live-transcribe"
     assert calls[0]["turn_detection"] is False
     assert connected is not None
+
+
+async def test_proxied_openai_realtime_has_a_longer_opening_deadline(monkeypatch):
+    from pipecat.services.websocket_service import WebsocketService
+
+    calls: list[dict[str, Any]] = []
+
+    async def connect(_service: object, _uri: str, **kwargs: Any) -> object:
+        calls.append(kwargs)
+        return object()
+
+    monkeypatch.setattr(WebsocketService, "_websocket_connect", connect)
+    legs = build_legs(
+        SpeechProviders(
+            stt="openai_realtime",
+            stt_key="dtn_secret_openai_under_test",
+            stt_model="gpt-live-transcribe",
+            use_environment_proxy=True,
+        ),
+        voice=PersonaVoice(voice_id="scripted", provider=None, speed=None),
+    )
+
+    await legs.stt._websocket_connect("wss://api.openai.com/v1/realtime")
+
+    assert calls == [
+        {"proxy": True, "open_timeout": OPENAI_REALTIME_PROXY_OPEN_SECONDS}
+    ]
+    assert legs.listening_ready_seconds == OPENAI_REALTIME_PROXY_READY_SECONDS
+    assert OPENAI_REALTIME_PROXY_READY_SECONDS > OPENAI_REALTIME_PROXY_OPEN_SECONDS
+
+
+async def test_direct_openai_realtime_keeps_the_library_opening_deadline(monkeypatch):
+    from pipecat.services.websocket_service import WebsocketService
+
+    calls: list[dict[str, Any]] = []
+
+    async def connect(_service: object, _uri: str, **kwargs: Any) -> object:
+        calls.append(kwargs)
+        return object()
+
+    monkeypatch.setattr(WebsocketService, "_websocket_connect", connect)
+    legs = build_legs(
+        SpeechProviders(
+            stt="openai_realtime",
+            stt_key=A_KEY,
+            stt_model="gpt-live-transcribe",
+        ),
+        voice=PersonaVoice(voice_id="scripted", provider=None, speed=None),
+    )
+
+    await legs.stt._websocket_connect("wss://api.openai.com/v1/realtime")
+
+    assert calls == [{}]
+    assert legs.listening_ready_seconds == LISTENING_READY_SECONDS
 
 
 async def test_live_transcribe_uses_the_plural_languages_request():


### PR DESCRIPTION
A production Daytona voice smoke reached the correct sandbox and claimed its simulation, but OpenAI Realtime STT failed 10.635 seconds after startup with `timed out during opening handshake`. Pipecat leaves `websockets` at its implicit 10-second opening deadline.

This change gives only proxied OpenAI Realtime connections a 30-second WebSocket opening deadline and a 45-second total listening-readiness deadline. Direct OpenAI connections and every other speech provider keep their current limits. There is no retry loop.

A disposable Daytona probe confirmed the underlying path is valid: authenticated OpenAI HTTPS returned 200 in 3.43 seconds and the proxied Realtime WebSocket opened in 4.83 seconds. The probe sandbox was deleted. Production failure evidence is preserved in [run `run_01M2330A0QE8HBAV0EWJ89FFT8`](https://app.egma.ai/projects/prj_01M01GBC88E4PVM6MYHYJRYNDY/runs/run_01M2330A0QE8HBAV0EWJ89FFT8).

Focused validation:
- streaming-leg timeout tests: 7 passed, 15 deselected
- voice listening/cancel test: 1 passed, 51 deselected
- Ruff check and format check on both changed files
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791550953&installation_model_id=431960&pr_number=338&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F338&signature=9bede1ad36aacc632732a2a99effcdf95f1a05c792ec495e4acdda9d5632abc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR narrowly extends startup deadlines for proxied OpenAI Realtime speech-to-text connections.
- Adds a 30-second WebSocket opening timeout for the Daytona environment-proxy path.
- Extends that path’s overall listening-readiness deadline to 45 seconds.
- Preserves existing deadlines for direct OpenAI connections and all other providers.
- Adds focused tests covering proxied and direct OpenAI Realtime behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete correctness, security, or repository-rule issues identified.

The longer deadlines are confined to the intended proxied OpenAI Realtime path, existing providers retain their behavior, and the changed timeout selection is covered by focused tests.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/simulator/src/egma_simulator/speech.py | Adds provider-specific WebSocket opening and readiness deadlines while preserving existing defaults elsewhere. |
| apps/simulator/tests/test_streaming_legs.py | Verifies timeout forwarding and deadline selection for proxied and direct OpenAI Realtime connections. |

<sub>Reviews (1): Last reviewed commit: ["fix(simulator): allow proxied OpenAI web..."](https://github.com/egma-ai/egma/commit/a5dfad71e7dd858a9fbf68c3dc47366532074213) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62097547)</sub>

<!-- /greptile_comment -->