### PR TITLE
Fix voice interruptions before audio starts

### DIFF
--- a/apps/api/test/simulator-conversation.test.ts
+++ b/apps/api/test/simulator-conversation.test.ts
@@ -1411,6 +1411,7 @@ describe.skipIf(!storage.available)("the shipped simulator against the real API"
       }> = [];
       let artifact: { file: string; sha256: string; version: string } | undefined;
       let runtime: { name: string; version: string } | undefined;
+      let diagnosticSimulationStatus: string | undefined;
       let diagnosticEvidence: Record<string, unknown> | undefined;
       let diagnosticGrade: {
         result: CurrentGrade["result"];
@@ -1562,6 +1563,7 @@ describe.skipIf(!storage.available)("the shipped simulator against the real API"
         expect(simulation).toBeDefined();
         const simulationId = simulation!.id;
         const terminalStatus = await waitForTerminal(simulationId, 120_000);
+        diagnosticSimulationStatus = terminalStatus;
         if (terminalStatus !== "completed") {
           const failed = await call("GET", `/v1/simulations/${simulationId}`, { key });
           diagnosticEvidence = failed.body;
@@ -1812,7 +1814,7 @@ describe.skipIf(!storage.available)("the shipped simulator against the real API"
             outcomes: {
               simulation: typeof diagnosticEvidence?.status === "string"
                 ? diagnosticEvidence.status
-                : "unknown",
+                : diagnosticSimulationStatus ?? "unknown",
               failureType: failure instanceof Error ? failure.name : "unknown",
             },
             ...(diagnosticEvidence === undefined ? {} : {

--- a/apps/api/test/simulator-conversation.test.ts
+++ b/apps/api/test/simulator-conversation.test.ts
@@ -64,6 +64,56 @@ const LIVE_MODALITY = process.env["SIMULATION_E2E_MODALITY"] ?? "chat";
 const LIVE_MOCKS = process.env["SIMULATION_E2E_MOCKS"] !== "off";
 const LIVE_ACCESS = process.env["SIMULATION_E2E_ACCESS"] ?? "project_credentials";
 
+type CustomerTurn = {
+  kind: "turn:human" | "turn:agent";
+  text: string;
+};
+
+function turnsInSpeakerOrder(turns: Array<{ kind: string; text: string }>): {
+  human: string[];
+  agent: string[];
+} {
+  const ordered = { human: [] as string[], agent: [] as string[] };
+  for (const turn of turns) {
+    if (turn.kind === "turn:human") ordered.human.push(turn.text);
+    else if (turn.kind === "turn:agent") ordered.agent.push(turn.text);
+    else throw new Error(`unexpected customer turn kind: ${turn.kind}`);
+  }
+  return ordered;
+}
+
+describe("customer turn evidence", () => {
+  const nativeTurns: CustomerTurn[] = [
+    { kind: "turn:human", text: "Thank you for the information." },
+    { kind: "turn:agent", text: "You're" },
+    { kind: "turn:human", text: "Goodbye." },
+    { kind: "turn:agent", text: "Goodbye! Have a great day!" },
+  ];
+  const overlappingPublicTurns: CustomerTurn[] = [
+    { kind: "turn:human", text: "Thank you for the information." },
+    { kind: "turn:agent", text: "You're" },
+    { kind: "turn:agent", text: "Goodbye! Have a great day!" },
+    { kind: "turn:human", text: "Goodbye." },
+  ];
+
+  it("keeps each speaker's sequence when overlapping turns have different total orders", () => {
+    expect(overlappingPublicTurns).not.toEqual(nativeTurns);
+    expect(turnsInSpeakerOrder(overlappingPublicTurns)).toEqual(
+      turnsInSpeakerOrder(nativeTurns),
+    );
+  });
+
+  it("rejects missing duplicate evidence", () => {
+    const nativeWithDuplicate = [
+      ...nativeTurns,
+      { kind: "turn:human" as const, text: "Goodbye." },
+    ];
+    expect(turnsInSpeakerOrder(overlappingPublicTurns)).not.toEqual(
+      turnsInSpeakerOrder(nativeWithDuplicate),
+    );
+  });
+});
+
 describe("quick tunnel output", () => {
   it("does not mistake the Cloudflare API error address for a public tunnel", () => {
     expect(quickTunnelUrl("request to https://api.trycloudflare.com failed")).toBeUndefined();
@@ -1619,20 +1669,27 @@ describe.skipIf(!storage.available)("the shipped simulator against the real API"
           }));
         expect(publicCustomerTurns).toEqual(storedCustomerTurns);
         const history = await nativeHistory(path.join(providerDirectory, "native-history.json"));
-        const nativeTurns = history.flatMap((item) => {
+        const nativeTurns: CustomerTurn[] = history.flatMap((item) => {
           if (item.type !== "message" || (item.role !== "user" && item.role !== "assistant")) return [];
           const text = historyText(item.content);
           return text === "" ? [] : [{
-            kind: item.role === "user" ? "turn:human" : "turn:agent",
+            kind: item.role === "user" ? "turn:human" as const : "turn:agent" as const,
             text: compactText(text),
           }];
         });
         expect(nativeTurns.some((turn) => turn.kind === "turn:human")).toBe(true);
         expect(nativeTurns.some((turn) => turn.kind === "turn:agent")).toBe(true);
-        expect(publicCustomerTurns.map((turn) => ({
-          kind: turn.kind,
+        const normalizedPublicCustomerTurns = publicCustomerTurns.map((turn) => ({
+          kind: String(turn.kind),
           text: compactText(turn.text ?? ""),
-        }))).toEqual(nativeTurns);
+        }));
+        if (LIVE_MODALITY === "voice") {
+          expect(turnsInSpeakerOrder(normalizedPublicCustomerTurns)).toEqual(
+            turnsInSpeakerOrder(nativeTurns),
+          );
+        } else {
+          expect(normalizedPublicCustomerTurns).toEqual(nativeTurns);
+        }
         const nativeCalls = history.filter((item) => item.type === "function_call");
         const nativeOutputs = history.filter((item) => item.type === "function_call_output");
         const outputsByCall = new Map(nativeOutputs.map((item) => [
@@ -1753,7 +1810,9 @@ describe.skipIf(!storage.available)("the shipped simulator against the real API"
             ...(artifact === undefined ? {} : { artifact }),
             ...(runtime === undefined ? {} : { runtime }),
             outcomes: {
-              simulation: "failed",
+              simulation: typeof diagnosticEvidence?.status === "string"
+                ? diagnosticEvidence.status
+                : "unknown",
               failureType: failure instanceof Error ? failure.name : "unknown",
             },
             ...(diagnosticEvidence === undefined ? {} : {

--- a/apps/simulator/src/egma_simulator/conductor.py
+++ b/apps/simulator/src/egma_simulator/conductor.py
@@ -836,6 +836,10 @@ class _PersonaReplyGate(FrameProcessor):
 
     async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
         await super().process_frame(frame, direction)
+        if direction == FrameDirection.DOWNSTREAM and isinstance(
+            frame, InterruptionFrame
+        ):
+            self._conductor.persona_will_not_finish()
         if direction != FrameDirection.DOWNSTREAM or self._waiting is None:
             await self.push_frame(frame, direction)
             return
@@ -1634,14 +1638,13 @@ class VoiceConductor:
         where the speech leg had already run to.
         """
         ended = self._persona_ended
-        if ended is None:
-            return
         began = self._persona_began
-        ended = min(ended, heard_through)
-        if began is not None and ended < began:
-            ended = began
-        self._record.persona_last_stopped_at = ended
-        self._record.quiet_since = max(self._record.quiet_since, ended)
+        if ended is not None:
+            ended = min(ended, heard_through)
+            if began is not None and ended < began:
+                ended = began
+            self._record.persona_last_stopped_at = ended
+            self._record.quiet_since = max(self._record.quiet_since, ended)
         self._pending_persona_text = None
         self._pending_persona_concludes = False
         self._pending_silence_follow_up = 0
@@ -1649,6 +1652,12 @@ class VoiceConductor:
         self._persona_ended = None
         self._owes_a_turn = False
         self.media_advanced()
+
+    def persona_will_not_finish(self) -> None:
+        """Forget transcript state before TTS completes an interrupted context."""
+        self._pending_persona_text = None
+        self._pending_persona_concludes = False
+        self._pending_silence_follow_up = 0
 
     async def persona_stopped(self) -> None:
         text, self._pending_persona_text = self._pending_persona_text, None

--- a/apps/simulator/tests/test_openai_tts_completion.py
+++ b/apps/simulator/tests/test_openai_tts_completion.py
@@ -8,6 +8,7 @@ import pytest
 from pipecat.frames.frames import (
     EndFrame,
     ErrorFrame,
+    InterruptionFrame,
     LLMFullResponseEndFrame,
     LLMFullResponseStartFrame,
     TextFrame,
@@ -125,6 +126,53 @@ class _Conductor:
 
     def media_advanced(self) -> None:
         pass
+
+
+class _PendingVoiceTurn(_Conductor):
+    def __init__(self) -> None:
+        super().__init__()
+        self._pending_persona_text = None
+        self._pending_persona_concludes = False
+        self._pending_silence_follow_up = 0
+        self._persona_began = None
+        self._persona_ended = None
+        self._owes_a_turn = True
+        self._record = SimpleNamespace(
+            persona_last_stopped_at=None,
+            quiet_since=0,
+            persona_response_pending=False,
+        )
+        self.turns: list[str] = []
+        self.stop_count = 0
+        self.stop_errors: list[BaseException] = []
+        self.interrupted = asyncio.Event()
+        self.interruption_finished = asyncio.Event()
+        conductor_module.VoiceConductor.persona_will_speak(self, "fixture reply")
+
+    persona_audio = conductor_module.VoiceConductor.persona_audio
+
+    def persona_interrupted(self, *, heard_through) -> None:
+        conductor_module.VoiceConductor.persona_interrupted(
+            self, heard_through=heard_through
+        )
+        self.interruption_finished.set()
+
+    def persona_will_not_finish(self) -> None:
+        conductor_module.VoiceConductor.persona_will_not_finish(self)
+        self.interrupted.set()
+
+    async def persona_stopped(self) -> None:
+        try:
+            await conductor_module.VoiceConductor.persona_stopped(self)
+        except BaseException as fault:
+            self.stop_errors.append(fault)
+            raise
+        finally:
+            self.stop_count += 1
+            self.stopped.set()
+
+    async def _took_a_turn(self, _speaker, text, *_positions, **_kwargs) -> None:
+        self.turns.append(text)
 
 
 class _Media:
@@ -264,6 +312,79 @@ async def test_openai_http_tts_cancellation_reaps_the_held_context() -> None:
     await asyncio.wait_for(running, 5)
 
     assert not tts._audio_contexts
+
+
+@pytest.mark.asyncio
+async def test_openai_interruption_before_audio_has_no_late_completion() -> None:
+    response = _HeldResponse()
+    next_response = _HeldResponse()
+    tts, _create = _openai_tts(response, next_response)
+    output = _AcceptedOutput()
+    recorder = conductor_module._EvidenceRecorder(
+        num_channels=2, auto_start_recording=True
+    )
+    conductor = _PendingVoiceTurn()
+    timeline = conductor_module._Timeline(conductor, _Media(), recorder)
+    replies = conductor_module._PersonaReplyGate(
+        service=SimpleNamespace(), conductor=conductor
+    )
+    worker = PipelineWorker(
+        Pipeline([replies, tts, output, PlayoutStamp(), recorder, timeline]),
+        enable_tracing=False,
+        enable_turn_tracking=False,
+        enable_rtvi=False,
+        idle_timeout_secs=None,
+    )
+    failed = asyncio.Event()
+
+    @worker.event_handler("on_pipeline_error")
+    async def on_error(_worker, _frame: ErrorFrame) -> None:
+        failed.set()
+
+    runner = WorkerRunner(handle_sigint=False)
+    await runner.add_workers(worker)
+    running = asyncio.create_task(runner.run())
+    try:
+        await worker.queue_frames(
+            [
+                LLMFullResponseStartFrame(),
+                TextFrame("fixture reply"),
+                LLMFullResponseEndFrame(),
+            ]
+        )
+        await asyncio.wait_for(response.entered.wait(), 1)
+        await worker.queue_frame(InterruptionFrame())
+        await asyncio.wait_for(conductor.interrupted.wait(), 1)
+        assert conductor._pending_persona_text is None
+        await asyncio.wait_for(conductor.stopped.wait(), 1)
+        await asyncio.wait_for(conductor.interruption_finished.wait(), 1)
+        assert conductor.stop_errors == []
+        assert not tts._audio_contexts
+        assert conductor.turns == []
+
+        conductor.stopped.clear()
+        conductor_module.VoiceConductor.persona_will_speak(conductor, "Next reply")
+        await worker.queue_frames(
+            [
+                LLMFullResponseStartFrame(),
+                TextFrame("Next reply"),
+                LLMFullResponseEndFrame(),
+            ]
+        )
+        await asyncio.wait_for(next_response.entered.wait(), 1)
+        next_response.first.set()
+        await asyncio.wait_for(next_response.first_sent.wait(), 1)
+        next_response.middle.set()
+        await asyncio.wait_for(next_response.ended.wait(), 1)
+        await asyncio.wait_for(conductor.stopped.wait(), 1)
+        assert conductor.stop_errors == []
+        assert not failed.is_set()
+        assert conductor.stop_count == 2
+        assert conductor.turns == ["Next reply"]
+    finally:
+        if not running.done():
+            await worker.cancel()
+        await asyncio.wait_for(running, 1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A customer interruption before the persona's first audio could leave a pending transcript behind. Pipecat then delivered the canceled TTS completion, and Egma treated it as a speech request that finished without audio. Clear pending speech intent before forwarding the interruption, then reset the remaining speech state at the recorded interruption boundary. Uninterrupted empty audio still fails.

The voice E2E now compares every native customer turn in order for each speaker, allowing overlapping speakers to have different combined orders. Chat keeps exact ordering. Failure artifacts retain the simulation's known terminal status if a later evidence or grading assertion fails.

Validation:

- A deterministic test through the real Pipecat TTS/output/recording pipeline reproduces the exact failure on the old code and passes with the fix. It also verifies that the next spoken response records normally.
- Independent Sol reviews completed for both changes.
- All six paid simulation-to-grading E2Es passed locally: Python and JavaScript chat/voice on LiveKit Agents 1.7.1, plus Retell text/web, with mocks enabled.
- Full simulator suite: 999 passed, 7 skipped. Focused TypeScript regressions, simulator/API-test lint, and test TypeScript compilation passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791685067&installation_model_id=431960&pr_number=348&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F348&signature=8b0b565c1b73115e38556c5b840fea2e595a3b70a29168d59e2535f2c22ccd0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects voice interruption handling before persona audio begins and updates end-to-end diagnostics and transcript comparisons.
- Clears pending persona speech intent before an interruption continues through the TTS/output pipeline.
- Resets remaining speech and turn state at the interruption boundary even when no audio began.
- Adds a deterministic regression test covering canceled TTS completion and the next successful reply.
- Retains terminal simulation status in failure artifacts and permits voice transcript ordering differences between overlapping speakers.

<h3>Confidence Score: 4/5</h3>

The production interruption fix appears safe to merge, with a non-blocking test-quality concern in the voice transcript comparison.

The new conductor behavior is covered through the real TTS/output/recording pipeline and no production failure remains, but the revised voice E2E can accept causally impossible cross-speaker transcript ordering.

**Files Needing Attention:** apps/api/test/simulator-conversation.test.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/simulator/src/egma_simulator/conductor.py | Clears pending transcript state before forwarding interruptions and completes speech-state cleanup even when interrupted audio never began. |
| apps/simulator/tests/test_openai_tts_completion.py | Adds pipeline-level regression coverage for pre-audio interruption, late TTS completion, and successful subsequent speech. |
| apps/api/test/simulator-conversation.test.ts | Improves terminal-status diagnostics but weakens voice transcript validation by discarding all cross-speaker ordering constraints. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Persona reply pending] --> B[TTS request]
  B --> C{Customer interrupts}
  C -->|Before audio| D[Reply gate clears pending speech intent]
  D --> E[TTS cancellation completes]
  E --> F[Timeline resets speech state at interruption boundary]
  F --> G[No canceled persona turn recorded]
  G --> H[Next persona reply proceeds normally]
  C -->|No interruption| I[Audio begins and completes]
  I --> J[Persona turn recorded]
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22egma-ai%2Fegma%22%20on%20the%20existing%20branch%20%22codex%2Ffix-voice-e2e-boundaries%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-voice-e2e-boundaries%22.%0A%0AGreploop%20egma-ai%2Fegma%20PR%20%23348%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=egma-ai%2Fegma&pr=348&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22egma-ai%2Fegma%22%20on%20the%20existing%20branch%20%22codex%2Ffix-voice-e2e-boundaries%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-voice-e2e-boundaries%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Fapi%2Ftest%2Fsimulator-conversation.test.ts%3A1688-1692%0A**Voice%20ordering%20is%20underchecked**%0A%0AFor%20voice%20runs%2C%20this%20comparison%20splits%20the%20transcript%20into%20independent%20speaker%20sequences%20and%20loses%20all%20ordering%20between%20speakers.%20It%20can%20therefore%20accept%20an%20agent%20response%20recorded%20before%20its%20non-overlapping%20customer%20prompt%2C%20as%20long%20as%20each%20speaker's%20own%20turns%20remain%20in%20order.%20This%20weakens%20the%20E2E%20because%20it%20no%20longer%20catches%20causally%20invalid%20transcript%20ordering%3B%20retain%20enough%20timing%20or%20overlap%20information%20to%20allow%20only%20differences%20caused%20by%20actual%20overlap.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=egma-ai%2Fegma&pr=348&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fapi%2Ftest%2Fsimulator-conversation.test.ts%3A1688-1692%0A**Voice%20ordering%20is%20underchecked**%0A%0AFor%20voice%20runs%2C%20this%20comparison%20splits%20the%20transcript%20into%20independent%20speaker%20sequences%20and%20loses%20all%20ordering%20between%20speakers.%20It%20can%20therefore%20accept%20an%20agent%20response%20recorded%20before%20its%20non-overlapping%20customer%20prompt%2C%20as%20long%20as%20each%20speaker's%20own%20turns%20remain%20in%20order.%20This%20weakens%20the%20E2E%20because%20it%20no%20longer%20catches%20causally%20invalid%20transcript%20ordering%3B%20retain%20enough%20timing%20or%20overlap%20information%20to%20allow%20only%20differences%20caused%20by%20actual%20overlap.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=egma-ai%2Fegma&pr=348&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix pre-audio persona interruptions"](https://github.com/egma-ai/egma/commit/2dc13e4144fe42b81c1343f83ac47ecb6859736a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62907702)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Simulation platform](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/simulation-platform.md)
- Knowledge Base — [Simulator execution pipeline](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/simulator-execution.md)

<!-- /greptile_comment -->