### PR TITLE
Keep billing return toasts visible

### DIFF
--- a/apps/web/app/projects/[projectId]/settings/billing/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/billing/page.tsx
@@ -4,7 +4,6 @@ import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 import {
   useParams,
   usePathname,
-  useRouter,
   useSearchParams,
 } from "next/navigation";
 import { toast } from "sonner";
@@ -31,7 +30,6 @@ export default function UsageAndBillingPage() {
 
 function UsageAndBillingBody({ projectId }: { readonly projectId: string }) {
   const pathname = usePathname();
-  const router = useRouter();
   const search = useSearchParams();
   const returnedPlan = search.get("plan");
   const returnedCredit = search.get("credit");
@@ -110,7 +108,9 @@ function UsageAndBillingBody({ projectId }: { readonly projectId: string }) {
     const nextSearch = new URLSearchParams(search.toString());
     nextSearch.delete("plan");
     nextSearch.delete("credit");
-    router.replace(
+    globalThis.history.replaceState(
+      globalThis.history.state,
+      "",
       nextSearch.size === 0 ? pathname : `${pathname}?${nextSearch.toString()}`,
     );
   }, [
@@ -121,7 +121,6 @@ function UsageAndBillingBody({ projectId }: { readonly projectId: string }) {
     refresh,
     returnedCredit,
     returnedPlan,
-    router,
     search,
   ]);
 

--- a/apps/web/app/projects/[projectId]/settings/billing/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/billing/page.tsx
@@ -109,7 +109,7 @@ function UsageAndBillingBody({ projectId }: { readonly projectId: string }) {
     nextSearch.delete("plan");
     nextSearch.delete("credit");
     globalThis.history.replaceState(
-      globalThis.history.state,
+      null,
       "",
       nextSearch.size === 0 ? pathname : `${pathname}?${nextSearch.toString()}`,
     );

--- a/apps/web/test/usage-and-billing.test.tsx
+++ b/apps/web/test/usage-and-billing.test.tsx
@@ -286,7 +286,7 @@ it("toasts a completed credit checkout once, clears its query, and lets the toas
     ),
   ).toBeTruthy();
   expect(replaceState).toHaveBeenCalledWith(
-    globalThis.history.state,
+    null,
     "",
     "/projects/prj_1/settings/billing",
   );
@@ -330,7 +330,7 @@ it("does not upgrade the displayed plan merely from a return parameter", async (
   ).toBeTruthy();
   expect(screen.getByText("Hobby")).toBeTruthy();
   expect(replaceState).toHaveBeenCalledWith(
-    globalThis.history.state,
+    null,
     "",
     "/projects/prj_1/settings/billing",
   );
@@ -348,7 +348,7 @@ it("keeps a closed-plan toast visible after removing the return query", async ()
   ).toBeTruthy();
   expect(screen.getByText("$4.25")).toBeTruthy();
   expect(replaceState).toHaveBeenCalledWith(
-    globalThis.history.state,
+    null,
     "",
     "/projects/prj_1/settings/billing",
   );

--- a/apps/web/test/usage-and-billing.test.tsx
+++ b/apps/web/test/usage-and-billing.test.tsx
@@ -8,7 +8,6 @@ import {
   within,
 } from "@testing-library/react";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
-import { toast } from "sonner";
 import UsageAndBillingPage from "../app/projects/[projectId]/settings/billing/page.tsx";
 import OrganizationSettingsPage from "../app/projects/[projectId]/settings/organization/page.tsx";
 import { HOBBY, PRO, USAGE, memberSession } from "./usage-billing-fixtures.ts";
@@ -278,18 +277,20 @@ it("loads another ledger page without losing history when a retry is needed", as
   ).toBe("older/+page");
 });
 it("toasts a completed credit checkout once, clears its query, and lets the toast refresh", async () => {
-  const notice = vi.spyOn(toast, "info");
+  const replaceState = vi.spyOn(globalThis.history, "replaceState");
   routed.search = "credit=bought";
   open();
-  await waitFor(() =>
-    expect(notice).toHaveBeenCalledWith(
+  expect(
+    await screen.findByText(
       "Check billing history for your payment. If it has not appeared yet, refresh in a moment.",
-      expect.objectContaining({ action: expect.any(Object) }),
     ),
-  );
-  expect(routed.router.replace).toHaveBeenCalledWith(
+  ).toBeTruthy();
+  expect(replaceState).toHaveBeenCalledWith(
+    globalThis.history.state,
+    "",
     "/projects/prj_1/settings/billing",
   );
+  expect(routed.router.replace).not.toHaveBeenCalled();
   expect(screen.queryByText("Credit purchase")).toBeNull();
   responses["/api/organization/billing"] = {
     status: 200,
@@ -310,47 +311,49 @@ it("toasts a completed credit checkout once, clears its query, and lets the toas
       },
     },
   };
-  const options = notice.mock.calls[0]?.[1] as unknown as {
-    readonly action: {
-      readonly onClick: (event: never) => void;
-    };
-  };
-  options.action.onClick(new MouseEvent("click") as never);
+  fireEvent.click(screen.getByRole("button", { name: "Check again" }));
   expect(await screen.findByText("$29.25")).toBeTruthy();
   expect(screen.getByText("Credit purchase")).toBeTruthy();
   expect(
     requests.filter((request) => request.path === "/api/organization/billing"),
   ).toHaveLength(2);
-  notice.mockRestore();
+  replaceState.mockRestore();
 });
 it("does not upgrade the displayed plan merely from a return parameter", async () => {
-  const notice = vi.spyOn(toast, "warning");
+  const replaceState = vi.spyOn(globalThis.history, "replaceState");
   routed.search = "plan=pro";
   open();
-  await waitFor(() =>
-    expect(notice).toHaveBeenCalledWith(
+  expect(
+    await screen.findByText(
       "Pro is not active yet. Refresh after checkout finishes.",
-      expect.objectContaining({ action: expect.any(Object) }),
     ),
-  );
+  ).toBeTruthy();
   expect(screen.getByText("Hobby")).toBeTruthy();
-  expect(routed.router.replace).toHaveBeenCalledWith(
+  expect(replaceState).toHaveBeenCalledWith(
+    globalThis.history.state,
+    "",
     "/projects/prj_1/settings/billing",
   );
-  notice.mockRestore();
+  expect(routed.router.replace).not.toHaveBeenCalled();
+  replaceState.mockRestore();
 });
-it("toasts a closed checkout while showing actual account facts", async () => {
-  const notice = vi.spyOn(toast, "info");
-  routed.search = "credit=cancelled";
+it("keeps a closed-plan toast visible after removing the return query", async () => {
+  const replaceState = vi.spyOn(globalThis.history, "replaceState");
+  routed.search = "plan=cancelled";
   open();
-  await waitFor(() =>
-    expect(notice).toHaveBeenCalledWith(
+  expect(
+    await screen.findByText(
       "Checkout closed. Your current billing details are shown below.",
-      expect.objectContaining({ action: expect.any(Object) }),
     ),
-  );
+  ).toBeTruthy();
   expect(screen.getByText("$4.25")).toBeTruthy();
-  notice.mockRestore();
+  expect(replaceState).toHaveBeenCalledWith(
+    globalThis.history.state,
+    "",
+    "/projects/prj_1/settings/billing",
+  );
+  expect(routed.router.replace).not.toHaveBeenCalled();
+  replaceState.mockRestore();
 });
 it("buys a preset and preserves an action failure", async () => {
   open();


### PR DESCRIPTION
Opening the billing page after a Stripe Checkout return created a Sonner toast and immediately called `router.replace`. In production, that navigation remounted the page and cleared the toast, so the checkout result was invisible.

This change removes the consumed `plan` and `credit` parameters with `history.replaceState`, preserving both the rendered toast and current page state. The regression test now renders the real AppShell toaster, verifies the visible checkout message, exercises the visible **Check again** action, confirms refreshed billing history, and proves query cleanup does not call the Next router.

Validation:
- `pnpm vitest run apps/web/test/usage-and-billing.test.tsx` (22 passed)
- `pnpm --filter @egma/web typecheck`
- `pnpm lint`
- `git diff --check`
- Sol standards review: no findings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791578253&installation_model_id=431960&pr_number=340&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F340&signature=02ce825e3fb954ba0775b776b03fcb0dc95c2d4963a7f638fa5887d6fefb4df0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps Stripe Checkout return notifications visible by cleaning consumed billing query parameters through the native History API instead of triggering a router navigation.
- Uses `history.replaceState(null, "", cleanedUrl)` so Next synchronizes its canonical URL without remounting the page.
- Exercises the rendered toast, its visible **Check again** action, refreshed billing history, and absence of router navigation.
- The previously reported stale-router-state finding is resolved.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the previous router synchronization concern is resolved and no new actionable issues remain.

The cleaned URL now uses the native history synchronization path without remounting the billing page, while the focused tests cover visible toast behavior and retry-driven billing refresh. The previous finding was manually resolved after the implementation changed the replacement state to `null`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/settings/billing/page.tsx | Replaces router navigation with synchronized native history cleanup so billing-return toasts remain mounted and visible. |
| apps/web/test/usage-and-billing.test.tsx | Verifies visible checkout messages, query cleanup without router navigation, the retry action, and refreshed billing data. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant BillingPage
    participant Toast
    participant History
    participant NextRouter

    Stripe->>BillingPage: Return with plan/credit query
    BillingPage->>Toast: Render checkout result
    BillingPage->>History: replaceState(null, cleaned URL)
    History->>NextRouter: Synchronize canonical URL/search params
    Note over BillingPage,Toast: Page remains mounted and toast stays visible
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Synchronize cleaned billing URL with Nex..."](https://github.com/egma-ai/egma/commit/112ba0433789dd852c843486692a020ea39f5b36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62302473)</sub>

<!-- /greptile_comment -->