### PR TITLE
Fix billing page and Stripe Checkout presentation

### DIFF
--- a/apps/web/app/projects/[projectId]/settings/billing/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/billing/page.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { Suspense, useCallback, useEffect, useState } from "react";
-import { useParams, useSearchParams } from "next/navigation";
-import { Button } from "@/components/ui/button";
+import { Suspense, useCallback, useEffect, useRef, useState } from "react";
+import {
+  useParams,
+  usePathname,
+  useRouter,
+  useSearchParams,
+} from "next/navigation";
+import { toast } from "sonner";
 import { Card } from "@/components/ui/card";
 import type { Answer } from "@/lib/api";
 import { readBillingAccount, type BillingAccount } from "@/lib/billing";
@@ -25,13 +30,16 @@ export default function UsageAndBillingPage() {
 }
 
 function UsageAndBillingBody({ projectId }: { readonly projectId: string }) {
+  const pathname = usePathname();
+  const router = useRouter();
   const search = useSearchParams();
-  const returned = search.has("credit") || search.has("plan");
+  const returnedPlan = search.get("plan");
+  const returnedCredit = search.get("credit");
+  const handledReturn = useRef<string | null>(null);
   const [billing, setBilling] = useState<
     Answer<BillingAccount> | null | undefined
   >();
   const [usage, setUsage] = useState<Answer<PeriodUsage> | null>(null);
-  const [actionBusy, setActionBusy] = useState(false);
   const [revision, setRevision] = useState(0);
   const refresh = useCallback(() => setRevision((value) => value + 1), []);
 
@@ -66,79 +74,96 @@ function UsageAndBillingBody({ projectId }: { readonly projectId: string }) {
     billing !== undefined && billing !== null && billing.status !== "ready"
       ? billing
       : null;
-  const reading = billing === undefined || (failure === null && usage === null);
-  const returnMessage = reading
-    ? "Checking your current billing details…"
-    : failure !== null
-      ? "Your billing details could not be checked. Refresh to try again."
-      : search.get("plan") === "pro" && account?.plan.code === "pro"
-        ? "Your organization is on Pro."
-        : search.get("plan") === "pro"
-          ? "Pro is not active yet. Refresh after checkout finishes."
-          : search.get("credit") === "bought"
-            ? "Check billing history for your payment. If it has not appeared yet, refresh in a moment."
-            : "Checkout closed. Your current billing details are shown below.";
+  useEffect(() => {
+    if (
+      billing === undefined ||
+      (returnedPlan === null && returnedCredit === null)
+    ) {
+      return;
+    }
+
+    const returnKey = `${returnedPlan ?? ""}\u0000${returnedCredit ?? ""}`;
+    if (handledReturn.current === returnKey) return;
+    handledReturn.current = returnKey;
+
+    const action = { label: "Check again", onClick: refresh };
+    if (failure !== null) {
+      toast.error("Your billing details could not be checked.", { action });
+    } else if (returnedPlan === "pro" && account?.plan.code === "pro") {
+      toast.success("Your organization is on Pro.", { action });
+    } else if (returnedPlan === "pro") {
+      toast.warning("Pro is not active yet. Refresh after checkout finishes.", {
+        action,
+      });
+    } else if (returnedCredit === "bought") {
+      toast.info(
+        "Check billing history for your payment. If it has not appeared yet, refresh in a moment.",
+        { action },
+      );
+    } else {
+      toast.info(
+        "Checkout closed. Your current billing details are shown below.",
+        { action },
+      );
+    }
+
+    const nextSearch = new URLSearchParams(search.toString());
+    nextSearch.delete("plan");
+    nextSearch.delete("credit");
+    router.replace(
+      nextSearch.size === 0 ? pathname : `${pathname}?${nextSearch.toString()}`,
+    );
+  }, [
+    account?.plan.code,
+    billing,
+    failure,
+    pathname,
+    refresh,
+    returnedCredit,
+    returnedPlan,
+    router,
+    search,
+  ]);
 
   return (
     <>
-          {returned ? (
-            <div className="flex items-center gap-3">
-              <p className="m-0 text-sm text-muted-foreground" role="status">
-                {returnMessage}
+      {billing === undefined ? (
+        <Loading what="usage and billing" />
+      ) : failure !== null ? (
+        <Failure
+          title="Billing details are unavailable."
+          message={
+            failure.status === "signed-out"
+              ? "Sign in again to read usage and billing."
+              : failure.refusal.message
+          }
+          onRetry={refresh}
+        />
+      ) : (
+        <>
+          {account === null ? (
+            <Card>
+              <p className="m-0 text-base">
+                Billing is not enabled on this deployment.
               </p>
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={refresh}
-                disabled={reading || actionBusy}
-              >
-                Check again
-              </Button>
-            </div>
-          ) : null}
-          {billing === undefined ? (
-            <Loading what="usage and billing" />
-          ) : failure !== null ? (
-            <Failure
-              title="Billing details are unavailable."
-              message={
-                failure.status === "signed-out"
-                  ? "Sign in again to read usage and billing."
-                  : failure.refusal.message
-              }
-              onRetry={refresh}
-            />
+              <p className="m-0 text-sm text-muted-foreground">
+                Usage and provider costs are available below. There is no plan
+                or inference balance.
+              </p>
+            </Card>
           ) : (
-            <>
-              {account === null ? (
-                <Card>
-                  <p className="m-0 text-base">
-                    Billing is not enabled on this deployment.
-                  </p>
-                  <p className="m-0 text-sm text-muted-foreground">
-                    Usage and provider costs are available below. There is no
-                    plan or inference balance.
-                  </p>
-                </Card>
-              ) : (
-                <BillingAccountSections
-                  account={account}
-                  onRefresh={refresh}
-                  onBusyChange={setActionBusy}
-                />
-              )}
-              <UsageAllowances
-                account={account}
-                usage={usage}
-                onRetry={refresh}
-              />
-              <ProviderUsage usage={usage} onRetry={refresh} />
-              {account === null ? null : (
-                <BillingHistory key={revision} initial={account.ledger} />
-              )}
-            </>
+            <BillingAccountSections account={account} onRefresh={refresh} />
           )}
+          <UsageAllowances account={account} usage={usage} onRetry={refresh} />
+          <ProviderUsage usage={usage} onRetry={refresh} />
+          {account === null ? null : (
+            <BillingHistory
+              key={JSON.stringify(account.ledger.entries.map((entry) => entry.id))}
+              initial={account.ledger}
+            />
+          )}
+        </>
+      )}
     </>
   );
 }

--- a/apps/web/test/usage-and-billing.test.tsx
+++ b/apps/web/test/usage-and-billing.test.tsx
@@ -8,6 +8,7 @@ import {
   within,
 } from "@testing-library/react";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { toast } from "sonner";
 import UsageAndBillingPage from "../app/projects/[projectId]/settings/billing/page.tsx";
 import OrganizationSettingsPage from "../app/projects/[projectId]/settings/organization/page.tsx";
 import { HOBBY, PRO, USAGE, memberSession } from "./usage-billing-fixtures.ts";
@@ -89,6 +90,9 @@ beforeEach(() => {
   requests.length = 0;
   for (const key of Object.keys(responses)) delete responses[key];
   routed.search = "";
+  routed.router.push.mockReset();
+  routed.router.replace.mockReset();
+  routed.router.back.mockReset();
   vi.stubGlobal("scrollTo", vi.fn());
   vi.stubGlobal("location", { assign: vi.fn(), href: "http://localhost/" });
 });
@@ -121,30 +125,35 @@ it("puts all billing facts on the named settings page and uses the activation bo
       .getAttribute("aria-current"),
   ).toBe("page");
 });
-it("groups plan controls separately from the inference balance and credit purchase", async () => {
+it("puts the plan and inference credit in separate summary cards before payments", async () => {
   open();
   await screen.findByText("$4.25");
   const plan = screen
-    .getByRole("heading", { name: "Plan", level: 2 })
+    .getByRole("heading", { name: "Current plan", level: 2 })
     .closest("section")!;
-  const balance = screen
-    .getByRole("heading", { name: "Inference balance", level: 2 })
+  const credit = screen
+    .getByRole("heading", { name: "Inference credit", level: 2 })
+    .closest("section")!;
+  const payments = screen
+    .getByRole("heading", { name: "Payments", level: 2 })
     .closest("section")!;
   expect(within(plan).getByText("Hobby")).toBeTruthy();
+  expect(within(plan).queryByText("Free")).toBeNull();
+  expect(within(plan).queryByText("$50.00")).toBeNull();
   expect(within(plan).getByRole("button", { name: "Upgrade to Pro" })).toBeTruthy();
-  expect(
-    within(plan).getByRole("button", { name: "Manage payment and invoices" }),
-  ).toBeTruthy();
   expect(within(plan).queryByRole("button", { name: "Buy credit" })).toBeNull();
   expect(within(plan).queryByText("$4.25")).toBeNull();
-  expect(within(balance).getByText("$4.25")).toBeTruthy();
-  expect(within(balance).getByRole("button", { name: "Buy credit" })).toBeTruthy();
+  expect(within(credit).getByText("$4.25")).toBeTruthy();
+  expect(within(credit).getByRole("button", { name: "Buy credit" })).toBeTruthy();
   expect(
-    within(balance).queryByRole("button", { name: "Manage payment and invoices" }),
+    within(credit).queryByRole("button", { name: "Payment methods and invoices" }),
   ).toBeNull();
   expect(
-    within(balance).queryByRole("button", { name: "Upgrade to Pro" }),
+    within(credit).queryByRole("button", { name: "Upgrade to Pro" }),
   ).toBeNull();
+  expect(
+    within(payments).getByRole("button", { name: "Payment methods and invoices" }),
+  ).toBeTruthy();
 });
 it("lets members read provider costs and all history without payment actions", async () => {
   open({ ...HOBBY, mayManageBilling: false }, "member");
@@ -161,7 +170,7 @@ it("shows OSS usage without a pretend plan or balance", async () => {
   expect(await screen.findByText("128 simulations")).toBeTruthy();
   expect(screen.getByText("41.5 minutes")).toBeTruthy();
   expect(screen.getByText("openai/gpt-4o-mini")).toBeTruthy();
-  expect(screen.queryByText("Inference balance")).toBeNull();
+  expect(screen.queryByText("Inference credit")).toBeNull();
   expect(
     requests.find((request) => request.path === "/api/organization/usage")
       ?.address.search,
@@ -268,15 +277,19 @@ it("loads another ledger page without losing history when a retry is needed", as
       ?.address.searchParams.get("cursor"),
   ).toBe("older/+page");
 });
-it("keeps checkout-return facts visible and refreshes them from the billing controls", async () => {
+it("toasts a completed credit checkout once, clears its query, and lets the toast refresh", async () => {
+  const notice = vi.spyOn(toast, "info");
   routed.search = "credit=bought";
   open();
-  expect(
-    await screen.findByText(
+  await waitFor(() =>
+    expect(notice).toHaveBeenCalledWith(
       "Check billing history for your payment. If it has not appeared yet, refresh in a moment.",
+      expect.objectContaining({ action: expect.any(Object) }),
     ),
-  ).toBeTruthy();
-  expect(screen.queryByText(/payment successful/i)).toBeNull();
+  );
+  expect(routed.router.replace).toHaveBeenCalledWith(
+    "/projects/prj_1/settings/billing",
+  );
   expect(screen.queryByText("Credit purchase")).toBeNull();
   responses["/api/organization/billing"] = {
     status: 200,
@@ -297,30 +310,47 @@ it("keeps checkout-return facts visible and refreshes them from the billing cont
       },
     },
   };
-  fireEvent.click(screen.getByRole("button", { name: "Check again" }));
+  const options = notice.mock.calls[0]?.[1] as unknown as {
+    readonly action: {
+      readonly onClick: (event: never) => void;
+    };
+  };
+  options.action.onClick(new MouseEvent("click") as never);
   expect(await screen.findByText("$29.25")).toBeTruthy();
   expect(screen.getByText("Credit purchase")).toBeTruthy();
+  expect(
+    requests.filter((request) => request.path === "/api/organization/billing"),
+  ).toHaveLength(2);
+  notice.mockRestore();
 });
 it("does not upgrade the displayed plan merely from a return parameter", async () => {
+  const notice = vi.spyOn(toast, "warning");
   routed.search = "plan=pro";
   open();
-  expect(
-    await screen.findByText(
+  await waitFor(() =>
+    expect(notice).toHaveBeenCalledWith(
       "Pro is not active yet. Refresh after checkout finishes.",
+      expect.objectContaining({ action: expect.any(Object) }),
     ),
-  ).toBeTruthy();
+  );
   expect(screen.getByText("Hobby")).toBeTruthy();
-  expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
+  expect(routed.router.replace).toHaveBeenCalledWith(
+    "/projects/prj_1/settings/billing",
+  );
+  notice.mockRestore();
 });
-it("says checkout closed on cancellation while showing actual account facts", async () => {
+it("toasts a closed checkout while showing actual account facts", async () => {
+  const notice = vi.spyOn(toast, "info");
   routed.search = "credit=cancelled";
   open();
-  expect(
-    await screen.findByText(
+  await waitFor(() =>
+    expect(notice).toHaveBeenCalledWith(
       "Checkout closed. Your current billing details are shown below.",
+      expect.objectContaining({ action: expect.any(Object) }),
     ),
-  ).toBeTruthy();
+  );
   expect(screen.getByText("$4.25")).toBeTruthy();
+  notice.mockRestore();
 });
 it("buys a preset and preserves an action failure", async () => {
   open();
@@ -337,7 +367,7 @@ it("buys a preset and preserves an action failure", async () => {
     await screen.findByText("Checkout could not open. Try again."),
   ).toBeTruthy();
   const balance = screen
-    .getByRole("heading", { name: "Inference balance", level: 2 })
+    .getByRole("heading", { name: "Inference credit", level: 2 })
     .closest("section")!;
   expect(within(balance).getByRole("status").textContent).toBe(
     "Checkout could not open. Try again.",
@@ -393,7 +423,7 @@ it("blocks duplicate upgrade actions while their result is pending", async () =>
     await screen.findByText("Upgrade could not open. Try again."),
   ).toBeTruthy();
   const plan = screen
-    .getByRole("heading", { name: "Plan", level: 2 })
+    .getByRole("heading", { name: "Current plan", level: 2 })
     .closest("section")!;
   expect(within(plan).getByRole("status").textContent).toBe(
     "Upgrade could not open. Try again.",
@@ -424,7 +454,7 @@ it("confirms a downgrade and reports its actual scheduled date", async () => {
   );
   expect(screen.queryByRole("button", { name: "Downgrade at period end" })).toBeNull();
   const plan = screen
-    .getByRole("heading", { name: "Plan", level: 2 })
+    .getByRole("heading", { name: "Current plan", level: 2 })
     .closest("section")!;
   expect(within(plan).getByText(/Pro stops on/)).toBeTruthy();
   expect(
@@ -458,7 +488,7 @@ it("opens the existing payment portal action", async () => {
     body: { url: "https://billing.stripe.com/test" },
   };
   fireEvent.click(
-    await screen.findByRole("button", { name: "Manage payment and invoices" }),
+    await screen.findByRole("button", { name: "Payment methods and invoices" }),
   );
   await waitFor(() =>
     expect(window.location.assign).toHaveBeenCalledWith(
@@ -474,7 +504,7 @@ it("keeps usage out of the organization name form", async () => {
   expect(
     requests.some((request) => request.path.startsWith("/api/organization/")),
   ).toBe(false);
-  expect(screen.queryByText("Inference balance")).toBeNull();
+  expect(screen.queryByText("Inference credit")).toBeNull();
   routed.pathname = "/projects/prj_1/settings/billing";
 });
 
@@ -485,7 +515,7 @@ it("clears pending navigation when the browser returns to the page", async () =>
     body: { url: "https://billing.stripe.com/test" },
   };
   fireEvent.click(
-    await screen.findByRole("button", { name: "Manage payment and invoices" }),
+    await screen.findByRole("button", { name: "Payment methods and invoices" }),
   );
   await waitFor(() => expect(window.location.assign).toHaveBeenCalled());
   fireEvent(window, new Event("pageshow"));

--- a/apps/web/ui/billing.tsx
+++ b/apps/web/ui/billing.tsx
@@ -16,29 +16,22 @@ import {
 } from "../lib/billing.ts";
 import { asListInstant } from "../lib/instants.ts";
 import { Dialog } from "./dialog.tsx";
-import { Facts, Section } from "./section.tsx";
 
 export function BillingAccountSections({
   account,
   onRefresh,
-  onBusyChange,
 }: {
   readonly account: BillingAccount;
   readonly onRefresh: () => void;
-  readonly onBusyChange: (busy: boolean) => void;
 }) {
   const [busy, setBusy] = useState<string | null>(null);
   const [said, setSaid] = useState<{
-    readonly section: "plan" | "credit";
+    readonly section: "plan" | "credit" | "payments";
     readonly message: string;
   } | null>(null);
   const [picking, setPicking] = useState(false);
   const [stopping, setStopping] = useState(false);
   const actions = account.actions;
-  useEffect(() => {
-    onBusyChange(busy !== null);
-    return () => onBusyChange(false);
-  }, [busy, onBusyChange]);
   useEffect(() => {
     const returned = () => {
       setBusy(null);
@@ -71,7 +64,8 @@ export function BillingAccountSections({
       } catch {
         setBusy(null);
         setSaid({
-          section: what === "credit" ? "credit" : "plan",
+          section:
+            what === "credit" ? "credit" : what === "portal" ? "payments" : "plan",
           message: "The payment page could not open. Try again.",
         });
         return;
@@ -79,7 +73,8 @@ export function BillingAccountSections({
     }
     setBusy(null);
     setSaid({
-      section: what === "credit" ? "credit" : "plan",
+      section:
+        what === "credit" ? "credit" : what === "portal" ? "payments" : "plan",
       message:
         answer.status === "signed-out"
           ? "Sign in again to change this organization's billing."
@@ -105,130 +100,160 @@ export function BillingAccountSections({
     });
   };
 
+  const paymentMessage = !account.mayManageBilling
+    ? "An organization admin can manage the plan and payments."
+    : !actions.available
+      ? "Payment actions are unavailable. Ask your administrator to check billing setup."
+      : null;
+
   return (
-    <>
-      <Section title="Plan">
-        <Card>
-          <Facts facts={[{ label: "Plan", value: account.plan.name }]} />
-        </Card>
-        {account.scheduledDowngradeAt === null ? null : (
-          <p className="m-0 text-sm text-muted-foreground" role="status">
-            Pro stops on{" "}
-            <time
-              className="tabular-nums"
-              dateTime={account.scheduledDowngradeAt}
-            >
-              {asListInstant(account.scheduledDowngradeAt)}
-            </time>
-            . Everything it includes stays available until then.
-          </p>
-        )}
-        {!account.mayManageBilling ? (
-          <p className="m-0 text-sm text-muted-foreground">
-            An organization admin can manage the plan and payments.
-          </p>
-        ) : !actions.available ? (
-          <p className="m-0 text-sm text-muted-foreground">
-            Payment actions are unavailable. Ask your administrator to check
-            billing setup.
-          </p>
-        ) : (
-          <div className="flex flex-wrap items-center gap-2">
-            {onPro ? null : (
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                disabled={busy !== null}
-                onClick={() => void follow("upgrade", upgradeToPro)}
+    <div className="mt-8 flex flex-col gap-8">
+      <div className="grid gap-4 md:grid-cols-2">
+        <section aria-labelledby="billing-current-plan">
+          <Card className="h-full">
+            <div className="flex flex-col gap-2">
+              <h2
+                className="m-0 text-base font-medium"
+                id="billing-current-plan"
               >
-                {busy === "upgrade" ? "Opening Stripe…" : "Upgrade to Pro"}
-              </Button>
+                Current plan
+              </h2>
+              <p className="m-0 text-xl font-medium">{account.plan.name}</p>
+            </div>
+            {account.scheduledDowngradeAt === null ? null : (
+              <p className="m-0 text-sm text-muted-foreground" role="status">
+                Pro stops on{" "}
+                <time
+                  className="tabular-nums"
+                  dateTime={account.scheduledDowngradeAt}
+                >
+                  {asListInstant(account.scheduledDowngradeAt)}
+                </time>
+                . Everything it includes stays available until then.
+              </p>
             )}
+            {paymentMessage === null ? (
+              <div className="mt-auto flex flex-wrap items-center gap-2">
+                {onPro ? null : (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    disabled={busy !== null}
+                    onClick={() => void follow("upgrade", upgradeToPro)}
+                  >
+                    {busy === "upgrade" ? "Opening Stripe…" : "Upgrade to Pro"}
+                  </Button>
+                )}
+                {onPro && downgradeScheduled ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="ml-auto"
+                    disabled={busy !== null}
+                    onClick={() => void follow("portal", openPaymentPortal)}
+                  >
+                    Keep Pro in Stripe
+                  </Button>
+                ) : onPro ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="ml-auto text-destructive"
+                    disabled={busy !== null}
+                    onClick={() => {
+                      setSaid(null);
+                      setStopping(true);
+                    }}
+                  >
+                    {busy === "downgrade"
+                      ? "Asking Stripe…"
+                      : "Downgrade at period end"}
+                  </Button>
+                ) : null}
+              </div>
+            ) : null}
+            {said?.section === "plan" ? (
+              <p className="m-0 text-sm text-muted-foreground" role="status">
+                {said.message}
+              </p>
+            ) : null}
+          </Card>
+        </section>
+
+        <section aria-labelledby="billing-inference-credit">
+          <Card className="h-full">
+            <div className="flex flex-col gap-2">
+              <h2
+                className="m-0 text-base font-medium"
+                id="billing-inference-credit"
+              >
+                Inference credit
+              </h2>
+              <p className="m-0 text-xl font-medium tabular-nums">
+                {moneyLabel(account.balanceMicros)}
+              </p>
+              <p className="m-0 text-sm text-muted-foreground">
+                Pays for model usage made with Egma provider keys.
+              </p>
+            </div>
+            {account.mayManageBilling && actions.available ? (
+              <div className="mt-auto">
+                <Button
+                  type="button"
+                  size="sm"
+                  disabled={busy !== null}
+                  onClick={() => {
+                    setSaid(null);
+                    setPicking(true);
+                  }}
+                >
+                  Buy credit
+                </Button>
+              </div>
+            ) : null}
+            {said?.section === "credit" ? (
+              <p className="m-0 text-sm text-muted-foreground" role="status">
+                {said.message}
+              </p>
+            ) : null}
+          </Card>
+        </section>
+      </div>
+
+      <section aria-labelledby="billing-payments">
+        <Card className="flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-1">
+            <h2 className="m-0 text-base font-medium" id="billing-payments">
+              Payments
+            </h2>
+            <p className="m-0 text-sm text-muted-foreground">
+              Update payment methods and download invoices in Stripe.
+            </p>
+          </div>
+          {paymentMessage === null ? (
             <Button
               type="button"
               variant="secondary"
-              size="sm"
               disabled={busy !== null}
               onClick={() => void follow("portal", openPaymentPortal)}
             >
               {busy === "portal"
                 ? "Opening Stripe…"
-                : "Manage payment and invoices"}
+                : "Payment methods and invoices"}
             </Button>
-            {onPro && downgradeScheduled ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="ml-auto"
-                disabled={busy !== null}
-                onClick={() => void follow("portal", openPaymentPortal)}
-              >
-                Keep Pro in Stripe
-              </Button>
-            ) : onPro ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="ml-auto text-destructive"
-                disabled={busy !== null}
-                onClick={() => {
-                  setSaid(null);
-                  setStopping(true);
-                }}
-              >
-                {busy === "downgrade"
-                  ? "Asking Stripe…"
-                  : "Downgrade at period end"}
-              </Button>
-            ) : null}
-          </div>
-        )}
-        {said?.section === "plan" ? (
-          <p className="m-0 text-sm text-muted-foreground" role="status">
-            {said.message}
-          </p>
-        ) : null}
-      </Section>
-
-      <Section title="Inference balance">
-        <Card>
-          <Facts
-            facts={[
-              {
-                label: "Balance",
-                value: (
-                  <span className="tabular-nums">
-                    {moneyLabel(account.balanceMicros)}
-                  </span>
-                ),
-              },
-            ]}
-          />
+          ) : (
+            <p className="m-0 text-sm text-muted-foreground">{paymentMessage}</p>
+          )}
+          {said?.section === "payments" ? (
+            <p className="m-0 text-sm text-muted-foreground" role="status">
+              {said.message}
+            </p>
+          ) : null}
         </Card>
-        {account.mayManageBilling && actions.available ? (
-          <div>
-            <Button
-              type="button"
-              size="sm"
-              disabled={busy !== null}
-              onClick={() => {
-                setSaid(null);
-                setPicking(true);
-              }}
-            >
-              Buy credit
-            </Button>
-          </div>
-        ) : null}
-        {said?.section === "credit" ? (
-          <p className="m-0 text-sm text-muted-foreground" role="status">
-            {said.message}
-          </p>
-        ) : null}
-      </Section>
+      </section>
 
       {picking ? (
         <BuyCreditDialog
@@ -252,7 +277,7 @@ export function BillingAccountSections({
           }}
         />
       ) : null}
-    </>
+    </div>
   );
 }
 

--- a/ee/src/stripe/actions.ts
+++ b/ee/src/stripe/actions.ts
@@ -177,6 +177,7 @@ export async function openCreditCheckout(
         mode: "payment",
         customer: customerId,
         client_reference_id: auth.organizationId,
+        allow_promotion_codes: true,
         automatic_tax: { enabled: true },
         // Stripe Tax needs an address to work out a rate, and a returning
         // customer should not retype one they have already given.
@@ -258,13 +259,14 @@ export async function openUpgradeCheckout(
         mode: "subscription",
         customer: customerId,
         client_reference_id: auth.organizationId,
+        allow_promotion_codes: true,
         automatic_tax: { enabled: true },
         customer_update: { address: "auto", name: "auto" },
         line_items: [
           { price: prices.fee, quantity: 1 },
           // A metered item carries no quantity: the meter is what says how much.
-          { price: prices.webCall },
           { price: prices.phone },
+          { price: prices.webCall },
         ],
         subscription_data: {
           // What the invoice and the dashboard say this subscription is for.

--- a/ee/src/stripe/setup.ts
+++ b/ee/src/stripe/setup.ts
@@ -22,22 +22,36 @@ import { METER_EVENT_NAMES } from "./meter.ts";
  * **Why it exists at all.** The Stripe objects are not in `plans.json` and
  * cannot be: a product id and a price id are made by Stripe and belong to one
  * account, so a fresh sandbox, a second sandbox and a live account each need
- * their own. A dashboard click-through would put six identifiers in a runbook
- * nobody re-reads. This is one command whose result is the same however many
- * times it runs.
+ * their own. A dashboard click-through would put the catalog identifiers in a
+ * runbook nobody re-reads. This is one command whose result is the same however
+ * many times it runs.
  *
  * **Nothing here is on a request path**, and nothing on one calls it.
  */
 
-/** Where the fee and the two metered prices are found again, by lookup key. */
+/**
+ * Where the current prices are found again.
+ *
+ * The v2 meter keys leave the original shared-product keys in place, so an
+ * older setup binary can still restore its own catalog after a rollback.
+ */
 export const PRICE_LOOKUP_KEYS = {
   fee: "egma_pro_fee_monthly",
-  web_call_minutes: "egma_pro_web_call_minutes",
-  phone_minutes: "egma_pro_phone_minutes",
+  web_call_minutes: "egma_pro_web_call_minutes_v2",
+  phone_minutes: "egma_pro_phone_minutes_v2",
 } as const;
 
-/** What names the Pro product on the Stripe account, so it can be found again. */
-export const PRODUCT_METADATA_KEY = "egma_plan";
+/** What identifies each product in Egma's Checkout catalog. */
+export const PRODUCT_METADATA_KEY = "egma_catalog_item";
+
+/** The metadata on the original shared Pro product. */
+const LEGACY_PRODUCT_METADATA_KEY = "egma_plan";
+
+const PRODUCT_METADATA_VALUES = {
+  fee: "pro_monthly_fee",
+  webCall: "web_call_minutes",
+  phone: "phone_minutes",
+} as const;
 
 /** The business address Stripe Tax works a rate out from. */
 export type HeadOffice = {
@@ -66,19 +80,20 @@ export type StripeSetupOptions = {
 /** What one run of the setup found or made. */
 export type StripeSetup = {
   readonly taxStatus: "active" | "pending" | "skipped";
+  /** The Egma Pro product. The price columns record the other catalog items. */
   readonly productId: string;
   readonly feePriceId: string;
   readonly webCallMeterId: string;
   readonly phoneMeterId: string;
   readonly webCallMeterPriceId: string;
   readonly phoneMeterPriceId: string;
-  /** Which of the six this run created rather than found. */
+  /** Which catalog objects this run created rather than found. */
   readonly created: readonly string[];
 };
 
 /**
- * Set this Stripe account up to sell Pro, and write the object ids onto the
- * plan row.
+ * Set this Stripe account up to sell Pro, and write the current price ids onto
+ * the plan row.
  *
  * The plan rows are seeded first, because the prices are made from Pro's fee,
  * its two allowances and its two overage prices — and a price created from a
@@ -118,17 +133,37 @@ export async function setUpStripe(
     say,
   );
 
-  const product = await findOrCreateProduct(gateway, pro, created, say);
+  const feeProduct = await findOrCreateProduct(
+    gateway,
+    PRODUCT_METADATA_VALUES.fee,
+    "Egma Pro",
+    created,
+    say,
+  );
+  const webCallProduct = await findOrCreateProduct(
+    gateway,
+    PRODUCT_METADATA_VALUES.webCall,
+    "Web call minutes",
+    created,
+    say,
+  );
+  const phoneProduct = await findOrCreateProduct(
+    gateway,
+    PRODUCT_METADATA_VALUES.phone,
+    "Phone minutes",
+    created,
+    say,
+  );
   const feePrice = await findOrCreateFeePrice(
     gateway,
-    product.id,
+    feeProduct.id,
     pro,
     created,
     say,
   );
   const webCallPrice = await findOrCreateMeteredPrice(
     gateway,
-    product.id,
+    webCallProduct.id,
     {
       lookupKey: PRICE_LOOKUP_KEYS.web_call_minutes,
       nickname: "Pro web-call minutes",
@@ -141,7 +176,7 @@ export async function setUpStripe(
   );
   const phonePrice = await findOrCreateMeteredPrice(
     gateway,
-    product.id,
+    phoneProduct.id,
     {
       lookupKey: PRICE_LOOKUP_KEYS.phone_minutes,
       nickname: "Pro phone minutes",
@@ -155,7 +190,7 @@ export async function setUpStripe(
 
   const objects = {
     planCode: "pro",
-    productId: product.id,
+    productId: feeProduct.id,
     feePriceId: feePrice.id,
     webCallMeterId: webCallMeter.id,
     phoneMeterId: phoneMeter.id,
@@ -163,7 +198,7 @@ export async function setUpStripe(
     phoneMeterPriceId: phonePrice.id,
   } as const;
   await recordStripePlanObjects(objects);
-  say(`Wrote the six Stripe object ids onto the ${objects.planCode} plan row.`);
+  say(`Wrote the current Stripe price ids onto the ${objects.planCode} plan row.`);
 
   return { taxStatus, created, ...objects };
 }
@@ -259,30 +294,67 @@ async function findOrCreateMeter(
   return meter;
 }
 
-/** The Pro product, found by its metadata or made. */
+/** One Checkout product, found by its catalog metadata or made. */
 async function findOrCreateProduct(
   gateway: StripeGateway,
-  plan: CloudPlan,
+  catalogItem: (typeof PRODUCT_METADATA_VALUES)[keyof typeof PRODUCT_METADATA_VALUES],
+  name: string,
   created: string[],
   say: (message: string) => void,
 ): Promise<Stripe.Product> {
-  const found = await findProduct(gateway, plan.code);
+  const found = await findProduct(gateway, catalogItem);
   if (found !== undefined) return found;
 
+  if (catalogItem === PRODUCT_METADATA_VALUES.fee) {
+    const legacy = await findLegacyProProduct(gateway);
+    if (legacy !== undefined) return adoptLegacyFeeProduct(gateway, legacy);
+  }
+
   const product = await gateway.api.products.create({
-    name: `Egma ${plan.name}`,
-    description:
-      "The Egma Pro plan: unlimited chat simulations, included web-call and " +
-      "phone minutes, and per-minute overage past them.",
-    metadata: { [PRODUCT_METADATA_KEY]: plan.code },
+    name,
+    metadata: {
+      [PRODUCT_METADATA_KEY]: catalogItem,
+      ...(catalogItem === PRODUCT_METADATA_VALUES.fee
+        ? { [LEGACY_PRODUCT_METADATA_KEY]: "pro" }
+        : {}),
+    },
   });
-  created.push(`product ${plan.code}`);
-  say(`Created the ${plan.name} product (${product.id}).`);
+  created.push(`product ${catalogItem}`);
+  say(`Created the ${name} product (${product.id}).`);
   return product;
 }
 
 /**
- * The product whose metadata names this plan.
+ * Turn the original shared Pro product into the fee product.
+ *
+ * Its prices remain on the product, so existing subscriptions retain exactly
+ * the price ids they already have. The fee lookup key moves only when setup
+ * creates the replacement price for new Checkout Sessions.
+ */
+export async function adoptLegacyFeeProduct(
+  gateway: StripeGateway,
+  legacy: Stripe.Product,
+): Promise<Stripe.Product> {
+  return gateway.api.products.update(legacy.id, {
+    name: "Egma Pro",
+    // Stripe clears an optional text field when it receives an empty string.
+    description: "",
+    metadata: {
+      ...legacy.metadata,
+      [PRODUCT_METADATA_KEY]: PRODUCT_METADATA_VALUES.fee,
+    },
+  });
+}
+
+/** Find the original shared product, before it gains its catalog marker. */
+async function findLegacyProProduct(
+  gateway: StripeGateway,
+): Promise<Stripe.Product | undefined> {
+  return findProductByMetadata(gateway, LEGACY_PRODUCT_METADATA_KEY, "pro");
+}
+
+/**
+ * The product whose metadata names this Checkout catalog item.
  *
  * Search first, because that is what the metadata index is for; then a bounded
  * list, because search is eventually consistent and a product created a minute
@@ -291,11 +363,20 @@ async function findOrCreateProduct(
  */
 async function findProduct(
   gateway: StripeGateway,
-  planCode: string,
+  catalogItem: (typeof PRODUCT_METADATA_VALUES)[keyof typeof PRODUCT_METADATA_VALUES],
+): Promise<Stripe.Product | undefined> {
+  return findProductByMetadata(gateway, PRODUCT_METADATA_KEY, catalogItem);
+}
+
+/** Find the product whose metadata identifies one Egma catalog item. */
+async function findProductByMetadata(
+  gateway: StripeGateway,
+  metadataKey: string,
+  metadataValue: string,
 ): Promise<Stripe.Product | undefined> {
   try {
     const searched = await gateway.api.products.search({
-      query: `metadata['${PRODUCT_METADATA_KEY}']:'${planCode}'`,
+      query: `metadata['${metadataKey}']:'${metadataValue}'`,
       limit: 1,
     });
     const first = searched.data[0];
@@ -307,7 +388,7 @@ async function findProduct(
 
   let seen = 0;
   for await (const product of gateway.api.products.list({ limit: 100 })) {
-    if (product.metadata[PRODUCT_METADATA_KEY] === planCode) return product;
+    if (product.metadata[metadataKey] === metadataValue) return product;
     seen += 1;
     // A bound, so a very large account cannot turn a setup into a full scan.
     // A product this deployment made is one of the newest, and the list comes

--- a/ee/test/stripe/sandbox.test.ts
+++ b/ee/test/stripe/sandbox.test.ts
@@ -19,6 +19,7 @@ import {
   stripeMeterPeriods,
 } from "../../src/stripe/periods.ts";
 import { hourAround } from "../../src/stripe/facts.ts";
+import { adoptLegacyFeeProduct } from "../../src/stripe/setup.ts";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import {
@@ -553,7 +554,48 @@ describe.skipIf(!RUNNING).sequential("the Stripe sandbox, for real", () => {
     expect(again.productId).toBe(first.productId);
     expect(again.feePriceId).toBe(first.feePriceId);
     expect(again.webCallMeterPriceId).toBe(first.webCallMeterPriceId);
+
+    const products = await Promise.all(
+      [
+        first.feePriceId,
+        first.webCallMeterPriceId,
+        first.phoneMeterPriceId,
+      ].map(async (priceId) => {
+        const price = await stripe.prices.retrieve(priceId);
+        const productId =
+          typeof price.product === "string" ? price.product : price.product.id;
+        return stripe.products.retrieve(productId);
+      }),
+    );
+    expect(products.map((product) => product.name).sort()).toEqual([
+      "Egma Pro",
+      "Phone minutes",
+      "Web call minutes",
+    ]);
+    expect(new Set(products.map((product) => product.id)).size).toBe(3);
+    expect(products.every((product) => product.description === null)).toBe(true);
   }, 120_000);
+
+  it("adopts the legacy Pro product instead of creating another one", async () => {
+    const legacy = await stripe.products.create({
+      name: "Legacy Pro",
+      description: "A description that Checkout must not show",
+      metadata: { egma_plan: "pro" },
+    });
+    const before = await stripe.products.list({ limit: 100 });
+
+    const adopted = await adoptLegacyFeeProduct(gateway, legacy);
+    const after = await stripe.products.list({ limit: 100 });
+
+    expect(adopted.id).toBe(legacy.id);
+    expect(adopted.name).toBe("Egma Pro");
+    expect(adopted.description).toBeNull();
+    expect(adopted.metadata.egma_plan).toBe("pro");
+    expect(adopted.metadata[PRODUCT_METADATA_KEY]).toBe("pro_monthly_fee");
+    expect(after.data.map((product) => product.id).sort()).toEqual(
+      before.data.map((product) => product.id).sort(),
+    );
+  }, 60_000);
 
   it("prices the allowance at nothing and everything past it at the overage", async () => {
     const found = await stripe.prices.list({
@@ -601,6 +643,7 @@ describe.skipIf(!RUNNING).sequential("the Stripe sandbox, for real", () => {
     const session = sessions.data[0];
     expect(session?.mode).toBe("payment");
     expect(session?.automatic_tax.enabled).toBe(true);
+    expect(session?.allow_promotion_codes).toBe(true);
     expect(session?.client_reference_id).toBe(paying.organizationId);
     expect(session?.amount_subtotal).toBe(2_500);
     if (session === undefined) throw new Error("Checkout Session is missing");
@@ -660,13 +703,21 @@ describe.skipIf(!RUNNING).sequential("the Stripe sandbox, for real", () => {
     const session = sessions.data.find((one) => one.mode === "subscription");
     if (session === undefined)
       throw new Error("Upgrade did not create a real subscription Checkout");
+    expect(session.allow_promotion_codes).toBe(true);
     const lines = await stripe.checkout.sessions.listLineItems(session.id, {
       limit: 100,
     });
     const prices = await proPrices();
-    expect(lines.data.map((line) => line.price?.id).sort()).toEqual(
-      [prices.fee, prices.webCall, prices.phone].sort(),
-    );
+    expect(lines.data.map((line) => line.price?.id)).toEqual([
+      prices.fee,
+      prices.phone,
+      prices.webCall,
+    ]);
+    expect(lines.data.map((line) => line.description)).toEqual([
+      "Egma Pro",
+      "Phone minutes",
+      "Web call minutes",
+    ]);
     await stripe.checkout.sessions.expire(session.id);
   }, 120_000);
 

--- a/ee/test/stripe/sandbox.test.ts
+++ b/ee/test/stripe/sandbox.test.ts
@@ -19,7 +19,10 @@ import {
   stripeMeterPeriods,
 } from "../../src/stripe/periods.ts";
 import { hourAround } from "../../src/stripe/facts.ts";
-import { adoptLegacyFeeProduct } from "../../src/stripe/setup.ts";
+import {
+  adoptLegacyFeeProduct,
+  PRODUCT_METADATA_KEY,
+} from "../../src/stripe/setup.ts";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import {


### PR DESCRIPTION
Stripe Checkout showed all three subscription items as “Egma Pro,” including two “Price varies” rows, and the billing page mixed plan, credit, and payment actions. This change gives Checkout three clear lines—Egma Pro, Phone minutes, and Web call minutes—adds promotion-code entry, and applies the selected summary-first billing layout.

## What changed

- Split the Pro fee, phone minutes, and web-call minutes across named Stripe products with no descriptions.
- Preserve the legacy Stripe product and lookup keys while new metered prices use separate v2 keys, so existing subscriptions and rollback setup stay valid.
- Enable promotion codes for Pro and inference-credit Checkout sessions.
- Show only Hobby or Pro as the current plan, with separate inference-credit and payments panels.
- Replace the checkout-return page banner with a one-time Sonner toast and refresh billing history correctly.
- Remove the throwaway billing prototype after applying the selected direction.

## Production rollout

After this commit deploys, run `pnpm --filter @egma/ee stripe:setup` once with the production database and Stripe settings. The idempotent setup adopts the existing Egma Pro product, creates the two named metered products and v2 prices, and records those current price IDs in the Pro plan row.

## Validation

- `pnpm test:fast` — 3,856 passed, 13 expected skips
- `pnpm vitest run apps/web/test/usage-and-billing.test.tsx` — 22 passed
- `pnpm --filter @egma/web typecheck`
- `pnpm --filter @egma/ee build`
- `pnpm lint`
- `pnpm test:stripe` — lane collected; 12 real-sandbox tests skipped because no local Stripe sandbox key was configured
- Sol specification review and Sol standards review — no remaining findings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791573012&installation_model_id=431960&pr_number=339&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F339&signature=1fd38934636193d34e2cc3c684397c83245b43b05d646a8983877a429de1c25c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the billing and Stripe Checkout experience while preserving compatibility with existing Stripe catalog objects.
- Separates the Pro fee, phone minutes, and web-call minutes into clearly named Stripe products.
- Retains the legacy Pro product and introduces v2 lookup keys for new metered prices.
- Enables promotion codes for subscription and inference-credit Checkout sessions.
- Reorganizes billing into plan, inference-credit, and payments sections.
- Replaces checkout-return banners with one-time toasts and refreshes billing history.
- Adds sandbox coverage for product presentation, legacy-product adoption, line ordering, and promotion codes.
- The only change since the previous review adds the missing `PRODUCT_METADATA_KEY` test import.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no outstanding correctness, security, or repository-rule issues identified.

The final change correctly imports the exported Stripe product metadata key used by the sandbox test, resolving the repository-wide typecheck failure without changing production behavior.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/settings/billing/page.tsx | Replaces checkout-return banners with one-time toasts, cleans return parameters, and keys billing history to ledger contents. |
| apps/web/ui/billing.tsx | Reorganizes billing controls into separate plan, inference-credit, and payments panels. |
| ee/src/stripe/actions.ts | Enables promotion codes and presents subscription line items in the intended order. |
| ee/src/stripe/setup.ts | Creates distinct Checkout products while safely adopting the legacy Pro product and retaining rollback-compatible metadata and prices. |
| ee/test/stripe/sandbox.test.ts | Verifies product presentation, legacy adoption, promotion-code support, and Checkout line ordering; the final commit supplies its missing exported constant import. |
| apps/web/test/usage-and-billing.test.tsx | Updates billing-page coverage for the summary layout, return toasts, URL cleanup, and history refresh behavior. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Billing[Billing page] --> Pro[Current plan]
  Billing --> Credit[Inference credit]
  Billing --> Payments[Payments]
  Pro --> Upgrade[Stripe subscription Checkout]
  Credit --> Purchase[Stripe payment Checkout]
  Payments --> Portal[Stripe customer portal]
  Upgrade --> Fee[Egma Pro]
  Upgrade --> Phone[Phone minutes]
  Upgrade --> Web[Web call minutes]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix Stripe sandbox typecheck"](https://github.com/egma-ai/egma/commit/f128867b4332a20943b0fb94ee69ffdd0f93674f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62263577)</sub>

<!-- /greptile_comment -->