### PR TITLE
Stabilize persona simulator acceptance tests

### DIFF
--- a/apps/simulator/tests/test_interruption_acceptance.py
+++ b/apps/simulator/tests/test_interruption_acceptance.py
@@ -719,7 +719,7 @@ async def test_agent_stop_and_restart_during_deliberate_playout_preserves_one_ow
     tts.release.set()
     await asyncio.wait_for(tts.three_started.wait(), 1)
     connection.ended.set()
-    await asyncio.wait_for(running, 2.5)
+    await running
 
     assert tts.started_texts == [
         "Brief deliberate interruption.",

--- a/apps/simulator/tests/test_interruption_acceptance.py
+++ b/apps/simulator/tests/test_interruption_acceptance.py
@@ -719,7 +719,7 @@ async def test_agent_stop_and_restart_during_deliberate_playout_preserves_one_ow
     tts.release.set()
     await asyncio.wait_for(tts.three_started.wait(), 1)
     connection.ended.set()
-    await asyncio.wait_for(running, 1)
+    await asyncio.wait_for(running, 2.5)
 
     assert tts.started_texts == [
         "Brief deliberate interruption.",

--- a/apps/simulator/tests/test_live_livekit_background.py
+++ b/apps/simulator/tests/test_live_livekit_background.py
@@ -387,7 +387,8 @@ async def test_every_background_choice_reaches_one_real_caller_microphone_track(
         else:
             assert len(background_only) >= 10
             assert _rms(b"".join(background_only)) > 20
-            assert any(_rms(frame) > 20 for frame in remote.frames[:8])
+            # The assets fade in for 250 ms, so this window proves presence.
+            assert _rms(b"".join(remote.frames[:8])) > 1
             assert any(_rms(frame) > 20 for frame in remote.frames[20:])
     finally:
         await remote.close()

--- a/apps/simulator/tests/test_live_livekit_background.py
+++ b/apps/simulator/tests/test_live_livekit_background.py
@@ -56,6 +56,7 @@ from egma_simulator.speech import SCRIPTED_PAIR, encode_speech, voice_from_model
 
 SAMPLE_RATE = 24_000
 FRAME_SECONDS = 0.01
+PRE_SPEECH_BACKGROUND_FRAMES = round(0.3 / FRAME_SECONDS)
 
 
 def _token(key: str, secret: str, room: str, identity: str) -> str:
@@ -102,6 +103,8 @@ class _RemoteCapture:
     tracks: list[str] = field(default_factory=list)
     frames: list[bytes] = field(default_factory=list)
     frame_times: list[float] = field(default_factory=list)
+    background_before_speech: list[bytes] = field(default_factory=list)
+    frame_received: asyncio.Event = field(default_factory=asyncio.Event)
     subscribed: asyncio.Event = field(default_factory=asyncio.Event)
     stream: rtc.AudioStream | None = None
     reader: asyncio.Task[None] | None = None
@@ -287,6 +290,7 @@ async def _observer(server, room_name: str) -> _RemoteCapture:
             async for event in capture.stream:
                 capture.frames.append(bytes(event.frame.data))
                 capture.frame_times.append(time.monotonic())
+                capture.frame_received.set()
 
         capture.reader = asyncio.create_task(read())
         capture.subscribed.set()
@@ -338,7 +342,12 @@ async def _received_mix(
     running = asyncio.create_task(runner.run())
     try:
         await asyncio.wait_for(remote.subscribed.wait(), 5)
-        await asyncio.sleep(0.12)
+        async with asyncio.timeout(5):
+            while len(remote.frames) < PRE_SPEECH_BACKGROUND_FRAMES:
+                remote.frame_received.clear()
+                if len(remote.frames) < PRE_SPEECH_BACKGROUND_FRAMES:
+                    await remote.frame_received.wait()
+        remote.background_before_speech = list(remote.frames)
         speech = array("h", [8_000] * int(SAMPLE_RATE * 0.1)).tobytes()
         await worker.queue_frame(
             TTSAudioRawFrame(speech, sample_rate=SAMPLE_RATE, num_channels=1)
@@ -387,8 +396,7 @@ async def test_every_background_choice_reaches_one_real_caller_microphone_track(
         else:
             assert len(background_only) >= 10
             assert _rms(b"".join(background_only)) > 20
-            # The assets fade in for 250 ms, so this window proves presence.
-            assert _rms(b"".join(remote.frames[:8])) > 1
+            assert _rms(b"".join(remote.background_before_speech)) > 20
             assert any(_rms(frame) > 20 for frame in remote.frames[20:])
     finally:
         await remote.close()
@@ -424,8 +432,12 @@ async def test_remote_background_gain_and_recording_follow_submitted_audio(
             for kind, frame, _ in loud.frames
             if issubclass(kind, TTSAudioRawFrame)
         )
-        quiet_received_before_speech = b"".join(quiet_remote.frames[:8])
-        loud_received_before_speech = b"".join(loud_remote.frames[:8])
+        quiet_received_before_speech = b"".join(
+            quiet_remote.background_before_speech[-8:]
+        )
+        loud_received_before_speech = b"".join(
+            loud_remote.background_before_speech[-8:]
+        )
 
         assert _rms(loud_noise) > _rms(quiet_noise) * 8
         assert (


### PR DESCRIPTION
The persona merge passed its behavior checks but the `main` Simulator job failed because two new acceptance tests used timing guesses. The background test assumed the first eight LiveKit frames had crossed the assets' intentional 250 ms fade, and the interruption test required full cleanup within one second under full-suite load.

This change removes both timing guesses. The background proof waits for an observed 300 ms block of background-only frames before sending speech, then checks that captured block. The interruption proof waits for the conductor task's actual completion; the simulator suite's existing 120-second timeout still detects a real deadlock. Runtime behavior and audio assets do not change.

Validation:
- `uv run --frozen pytest -q tests/test_interruption_acceptance.py` — 12 passed
- `TEST_LIVEKIT_URL=ws://127.0.0.1:7880 TEST_LIVEKIT_API_KEY=devkey TEST_LIVEKIT_API_SECRET=secret uv run --frozen pytest -q tests/test_live_livekit_background.py` — 12 passed against LiveKit 1.13.5
- `uv run --frozen ruff check tests/test_interruption_acceptance.py tests/test_live_livekit_background.py`

No CLI or SDK release is needed because this changes tests only.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Stabilizes simulator acceptance tests by replacing load-sensitive timing assumptions with observable synchronization conditions.
- Waits for 30 background audio frames before submitting speech and preserves that pre-speech capture for assertions.
- Waits for the conductor task’s actual completion while retaining the suite-level deadlock timeout.

<h3>Confidence Score: 5/5</h3>

The test-only synchronization changes appear safe to merge.

No actionable defects or repository-rule violations remain; the revised tests replace timing guesses with observed task and audio-stream conditions while preserving bounded deadlock detection at the suite level.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/simulator/tests/test_interruption_acceptance.py | Replaces a short local completion deadline with direct task completion under the existing suite timeout. |
| apps/simulator/tests/test_live_livekit_background.py | Synchronizes speech submission with observed background frames and evaluates the captured pre-speech audio window. |

<sub>Reviews (2): Last reviewed commit: ["Wait for observable simulator conditions"](https://github.com/egma-ai/egma/commit/de4900b09f9d84e0746bf20593c8410904f55dc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63165718)</sub>

<!-- /greptile_comment -->