### PR TITLE
Tests grid: personas as chips with a cross to remove

### DIFF
--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { XIcon } from "lucide-react";
 import {
   Fragment,
   useCallback,
@@ -17,6 +18,7 @@ import {
   updateTest,
 } from "@egma/platform-api/client";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -169,9 +171,14 @@ const COLUMNS: readonly {
     width: "24%",
     required: true,
   },
-  { field: "personas", header: "Personas", width: "12%", required: true },
-  { field: "mockTools", header: "Mock tools", width: "15%", required: false },
-  { field: "env", header: "Env", width: "15%", required: false },
+  /*
+   * Wide enough for a persona's name to stand on one chip: at 12% every
+   * chip truncated to its first word. The two JSON columns lent the width;
+   * they mostly read `None`.
+   */
+  { field: "personas", header: "Personas", width: "18%", required: true },
+  { field: "mockTools", header: "Mock tools", width: "12%", required: false },
+  { field: "env", header: "Env", width: "12%", required: false },
 ];
 
 /**
@@ -423,17 +430,22 @@ function PersonaPicker({
       <PopoverTrigger asChild>
         <button
           className={ADD_LINE}
+          /*
+           * Marked, because the chips above take the caret back here when a
+           * removal leaves no cross to hold it. The grid's own markers are
+           * plain data attributes; `data-slot` belongs to the primitive.
+           */
+          data-persona-add=""
           type="button"
           /* The cell owns its own caret; opening must not move it first. */
           onMouseDown={(event) => event.preventDefault()}
         >
           {/*
-           * A cell that already names somebody opens a panel that both adds and
-           * removes, so the trigger says editing rather than adding. An empty
-           * one — the entry row, before anybody has been named — keeps the
-           * grid's own add line, because adding is all it can do.
+           * The panel adds, and the chips above remove, so the trigger says
+           * the one thing it does — on a cell that names nobody and on a cell
+           * that already names three.
            */}
-          {chosen.length === 0 ? "+ Add a persona" : "Edit personas"}
+          + Add a persona
         </button>
       </PopoverTrigger>
       <PopoverContent
@@ -459,12 +471,8 @@ function PersonaPicker({
   );
 }
 
-/** Why the only persona a test names cannot be taken off it. */
-const LAST_PERSONA = "A test needs at least one persona";
-
 /**
- * What the open picker holds: who is on the test, the search, the people, and
- * the way out.
+ * What the open picker holds: the search, the people, and the way out.
  *
  * It is its own component so that the read below runs when a panel opens
  * rather than when the grid draws, which is the difference between one request
@@ -488,21 +496,6 @@ function PersonaChoices({
   const [refused, setRefused] = useState<string | null>(null);
   /** Whether egma holds more than this picker read. Said out loud if so. */
   const [truncated, setTruncated] = useState(false);
