### PR TITLE
Use short Egma mark in docs header

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -9,8 +9,8 @@
     "dark": "#c2410c"
   },
   "logo": {
-    "light": "/docs/assets/logo/light.svg",
-    "dark": "/docs/assets/logo/dark.svg",
+    "light": "/docs/assets/logo/mark-light.svg",
+    "dark": "/docs/assets/logo/mark-dark.svg",
     "href": "/docs/get-started/introduction"
   },
   "favicon": "/favicon.svg",


### PR DESCRIPTION
Use the short Egma mark in the docs header for both light and dark mode.

Validation:
- `pnpm docs:check`
- `pnpm docs:build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791646072&installation_model_id=431960&pr_number=346&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F346&signature=f38e48502c0ab21002f1de64bbebcecb226f8e8d75f474aeafd314a5040f50da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the documentation header to use the short Egma mark in both themes.
- Replaces the light-mode logo with `mark-light.svg`.
- Replaces the dark-mode logo with `mark-dark.svg`.
- Preserves the existing documentation-header destination.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

Both configured logo paths resolve to existing assets, and no outstanding or newly introduced failures remain.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/docs.json | Points the light and dark documentation header logos to the existing short-mark assets. |

<sub>Reviews (2): Last reviewed commit: ["Use short mark in docs header"](https://github.com/egma-ai/egma/commit/8d44b07925a56a225a5e662225cacb0e8aee8650) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62645861)</sub>

<!-- /greptile_comment -->