-  const panel = useRef<HTMLDivElement>(null);
-  const said = useId();
-
-  /*
-   * **Who the test names now, built from the row rather than from the list
-   * below.** The list holds the project's available personas, and a test can
-   * name one the project has since deleted — which is exactly the test that
-   * cannot be saved again until that persona comes off it. Reading the row
-   * puts the deleted one on screen, with its own way out.
-   */
-  const onTest: readonly Named[] = chosen.map(
-    (id) => known.get(id) ?? { id, name: id },
-  );
-  /** The last persona standing stays: a test says who calls. */
-  const onlyOne = onTest.length === 1;
 
   /*
    * **Every persona the project holds, not the first page of them.**
@@ -573,63 +566,8 @@ function PersonaChoices({
     onChange(next, named);
   }
 
-  /**
-   * Take one persona off the test, and hold the caret inside the open panel.
-   *
-   * The row that was pressed is about to leave. Radix reads focus falling to
-   * the body as focus leaving the panel, so the caret goes to the search
-   * field, which outlives every row here.
-   */
-  function remove(one: Named): void {
-    toggle(one);
-    panel.current
-      ?.querySelector<HTMLInputElement>('[data-slot="command-input"]')
-      ?.focus();
-  }
-
   return (
-    <div className="flex flex-col" ref={panel}>
-      {onTest.length === 0 ? null : (
-        <div className="border-b border-border">
-          <p className="m-0 px-2.5 pt-2 pb-1 text-sm text-faint" id={said}>
-            On this test
-          </p>
-          {/* Bounded and scrolling, as the list below it is: a test may name
-              more callers than a panel can hold. */}
-          <ul
-            className="m-0 max-h-40 list-none overflow-y-auto p-0"
-            aria-labelledby={said}
-          >
-            {onTest.map((one) => (
-              <li
-                className="flex flex-wrap items-center gap-x-2 px-2.5 pb-1"
-                key={one.id}
-              >
-                <span className="min-w-0 flex-1 truncate text-sm text-foreground">
-                  {one.name}
-                  {one.archivedAt === null || one.archivedAt === undefined ? null : (
-                    // The test still names somebody the project has deleted.
-                    // Saying so is what makes the Remove beside it make sense.
-                    <span className="text-faint"> (deleted)</span>
-                  )}
-                </span>
-                <Button
-                  aria-label={`Remove ${one.name}`}
-                  className="px-0"
-                  disabled={onlyOne}
-                  onClick={() => remove(one)}
-                  size="sm"
-                  type="button"
-                  variant="link"
-                  {...(onlyOne ? { why: LAST_PERSONA } : {})}
-                >
-                  Remove
-                </Button>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+    <>
       {/*
        * **`label` names the search field, not the list, and that is `cmdk`'s
        * doing rather than a choice made here.** It renders the prop into a
@@ -711,7 +649,7 @@ function PersonaChoices({
           </button>
         </div>
       </Command>
-    </div>
+    </>
   );
 }
 /**
@@ -834,12 +772,148 @@ function BehaviorLines({
   );
 }
 
-/** The names a Personas cell shows, in the order they were authored. */
-function personaNames(
-  ids: readonly string[],
-  known: ReadonlyMap<string, Named>,
-): string {
-  return ids.map((id) => known.get(id)?.name ?? id).join(", ");
+/**
+ * The personas a cell names, as chips in the order the test names them.
+ *
+ * A woken cell grows a cross on each chip, and pressing one is the whole of
+ * taking that persona off: removal was a hunt through the picker before, which
+ * is a long way round for the commonest edit a Personas cell has.
+ */
+function PersonaChips({
+  ids,
+  known,
+  stored,
+  removable,
+  onRemove,
+}: {
+  readonly ids: readonly string[];
+  readonly known: ReadonlyMap<string, Named>;
+  /** The personas the row already holds, so only a new chip arrives. */
+  readonly stored: readonly string[];
+  /** Whether each chip carries a cross, which is what takes it off. */
+  readonly removable: boolean;
+  readonly onRemove: (id: string) => void;
+}) {
+  const crosses = useRef<(HTMLButtonElement | null)[]>([]);
+  /** The cell around the chips, held while the list stands. */
+  const around = useRef<HTMLElement | null>(null);
+  /**
+   * Which cross the caret is owed, and it is always one that just moved.
+   *
+   * The cross that was pressed is about to leave. Holding the index rather
+   * than an element is what lets the caret land on the chip that took its
+   * place, or on the one above when the last chip went.
+   */
+  const [caretAt, setCaretAt] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (caretAt === null) return;
+    const cross = crosses.current[caretAt];
+    setCaretAt(null);
+    if (cross !== null && cross !== undefined) {
+      cross.focus();
+      return;
+    }
+    /*
+     * Nothing left to hold the caret: the last persona on a stored test keeps
+     * no cross, and an emptied entry row has no chip at all. The add line is
+     * the cell's other way in, and the caret has to stay inside the cell —
+     * dropped to the body it blurs the cell, and a blur is a commit.
+     */
+    around.current?.querySelector<HTMLButtonElement>("[data-persona-add]")?.focus();
+  }, [caretAt, ids]);
+
+  if (ids.length === 0) return null;
+
+  return (
+    <ul
+      aria-label="Personas"
+      className="m-0 flex list-none flex-wrap gap-1 p-0"
+      ref={(node) => {
+        if (node !== null) around.current = node.parentElement;
+      }}
+    >
+      {ids.map((id, at) => {
+        const one = known.get(id);
+        const name = one?.name ?? id;
+        return (
+          <Badge
+            asChild
+            className={cn(
+              /* A persona's name is the record's name, not a state word. */
+              "max-w-full text-foreground",
+              /*
+               * On a coarse pointer the cross grows to the tap target, so the
+               * chip grows with it and lets the name wrap rather than truncate.
+               */
+              removable && "gap-1 pointer-coarse:h-auto pointer-coarse:min-h-(--tap-target)",
+            )}
+            key={id}
+            shape="count"
+            variant="neutral"
+          >
+            <li
+              data-slot="persona-chip"
+              /* A chip the row already holds is simply there; a just-chosen
+                 one arrives, which is what the theme's rule animates. */
+              {...(stored.includes(id) ? {} : { "data-arrived": "" })}
+            >
+              <span
+                className={cn(
+                  "min-w-0 truncate",
+                  removable && "pointer-coarse:whitespace-normal",
+                )}
+              >
+                {name}
+                {typeof one?.archivedAt === "string" ? (
+                  // The test still names somebody the project has deleted.
+                  // Saying so is what makes the cross beside it make sense.
+                  <span className="text-faint"> (deleted)</span>
+                ) : null}
+              </span>
+              {removable ? (
+                <button
+                  aria-label={`Remove ${name}`}
+                  className={cn(
+                    "inline-flex size-4 shrink-0 cursor-pointer items-center justify-center",
+                    "border-0 bg-transparent p-0 text-muted-foreground",
+                    /* Half of the chip's own side padding, so the cross sits
+                       inside the edge rather than a word's width from it. */
+                    "-mr-1",
+                    "transition-[color] duration-(--duration-hover) ease-out",
+                    /* Ember under a pointer, as a cell link and the add line are. */
+                    "pointer-hover:text-primary motion-reduce:transition-none",
+                    /* The tap target's height, as the Button keeps it; the
+                       width stays modest so the name keeps its room. */
+                    "pointer-coarse:h-(--tap-target) pointer-coarse:w-8",
+                  )}
+                  data-slot="persona-chip-remove"
+                  /* The cell owns its own caret; a press here must not move it. */
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => {
+                    /*
+                     * The chip leaves on the press and nothing fades it out:
+                     * a removal is a many-times-a-day edit, and a ghost chip
+                     * would still have to be answered for if the draft it
+                     * belongs to is reverted or refused.
+                     */
+                    setCaretAt(at === ids.length - 1 ? Math.max(at - 1, 0) : at);
+                    onRemove(id);
+                  }}
+                  ref={(node) => {
+                    crosses.current[at] = node;
+                  }}
+                  type="button"
+                >
+                  <XIcon aria-hidden="true" className="size-3" />
+                </button>
+              ) : null}
+            </li>
+          </Badge>
+        );
+      })}
+    </ul>
+  );
 }
 
 /**
@@ -853,6 +927,7 @@ function CellBody({
   woken,
   draft,
   known,
+  stored,
   projectId,
   owner,
   picking,
@@ -867,6 +942,8 @@ function CellBody({
   readonly woken: boolean;
   readonly draft: Draft;
   readonly known: ReadonlyMap<string, Named>;
+  /** The personas the stored row names, which the draft may have moved past. */
+  readonly stored: readonly string[];
   readonly projectId: string;
   /** This row's test id, which is what its picking is held under. */
   readonly owner: string;
@@ -957,7 +1034,7 @@ function CellBody({
 
   return (
     <div
-      className="relative flex flex-col gap-0.5"
+      className="relative flex min-w-0 flex-col gap-0.5"
       onKeyDown={(event) => {
         if (!woken || event.key !== "Escape") return;
         event.preventDefault();
@@ -965,9 +1042,27 @@ function CellBody({
         onCancel();
       }}
     >
-      <span className={cn(TEXT, VIEW_TEXT)}>
-        {personaNames(draft.personas, known)}
-      </span>
+      {/*
+       * The same list in both states, in the same place, so waking the cell
+       * grows the crosses on the chips that are already there rather than
+       * drawing the chips again.
+       */}
+      <PersonaChips
+        ids={draft.personas}
+        known={known}
+        stored={stored}
+        /*
+         * A test says who calls, so the one persona it has left keeps no
+         * cross. Unticking that persona in the picker is what says why.
+         */
+        removable={woken && draft.personas.length > 1}
+        onRemove={(id) =>
+          onChange({
+            ...draft,
+            personas: draft.personas.filter((one) => one !== id),
+          })
+        }
+      />
       {woken ? (
         <PersonaPicker
           projectId={projectId}
@@ -1812,6 +1907,7 @@ export function TestsGrid(props: GridProps) {
             woken={woken}
             draft={draft}
             known={known}
+            stored={test.personas.map((persona) => persona.id)}
             projectId={projectId}
             owner={test.id}
             picking={woken && picking === test.id}
@@ -1948,8 +2044,24 @@ export function TestsGrid(props: GridProps) {
               onCancel={askToDiscard}
             />
           ) : (
-            <div className="relative flex flex-col gap-0.5">
-              <span className={TEXT}>{personaNames(entry.personas, known)}</span>
+            <div className="relative flex min-w-0 flex-col gap-0.5">
+              <PersonaChips
+                ids={entry.personas}
+                known={known}
+                /* Nothing here is written yet: every chip is one just chosen. */
+                stored={[]}
+                /*
+                 * Every chip here can go. The row is not a test yet, and its
+                 * own Save is what says it needs one persona.
+                 */
+                removable
+                onRemove={(id) =>
+                  setEntry({
+                    ...entry,
+                    personas: entry.personas.filter((one) => one !== id),
+                  })
+                }
+              />
               <PersonaPicker
                 projectId={projectId}
                 chosen={entry.personas}

--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -458,6 +458,22 @@ function PersonaPicker({
          * caret after opening. Pointer dismissal and Escape still close the picker.
          */
         onFocusOutside={(event) => event.preventDefault()}
+        /*
+         * A cross on the cell's own chips is part of this editing surface, so
+         * pressing one does not shut the panel: the persona leaves the draft,
+         * its row unticks, and closing still commits. Left to dismiss, the
+         * close would commit and rest the cell before the press could remove
+         * anybody, and the removal would be lost.
+         */
+        onPointerDownOutside={(event) => {
+          const pressed = event.detail.originalEvent.target;
+          if (
+            pressed instanceof Element &&
+            pressed.closest('[data-slot="persona-chip-remove"]') !== null
+          ) {
+            event.preventDefault();
+          }
+        }}
       >
         <PersonaChoices
           projectId={projectId}

--- a/apps/web/test/test-suites-pages.test.tsx
+++ b/apps/web/test/test-suites-pages.test.tsx
@@ -2137,6 +2137,74 @@ describe("the suite-first Tests route", () => {
     });
   });
 
+  it("keeps the picker open when a cross is pressed beside it, and saves both on Done", async () => {
+    const BEN = { id: "prs_2", name: "Calm Ben", archivedAt: null };
+    const CHRIS = { id: "prs_3", name: "Careful Chris", archivedAt: null };
+    routed.pathname = "/projects/prj_1/tests/suites/ste_1";
+    routed.params = { projectId: "prj_1", suiteId: "ste_1" };
+    answers({
+      "/api/me": { status: 200, body: meWith("admin") },
+      "/v1/test-suites/ste_1": { status: 200, body: suiteBody() },
+      "/v1/tests": {
+        status: 200,
+        body: { tests: [testBody({ personas: [PERSONA, BEN] })], nextPageToken: null },
+      },
+      "/v1/tests/tst_1": {
+        status: 200,
+        body: testBody({ personas: [PERSONA, CHRIS], version: 2, versionId: "tstv_2" }),
+      },
+      "/v1/personas": {
+        status: 200,
+        body: { personas: [PERSONA, BEN, CHRIS], nextPageToken: null },
+      },
+    });
+
+    render(<TestSuitePage />);
+
+    expect(await screen.findByText("Books service")).toBeTruthy();
+    const written = screen.getByText("Books service").closest("tr");
+    if (written === null) throw new Error("the test's row is not on screen");
+    fireEvent.click(within(written).getByText("Impatient Rita"));
+    fireEvent.click(within(written).getByRole("button", { name: "+ Add a persona" }));
+    const panel = await screen.findByRole("dialog", { name: "Choose personas" });
+    fireEvent.click(await within(panel).findByRole("option", { name: "Careful Chris" }));
+
+    /*
+     * A real press on a cross is a pointerdown before the click, and pointerdown
+     * is what the open panel would dismiss on. It must not: dismissal commits,
+     * an unchanged draft rests the cell, and the click would then land on a
+     * cross that no longer exists.
+     */
+    const cross = within(written).getByRole("button", { name: "Remove Calm Ben" });
+    fireEvent.pointerDown(cross);
+    fireEvent.mouseDown(cross);
+    fireEvent.click(cross);
+
+    // The panel stands, the chip is gone, its row is unticked, nothing is sent.
+    expect(screen.getAllByRole("dialog", { name: "Choose personas" })).toHaveLength(1);
+    expect(
+      within(written)
+        .getAllByRole("listitem")
+        .map((chip) => chip.textContent),
+    ).toEqual(["Impatient Rita", "Careful Chris"]);
+    expect(
+      within(panel).getByRole("option", { name: "Calm Ben" }).getAttribute("aria-checked"),
+    ).toBe("false");
+    expect(sent.some((request) => request.method === "PATCH")).toBe(false);
+
+    // Done commits the tick and the removal together, as one save.
+    fireEvent.click(within(panel).getByRole("button", { name: "Done" }));
+    await waitFor(() => {
+      expect(sent.filter((request) => request.method === "PATCH")).toEqual([
+        {
+          path: "/v1/tests/tst_1",
+          method: "PATCH",
+          body: { personas: ["prs_1", "prs_3"], expectedVersionId: "tstv_1" },
+        },
+      ]);
+    });
+  });
+
   it("holds the caret in the cell when a cross takes the chip it stood on", async () => {
     const BEN = { id: "prs_2", name: "Calm Ben", archivedAt: null };
     const CHRIS = { id: "prs_3", name: "Careful Chris", archivedAt: null };

--- a/apps/web/test/test-suites-pages.test.tsx
+++ b/apps/web/test/test-suites-pages.test.tsx
@@ -1947,7 +1947,7 @@ describe("the suite-first Tests route", () => {
     const written = screen.getByText("Books service").closest("tr");
     if (written === null) throw new Error("the test's row is not on screen");
     fireEvent.click(within(written).getByText("Impatient Rita"));
-    fireEvent.click(within(written).getByRole("button", { name: "Edit personas" }));
+    fireEvent.click(within(written).getByRole("button", { name: "+ Add a persona" }));
 
     await waitFor(() => {
       expect(screen.getAllByRole("dialog", { name: "Choose personas" })).toHaveLength(1);
@@ -1989,7 +1989,7 @@ describe("the suite-first Tests route", () => {
     const written = screen.getByText("Books service").closest("tr");
     if (written === null) throw new Error("the test's row is not on screen");
     fireEvent.click(within(written).getByText("Impatient Rita"));
-    fireEvent.click(within(written).getByRole("button", { name: "Edit personas" }));
+    fireEvent.click(within(written).getByRole("button", { name: "+ Add a persona" }));
     fireEvent.click(await screen.findByRole("option", { name: "Calm Ben" }));
     expect(sent.some((request) => request.method === "PATCH")).toBe(false);
 
@@ -2040,6 +2040,55 @@ describe("the suite-first Tests route", () => {
     expect(entryTrigger.getAttribute("aria-expanded")).toBe("true");
   });
 
+  it("keeps the chips quiet at rest, and grows a cross on each when the cell wakes", async () => {
+    const BEN = { id: "prs_2", name: "Calm Ben", archivedAt: null };
+    gridAnswers({ tests: [testBody({ personas: [PERSONA, BEN] })] });
+
+    render(<TestSuitePage />);
+
+    expect(await screen.findByText("Books service")).toBeTruthy();
+    const written = screen.getByText("Books service").closest("tr");
+    if (written === null) throw new Error("the test's row is not on screen");
+
+    // A row nobody is editing offers nothing: the chips say who calls, in the
+    // order the test names them, and carry no control at all.
+    const chips = within(written).getAllByRole("listitem");
+    expect(chips.map((chip) => chip.textContent)).toEqual([
+      "Impatient Rita",
+      "Calm Ben",
+    ]);
+    expect(
+      within(written).queryAllByRole("button", { name: /^Remove / }),
+    ).toHaveLength(0);
+    // Nothing on a stored row arrives, so no chip animates on a page load.
+    // The slot is what the theme keys the arrival and the press feedback to.
+    expect(chips.map((chip) => chip.getAttribute("data-slot"))).toEqual([
+      "persona-chip",
+      "persona-chip",
+    ]);
+    expect(chips.map((chip) => chip.hasAttribute("data-arrived"))).toEqual([
+      false,
+      false,
+    ]);
+
+    fireEvent.click(within(written).getByText("Impatient Rita"));
+
+    const crosses = within(written).getAllByRole("button", { name: /^Remove / });
+    expect(crosses.map((cross) => cross.getAttribute("aria-label"))).toEqual([
+      "Remove Impatient Rita",
+      "Remove Calm Ben",
+    ]);
+    expect(crosses.map((cross) => cross.getAttribute("data-slot"))).toEqual([
+      "persona-chip-remove",
+      "persona-chip-remove",
+    ]);
+    // The very same chips: the list is drawn in one place in both states, so
+    // waking a cell grows the crosses rather than drawing the chips again.
+    const awake = within(written).getAllByRole("listitem");
+    expect(awake[0]).toBe(chips[0]);
+    expect(awake[1]).toBe(chips[1]);
+  });
+
   it("takes a persona off a woken cell and commits the rest in their order", async () => {
     const BEN = { id: "prs_2", name: "Calm Ben", archivedAt: null };
     const CHRIS = { id: "prs_3", name: "Careful Chris", archivedAt: null };
@@ -2060,33 +2109,22 @@ describe("the suite-first Tests route", () => {
     expect(await screen.findByText("Books service")).toBeTruthy();
     const written = screen.getByText("Books service").closest("tr");
     if (written === null) throw new Error("the test's row is not on screen");
-    fireEvent.click(
-      within(written).getByText("Impatient Rita, Calm Ben, Careful Chris"),
-    );
+    fireEvent.click(within(written).getByText("Impatient Rita"));
 
-    // The way in says what the panel does. A cell that already names somebody
-    // is edited, not only added to.
-    expect(
-      within(written).queryByRole("button", { name: "+ Add a persona" }),
-    ).toBeNull();
-    fireEvent.click(within(written).getByRole("button", { name: "Edit personas" }));
-
-    // The panel opens on who is on the test, in the order the test names them.
-    const panel = await screen.findByRole("dialog", { name: "Choose personas" });
-    expect(
-      within(panel)
-        .getAllByRole("listitem")
-        .map((row) => row.textContent),
-    ).toEqual(["Impatient RitaRemove", "Calm BenRemove", "Careful ChrisRemove"]);
-
-    fireEvent.click(within(panel).getByRole("button", { name: "Remove Calm Ben" }));
+    fireEvent.click(within(written).getByRole("button", { name: "Remove Calm Ben" }));
 
     // Taking somebody off a test is an edit, not a destruction: nothing is
-    // asked, and nothing is sent until the panel shuts, exactly as unticking.
-    expect(screen.queryAllByRole("dialog")).toHaveLength(1);
+    // asked, and nothing is sent until the cell is left, exactly as unticking.
+    expect(screen.queryAllByRole("dialog")).toHaveLength(0);
     expect(sent.some((request) => request.method === "PATCH")).toBe(false);
+    expect(
+      within(written)
+        .getAllByRole("listitem")
+        .map((chip) => chip.textContent),
+    ).toEqual(["Impatient Rita", "Careful Chris"]);
 
-    fireEvent.click(within(panel).getByRole("button", { name: "Done" }));
+    // The page's own background takes no focus, so leaving is the press itself.
+    fireEvent.pointerDown(document.body);
 
     await waitFor(() => {
       expect(sent.filter((request) => request.method === "PATCH")).toEqual([
@@ -2099,6 +2137,50 @@ describe("the suite-first Tests route", () => {
     });
   });
 
+  it("holds the caret in the cell when a cross takes the chip it stood on", async () => {
+    const BEN = { id: "prs_2", name: "Calm Ben", archivedAt: null };
+    const CHRIS = { id: "prs_3", name: "Careful Chris", archivedAt: null };
+    gridAnswers({ tests: [testBody({ personas: [PERSONA, BEN, CHRIS] })] });
+
+    render(<TestSuitePage />);
+
+    expect(await screen.findByText("Books service")).toBeTruthy();
+    const written = screen.getByText("Books service").closest("tr");
+    if (written === null) throw new Error("the test's row is not on screen");
+    fireEvent.click(within(written).getByText("Impatient Rita"));
+
+    /*
+     * The caret goes to the chip that took the removed one's place. Dropped to
+     * the body it would blur the cell, and a blur commits — so a keyboard
+     * removal would save itself the moment it happened.
+     */
+    const ben = within(written).getByRole("button", { name: "Remove Calm Ben" });
+    ben.focus();
+    fireEvent.click(ben);
+    expect(document.activeElement).toBe(
+      within(written).getByRole("button", { name: "Remove Careful Chris" }),
+    );
+    expect(document.querySelector("[data-woken-cell]")).not.toBeNull();
+
+    // One persona has to stay, so the chip left behind carries no cross. The
+    // add line takes the caret instead, and it is still inside the cell.
+    fireEvent.click(
+      within(written).getByRole("button", { name: "Remove Careful Chris" }),
+    );
+    const add = within(written).getByRole("button", { name: "+ Add a persona" });
+    expect(document.activeElement).toBe(add);
+    expect(sent.some((request) => request.method === "PATCH")).toBe(false);
+
+    // Escape reverts the cell, chips and all: nothing was sent, so the test
+    // still names everybody it named.
+    fireEvent.keyDown(add, { key: "Escape" });
+    expect(
+      within(written)
+        .getAllByRole("listitem")
+        .map((chip) => chip.textContent),
+    ).toEqual(["Impatient Rita", "Calm Ben", "Careful Chris"]);
+  });
+
   it("keeps the one persona a test has left, and says why on the row", async () => {
     gridAnswers();
 
@@ -2108,26 +2190,56 @@ describe("the suite-first Tests route", () => {
     const written = screen.getByText("Books service").closest("tr");
     if (written === null) throw new Error("the test's row is not on screen");
     fireEvent.click(within(written).getByText("Impatient Rita"));
-    fireEvent.click(within(written).getByRole("button", { name: "Edit personas" }));
 
+    // The last persona standing carries no cross: a test says who calls.
+    expect(
+      within(written).queryByRole("button", { name: "Remove Impatient Rita" }),
+    ).toBeNull();
+
+    // Unticking that persona in the picker is the way somebody still tries, so
+    // that is where the refusal is answered, on the row and out loud.
+    fireEvent.click(within(written).getByRole("button", { name: "+ Add a persona" }));
     const panel = await screen.findByRole("dialog", { name: "Choose personas" });
-    const remove = within(panel).getByRole("button", {
-      name: "Remove Impatient Rita",
-    }) as HTMLButtonElement;
-    expect(remove.disabled).toBe(true);
-
-    // The reason is drawn on the row and named by the button, so a keyboard
-    // and a screen reader reach it rather than only a resting pointer.
-    const why = within(panel).getByText("A test needs at least one persona");
-    expect(remove.getAttribute("aria-describedby")).toBe(why.id);
-
-    fireEvent.click(remove);
+    fireEvent.click(
+      await within(panel).findByRole("option", { name: "Impatient Rita" }),
+    );
     fireEvent.click(within(panel).getByRole("button", { name: "Done" }));
 
-    await waitFor(() => {
-      expect(screen.queryAllByRole("dialog", { name: "Choose personas" })).toHaveLength(0);
-    });
+    expect((await within(written).findByRole("alert")).textContent).toBe(
+      "A test needs at least one persona, because a test says who calls. The stored personas stand.",
+    );
     expect(sent.some((request) => request.method === "PATCH")).toBe(false);
+  });
+
+  it("lets the entry row take off every persona it named", async () => {
+    gridAnswers({ tests: [] });
+
+    render(<TestSuitePage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "+ Write a test" }));
+    fireEvent.click(screen.getByRole("button", { name: "+ Add a persona" }));
+    fireEvent.click(await screen.findByRole("option", { name: "Impatient Rita" }));
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+
+    // The row is not a test yet, so nothing has to stay: its one chip keeps
+    // its cross, and the caret lands on the way to name somebody again.
+    const cross = screen.getByRole("button", { name: "Remove Impatient Rita" });
+    // A persona somebody just chose is marked as having arrived, which is what
+    // the theme animates. A stored chip carries no such mark.
+    expect(cross.closest("li")?.hasAttribute("data-arrived")).toBe(true);
+    cross.focus();
+    fireEvent.click(cross);
+    expect(screen.queryByRole("button", { name: "Remove Impatient Rita" })).toBeNull();
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "+ Add a persona" }),
+    );
+
+    // The row's own Save is what says a test needs one persona.
+    const save = screen.getByRole("button", { name: "Save test" });
+    expect((save as HTMLButtonElement).disabled).toBe(true);
+    expect(
+      document.getElementById(save.getAttribute("aria-describedby") ?? "")?.textContent,
+    ).toContain("one persona");
   });
 
   it("shows a deleted persona a test still names, and takes it off", async () => {
@@ -2149,23 +2261,23 @@ describe("the suite-first Tests route", () => {
     expect(await screen.findByText("Books service")).toBeTruthy();
     const written = screen.getByText("Books service").closest("tr");
     if (written === null) throw new Error("the test's row is not on screen");
-    fireEvent.click(within(written).getByText("Impatient Rita, Retired Rae"));
-    fireEvent.click(within(written).getByRole("button", { name: "Edit personas" }));
+    fireEvent.click(within(written).getByText("Impatient Rita"));
 
+    // The chip says the persona is gone, which is what makes its cross make
+    // sense: the add list holds the project's available personas and nothing
+    // else, so the chip is the only place this one was ever reachable.
+    expect(within(written).getByText("(deleted)")).toBeTruthy();
+    fireEvent.click(within(written).getByRole("button", { name: "Remove Retired Rae" }));
+
+    fireEvent.click(within(written).getByRole("button", { name: "+ Add a persona" }));
     const panel = await screen.findByRole("dialog", { name: "Choose personas" });
-
-    // The add list holds the project's available personas and nothing else, so
-    // this one is reachable nowhere but the section that names the test's own.
     expect(await within(panel).findByRole("option", { name: "Impatient Rita" }))
       .toBeTruthy();
     expect(within(panel).queryByRole("option", { name: "Retired Rae" })).toBeNull();
-    expect(within(panel).getByText("(deleted)")).toBeTruthy();
-
-    fireEvent.click(within(panel).getByRole("button", { name: "Remove Retired Rae" }));
-    fireEvent.click(within(panel).getByRole("button", { name: "Done" }));
 
     // The deleted persona is what refuses every later edit of this test, and
-    // this is the one way it comes off.
+    // the cross is the one way it comes off.
+    fireEvent.click(within(panel).getByRole("button", { name: "Done" }));
     await waitFor(() => {
       expect(sent.filter((request) => request.method === "PATCH")).toEqual([
         {

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -730,11 +730,13 @@
    * exclusion: a button reached by keyboard fires without moving.
    */
   @media (hover: hover) and (pointer: fine) {
-    [data-slot="button"] {
+    [data-slot="button"],
+    [data-slot="persona-chip-remove"] {
       transition: transform var(--duration-press) var(--ease-out);
     }
 
-    [data-slot="button"]:active:not(:focus-visible):not(:disabled) {
+    [data-slot="button"]:active:not(:focus-visible):not(:disabled),
+    [data-slot="persona-chip-remove"]:active:not(:focus-visible):not(:disabled) {
       transform: scale(0.97);
     }
   }
@@ -996,6 +998,32 @@
 
   [data-preview="reduced-motion"] [data-slot="retell-account"],
   [data-preview="reduced-motion"] [data-slot="mock-tools-arrival"] {
+    animation: egma-fade-in var(--duration-hover) linear;
+  }
+
+  /*
+   * A persona chip somebody just chose, and the crosses a woken Personas cell
+   * grows on the chips already there.
+   *
+   * Both scale up from the place they appear in, on the popover pair: they are
+   * small anchored surfaces arriving where the eye already is. A chip the row
+   * already held carries no `data-arrived`, so nothing flutters on a page load
+   * or when a cell is woken.
+   */
+  [data-slot="persona-chip"][data-arrived],
+  [data-slot="persona-chip-remove"] {
+    animation: egma-anchored-in var(--duration-popover-in) var(--ease-out);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    [data-slot="persona-chip"][data-arrived],
+    [data-slot="persona-chip-remove"] {
+      animation: egma-fade-in var(--duration-hover) linear;
+    }
+  }
+
+  [data-preview="reduced-motion"] [data-slot="persona-chip"][data-arrived],
+  [data-preview="reduced-motion"] [data-slot="persona-chip-remove"] {
     animation: egma-fade-in var(--duration-hover) linear;
   }
 


### PR DESCRIPTION
## What changes

Removing a persona from a test is one press where the persona is, instead of a hunt through the picker.

- The Personas cell draws each persona as a chip: the shared `Badge` count chip, sharp-cornered, hairline, on the soft paper fill, in the order the test names them. At rest the chips are quiet and carry no control.
- Waking the cell grows a cross on every chip. Pressing a cross takes that persona off the cell's draft; the save happens when the cell is left (blur, a press elsewhere, or closing the picker), exactly as every other cell saves. Escape still reverts.
- `+ Add a persona` stays as it was, on every cell. The picker is an add panel again: the "On this test / Remove" section from #318 is gone, because the chips own removal now. Search, the checkbox list and Done are unchanged.
- The only persona left on a stored test carries no cross: a test says who calls. Unticking it in the picker still answers with the existing refusal. The entry row is not a test yet, so every chip there can go and its own Save says it needs one persona.
- A persona the project has deleted shows as `Name (deleted)` on its chip, and its cross is the one way it comes off.
- Keyboard: after a removal the caret moves to the cross that took the removed chip's place, or the one above, or the add line, so the cell stays woken and a keyboard removal does not blur-save itself. On a coarse pointer the cross grows to the 44px target height (the Button's own rule), the chip grows with it, and the name wraps instead of truncating.
- Pressing a cross while the picker is open does not dismiss the picker: the chip leaves, its row in the list unticks, and Done saves both as one change. Left to dismiss, the close committed and rested the cell before the press could remove anybody, and the removal was lost (Greptile's P1).
- The Personas column grows from 12% to 18%, lent by Mock tools and Env (15% to 12% each, they mostly read `None`): at 12% a chip truncated every name to its first word.
- Motion, on the theme's tokens: the crosses scale in from 0.97 over the popover-enter token when a cell wakes; a persona just chosen in the picker arrives the same way; a cross turns Ember under a pointer, as a cell link does, and answers a press with the button's scale. Stored chips never animate on load or wake. Reduced motion keeps an opacity fade. No exit animation: a removal is a many-times-a-day edit and the chip leaves on the press.

No API, contract or database change.

## Proof

- Focused grid tests: chips at rest without controls and the same elements growing crosses on wake, removal in order with the save on leaving the cell, the caret held inside the cell across removals, the last persona kept, the entry row emptied, the deleted persona taken off. 64 tests pass in `apps/web/test/test-suites-pages.test.tsx`.
- Web typecheck and lint pass. The rest of the suite runs in CI.
- Rendered on an isolated local stack through the real-browser harness: desktop light and dark, and an iPhone 13 touch profile, at rest, woken, cross hover and focus, after a removal, after the save, the single-persona cell and the entry row. No page errors. The shots are in `.proofs/persona-chips-2026-09-10/` on the developer's machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
